### PR TITLE
Oneliner fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,6 @@
       "prettier --write",
       "git add"
     ]
-  }
+  },
+  "sideEffects": false
 }

--- a/src/server/middleware/enhancers.ts
+++ b/src/server/middleware/enhancers.ts
@@ -3,7 +3,7 @@ import * as uuidV4 from 'uuid/v4'
 import { loggerFactory } from '../logging'
 
 export const setRequestUuidMiddleware: Middleware = async (ctx, next) => {
-  ctx.state.requestUuid = uuidV4()
+  ctx.state.requestUuid = ctx.get('x-request-id') || uuidV4()
 
   await next()
 }

--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -22,7 +22,7 @@ const template = (body: string, initialState: any) => `
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Example web app</title>
+  <title>Bli Hedvigmedlem</title>
 </head>
 <body>
   <div id="react-root">${body}</div>


### PR DESCRIPTION
- [x] SideEffects so webpack tree shakes properly
- [x] Get request id from header if it exists, to intercept heroku request ids
- [x] Add _better_ page title than "example web app" - we should probably give it something better but just so its not a disaster