### PR TITLE
Improve logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/react-router": "^4.0.31",
     "@types/react-router-dom": "^4.3.1",
     "@types/react-transition-group": "^2.0.14",
+    "@types/uuid": "^3.4.4",
     "@types/yup": "^0.24.9",
     "constate": "^0.8.2",
     "cookie-storage": "^3.2.0",
@@ -70,6 +71,8 @@
     "react-transition-group": "^2.4.0",
     "source-map-support": "^0.5.9",
     "typescript": "^3.0.3",
+    "typescript-logging": "^0.6.3",
+    "uuid": "^3.3.2",
     "yup": "^0.26.6"
   },
   "husky": {

--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -1,0 +1,14 @@
+import {
+  LFService,
+  LoggerFactoryOptions,
+  LogGroupRule,
+  LogLevel,
+} from 'typescript-logging'
+
+export const options = new LoggerFactoryOptions().addLogGroupRule(
+  new LogGroupRule(/.+/, LogLevel.fromString('info')),
+)
+
+export const loggerFactory = LFService.createLoggerFactory(options)
+
+export const appLogger = loggerFactory.getLogger('app')

--- a/src/server/middleware/enhancers.ts
+++ b/src/server/middleware/enhancers.ts
@@ -1,9 +1,9 @@
 import { Middleware } from 'koa'
-import * as uuidV1 from 'uuid/v1'
+import * as uuidV4 from 'uuid/v4'
 import { loggerFactory } from '../logging'
 
 export const setRequestUuidMiddleware: Middleware = async (ctx, next) => {
-  ctx.state.requestUuid = uuidV1()
+  ctx.state.requestUuid = uuidV4()
 
   await next()
 }

--- a/src/server/middleware/enhancers.ts
+++ b/src/server/middleware/enhancers.ts
@@ -1,0 +1,38 @@
+import { Middleware } from 'koa'
+import * as uuidV1 from 'uuid/v1'
+import { loggerFactory } from '../logging'
+
+export const setRequestUuidMiddleware: Middleware = async (ctx, next) => {
+  ctx.state.requestUuid = uuidV1()
+
+  await next()
+}
+
+export const setLoggerMiddleware: Middleware = async (ctx, next) => {
+  ctx.state.getLogger = (name: string) =>
+    loggerFactory.getLogger(
+      `requestUuid="${ctx.state.requestUuid}"${name ? `:${name}` : ''}`,
+    )
+
+  await next()
+}
+
+export const logRequestMiddleware: Middleware = async (ctx, next) => {
+  const log = (e?: Error) =>
+    ctx.state
+      .getLogger('request')
+      .info(
+        `${ctx.get('x-forwarded-proto') || ctx.request.protocol} ${
+          ctx.request.method
+        } ${ctx.request.originalUrl} - ${e !== undefined ? 500 : ctx.status}`,
+      )
+
+  try {
+    await next()
+    log()
+  } catch (e) {
+    log(e)
+    ctx.state.getLogger('request').error('Uncaught error in request', e)
+    throw e
+  }
+}

--- a/src/server/middleware/enhancers.ts
+++ b/src/server/middleware/enhancers.ts
@@ -31,8 +31,8 @@ export const logRequestMiddleware: Middleware = async (ctx, next) => {
     await next()
     log()
   } catch (e) {
-    log(e)
     ctx.state.getLogger('request').error('Uncaught error in request', e)
+    log(e)
     throw e
   }
 }

--- a/src/serverEntry.tsx
+++ b/src/serverEntry.tsx
@@ -1,21 +1,31 @@
 import 'source-map-support/register'
 import { createKoaServer } from '@hedviginsurance/web-survival-kit' // tslint:disable-line ordered-imports
 import { reactPageRoutes } from './routes'
+import { appLogger } from './server/logging'
 import { getPage } from './server/page'
 import { notNullable } from './utils/nullables'
+import {
+  logRequestMiddleware,
+  setLoggerMiddleware,
+  setRequestUuidMiddleware,
+} from './server/middleware/enhancers'
 
 const getPort = () => (process.env.PORT ? Number(process.env.PORT) : 8080)
 
-console.log(`Booting server on ${getPort()} 👢`) // tslint:disable-line no-console
+appLogger.info(`Booting server on ${getPort()} 👢`)
 
 const server = createKoaServer({
   publicPath: '/assets',
   assetLocation: __dirname + '/assets',
 })
-
+server.app.use(setRequestUuidMiddleware)
+server.app.use(setLoggerMiddleware)
+server.app.use(logRequestMiddleware)
+server.router.use(setRequestUuidMiddleware)
+server.router.use(setLoggerMiddleware)
+server.router.use(logRequestMiddleware)
 if (process.env.USE_AUTH) {
-  // tslint:disable-next-line no-console
-  console.log(
+  appLogger.info(
     `Protecting server using basic auth with user ${process.env.AUTH_NAME} 💂‍`,
   )
   const basicAuth = require('koa-basic-auth') // tslint:disable-line no-var-requires
@@ -26,8 +36,7 @@ if (process.env.USE_AUTH) {
   server.app.use(basicAuthMidleware)
   server.router.use(basicAuthMidleware)
 } else {
-  // tslint:disable-next-line no-console
-  console.log('Not using any auth, server is open to the public')
+  appLogger.info('Not using any auth, server is open to the public')
 }
 
 reactPageRoutes.forEach((route) => {
@@ -35,5 +44,5 @@ reactPageRoutes.forEach((route) => {
 })
 
 server.app.listen(getPort(), () => {
-  console.log(`Server started 🚀 listening on port ${getPort()}`) // tslint:disable-line no-console
+  appLogger.info(`Server started 🚀 listening on port ${getPort()}`)
 })

--- a/src/serverEntry.tsx
+++ b/src/serverEntry.tsx
@@ -1,14 +1,14 @@
-import 'source-map-support/register'
 import { createKoaServer } from '@hedviginsurance/web-survival-kit' // tslint:disable-line ordered-imports
+import 'source-map-support/register'
 import { reactPageRoutes } from './routes'
 import { appLogger } from './server/logging'
-import { getPage } from './server/page'
-import { notNullable } from './utils/nullables'
 import {
   logRequestMiddleware,
   setLoggerMiddleware,
   setRequestUuidMiddleware,
 } from './server/middleware/enhancers'
+import { getPage } from './server/page'
+import { notNullable } from './utils/nullables'
 
 const getPort = () => (process.env.PORT ? Number(process.env.PORT) : 8080)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,6 +1007,13 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
+"@types/uuid@^3.4.4":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"
+  integrity sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yup@^0.24.9":
   version "0.24.9"
   resolved "https://registry.yarnpkg.com/@types/yup/-/yup-0.24.9.tgz#da98f4b38eec7ca72146e7042679c8c8628896fa"
@@ -3100,6 +3107,13 @@ error-inject@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/error-inject/-/error-inject-1.0.0.tgz#e2b3d91b54aed672f309d950d154850fa11d4f37"
   integrity sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc=
+
+error-stack-parser@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-1.3.6.tgz#e0e73b93e417138d1cd7c0b746b1a4a14854c292"
+  integrity sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=
+  dependencies:
+    stackframe "^0.3.1"
 
 es-abstract@^1.10.0, es-abstract@^1.5.0, es-abstract@^1.5.1, es-abstract@^1.6.1:
   version "1.12.0"
@@ -7711,6 +7725,11 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
+
 source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -7819,10 +7838,44 @@ ssri@^5.2.4:
   dependencies:
     safe-buffer "^5.1.1"
 
+stack-generator@^1.0.7:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-1.1.0.tgz#36f6a920751a6c10f499a13c32cbb5f51a0b8b25"
+  integrity sha1-NvapIHUabBD0maE8Msu19RoLiyU=
+  dependencies:
+    stackframe "^1.0.2"
+
 stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
   integrity sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=
+
+stackframe@^0.3.1, stackframe@~0.3:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
+  integrity sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=
+
+stackframe@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.0.4.tgz#357b24a992f9427cba6b545d96a14ed2cbca187b"
+  integrity sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==
+
+stacktrace-gps@^2.4.3:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-2.4.4.tgz#69c827e9d6d6f41cf438d7f195e2e3cbfcf28c44"
+  integrity sha1-acgn6dbW9Bz0ONfxleLjy/zyjEQ=
+  dependencies:
+    source-map "0.5.6"
+    stackframe "~0.3"
+
+stacktrace-js@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-1.3.1.tgz#67cab2589af5c417b962f7369940277bb3b6a18b"
+  integrity sha1-Z8qyWJr1xBe5Yvc2mUAne7O2oYs=
+  dependencies:
+    error-stack-parser "^1.3.6"
+    stack-generator "^1.0.7"
+    stacktrace-gps "^2.4.3"
 
 staged-git-files@1.1.1:
   version "1.1.1"
@@ -8312,6 +8365,13 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript-logging@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/typescript-logging/-/typescript-logging-0.6.3.tgz#cad05be714553621ccc776536f6b8793e1c6e847"
+  integrity sha512-0zDqwjZ7KCvRobh3tXRel4IYU95iqThlsKxPeqxUmDBmhXO695LrTHvwgg9CjAPVqftSvL8ZPRcSAPT3i5DkLQ==
+  dependencies:
+    stacktrace-js "1.3.1"
 
 typescript@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
Makes it possible to trace errors between requests without logging i.e. IPs, adds some timestamps, and avoids console.log which is awesome.

Example; This is what we'd get if we throw the following error in `App.tsx` `throw new Error('expected')`, simulating a render error in react

```
2018-10-03 11:24:45,672 INFO [app] Booting server on 8080 👢
2018-10-03 11:24:45,676 INFO [app] Not using any auth, server is open to the public
2018-10-03 11:24:45,681 INFO [app] Server started 🚀 listening on port 8080

  Error: expected
      at /Users/johanpalmfjord/dev/projects/web-onboarding/build/webpack:/src/App.tsx:17:76
      at App (/Users/johanpalmfjord/dev/projects/web-onboarding/build/webpack:/src/App.tsx:17:62)
      at processChild (/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/react-dom/cjs/react-dom-server.node.development.js:2458:14)
      at resolve (/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/react-dom/cjs/react-dom-server.node.development.js:2384:5)
      at ReactDOMServerRenderer.render (/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/react-dom/cjs/react-dom-server.node.development.js:2706:22)
      at ReactDOMServerRenderer.read (/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/react-dom/cjs/react-dom-server.node.development.js:2680:23)
      at renderToString (/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/react-dom/cjs/react-dom-server.node.development.js:3071:25)
      at _callee$ (/Users/johanpalmfjord/dev/projects/web-onboarding/build/webpack:/src/server/page.tsx:36:19)
      at tryCatch (/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/regenerator-runtime/runtime.js:62:40)
      at Generator.invoke [as _invoke] (/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/regenerator-runtime/runtime.js:296:22)

2018-10-03 11:24:46,565 ERROR [requestUuid="2b4a3600-c6ee-11e8-aadd-953850855f83":request] Uncaught error in request
Error: expected
@
{anonymous}()@/Users/johanpalmfjord/dev/projects/web-onboarding/build/webpack:/src/App.tsx:17:76
  App()@/Users/johanpalmfjord/dev/projects/web-onboarding/build/webpack:/src/App.tsx:17:62
  processChild()@/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/react-dom/cjs/react-dom-server.node.development.js:2458:14
  resolve()@/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/react-dom/cjs/react-dom-server.node.development.js:2384:5
  ReactDOMServerRenderer.render()@/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/react-dom/cjs/react-dom-server.node.development.js:2706:22
  ReactDOMServerRenderer.read()@/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/react-dom/cjs/react-dom-server.node.development.js:2680:23
  renderToString()@/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/react-dom/cjs/react-dom-server.node.development.js:3071:25
  _callee$()@/Users/johanpalmfjord/dev/projects/web-onboarding/build/webpack:/src/server/page.tsx:36:19
  tryCatch()@/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/regenerator-runtime/runtime.js:62:40
  Generator.invoke [as _invoke]()@/Users/johanpalmfjord/dev/projects/web-onboarding/node_modules/regenerator-runtime/runtime.js:296:22
2018-10-03 11:24:46,642 INFO [requestUuid="2b4a3600-c6ee-11e8-aadd-953850855f83":request] http GET /hedvig - 500
```