### PR TITLE
Add ICE middleware and a panic room

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/koa": "^2.0.46",
     "@types/koa-basic-auth": "^2.0.3",
     "@types/koa-router": "^7.0.32",
+    "@types/node": "^10.11.7",
     "@types/react": "^16.4.14",
     "@types/react-dom": "^16.0.7",
     "@types/react-hot-loader": "^4.1.0",

--- a/src/server/middleware/enhancers.ts
+++ b/src/server/middleware/enhancers.ts
@@ -51,6 +51,7 @@ export const inCaseOfEmergency: Middleware = async (ctx, next) => {
   try {
     await next()
   } catch (e) {
+    ctx.status = 500
     try {
       ;(ctx.state.getLogger('emergency') as Logger).error(
         'Uncaught error in request, requesting 500 page',

--- a/src/serverEntry.tsx
+++ b/src/serverEntry.tsx
@@ -3,6 +3,7 @@ import 'source-map-support/register'
 import { reactPageRoutes } from './routes'
 import { appLogger } from './server/logging'
 import {
+  inCaseOfEmergency,
   logRequestMiddleware,
   setLoggerMiddleware,
   setRequestUuidMiddleware,
@@ -26,6 +27,8 @@ server.app.use(logRequestMiddleware)
 server.router.use(setRequestUuidMiddleware)
 server.router.use(setLoggerMiddleware)
 server.router.use(logRequestMiddleware)
+server.app.use(inCaseOfEmergency)
+server.router.use(inCaseOfEmergency)
 if (process.env.USE_AUTH) {
   appLogger.info(
     `Protecting server using basic auth with user ${process.env.AUTH_NAME} 💂‍`,
@@ -43,6 +46,12 @@ if (process.env.USE_AUTH) {
 
 reactPageRoutes.forEach((route) => {
   server.router.get(route.path, getPage)
+})
+
+server.router.get('/panic-room', async () => {
+  throw new Error(
+    'Entered the panic room, this is an expected error. Carry on 👜',
+  )
 })
 
 server.app.listen(getPort(), () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -960,6 +960,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.3.tgz#c055536ac8a5e871701aa01914be5731539d01ee"
   integrity sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ==
 
+"@types/node@^10.11.7":
+  version "10.11.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.7.tgz#0e75ca9357d646ca754016ca1d68a127ad7e7300"
+  integrity sha512-yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg==
+
 "@types/prop-types@*":
   version "15.5.6"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.6.tgz#9c03d3fed70a8d517c191b7734da2879b50ca26c"


### PR DESCRIPTION
Panic room = intentionally throw errors in case we want to see that error reporting works as expected
ICE reverse proxies https://github.com/HedvigInsurance/cdn-files/pull/7 so that needs to be merged and CF needs to be invalidated be4 this'll work

ping @HedvigInsurance/clients 