### PR TITLE
Input -> offer transition

### DIFF
--- a/src/components/buttons.tsx
+++ b/src/components/buttons.tsx
@@ -30,5 +30,9 @@ export const Button = styled('button')(
     '&:focus': {
       outlineColor: background,
     },
+
+    '&:disabled': {
+      backgroundColor: colors.LIGHT_GRAY,
+    },
   }),
 )

--- a/src/pages/Chat/components/LoadingScreen.tsx
+++ b/src/pages/Chat/components/LoadingScreen.tsx
@@ -26,4 +26,4 @@ const Wrapper = styled('div')({
   zIndex: 999,
 })
 
-export const LoadingScreen = () => <Wrapper>hello</Wrapper>
+export const LoadingScreen = () => <Wrapper>loading</Wrapper>

--- a/src/pages/Chat/components/LoadingScreen.tsx
+++ b/src/pages/Chat/components/LoadingScreen.tsx
@@ -1,0 +1,29 @@
+import { colors } from '@hedviginsurance/brand'
+import * as React from 'react'
+import styled, { keyframes } from 'react-emotion'
+
+const popIn = keyframes({
+  from: {
+    opacity: 0,
+    transform: 'scale(.95)',
+  },
+  to: {
+    opacity: 1,
+    transform: 'scale(1)',
+  },
+})
+
+const Wrapper = styled('div')({
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  backgroundColor: colors.GREEN,
+  color: colors.WHITE,
+  animation: `${popIn} 300ms forwards`,
+  transformOrigin: 'bottom center',
+  zIndex: 999,
+})
+
+export const LoadingScreen = () => <Wrapper>hello</Wrapper>

--- a/src/pages/Chat/components/OfferCreationHandler.test.tsx
+++ b/src/pages/Chat/components/OfferCreationHandler.test.tsx
@@ -1,0 +1,51 @@
+import { Provider } from 'constate'
+import { mount } from 'enzyme'
+import * as React from 'react'
+import { Redirect, StaticRouter } from 'react-router'
+import { ChatScreenContainer } from '../containers/ChatScreenContainer'
+import { LoadingScreen } from './LoadingScreen'
+import { OfferCreationHandler } from './OfferCreationHandler'
+
+jest.useFakeTimers()
+it('does nothing when no correct state is set', () => {
+  const wrapper = mount(
+    <StaticRouter context={{}}>
+      <Provider initialState={{}}>
+        <OfferCreationHandler />
+        <ChatScreenContainer>
+          {(state) => (
+            <>
+              <button
+                id="trigger-debounce"
+                onClick={() => state.beginDebounce()}
+              />
+              <button
+                id="trigger-loading"
+                onClick={() => state.beginCreateOffer()}
+              />
+              <button
+                id="trigger-finished"
+                onClick={() => state.createOfferSuccess()}
+              />
+            </>
+          )}
+        </ChatScreenContainer>
+      </Provider>
+    </StaticRouter>,
+  )
+
+  expect(wrapper.find(Redirect)).toHaveLength(0)
+  expect(wrapper.find(LoadingScreen)).toHaveLength(0)
+
+  wrapper.find('#trigger-loading').simulate('click')
+  expect(wrapper.find(LoadingScreen)).toHaveLength(1)
+
+  wrapper.find('#trigger-debounce').simulate('click')
+  wrapper.find('#trigger-finished').simulate('click')
+  expect(wrapper.find(LoadingScreen)).toHaveLength(1)
+
+  jest.runAllTimers()
+  wrapper.update()
+
+  expect(wrapper.find(Redirect).prop('to')).toBe('/offer')
+})

--- a/src/pages/Chat/components/OfferCreationHandler.tsx
+++ b/src/pages/Chat/components/OfferCreationHandler.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { Redirect } from 'react-router-dom'
+import {
+  ChatScreenContainer,
+  LoadingState,
+} from '../containers/ChatScreenContainer'
+import { LoadingScreen } from './LoadingScreen'
+
+export const OfferCreationHandler = () => (
+  <ChatScreenContainer>
+    {(state) => {
+      if (
+        state.offerCreationDebounceState === LoadingState.LOADING ||
+        state.offerCreationLoadingState === LoadingState.LOADING
+      ) {
+        return <LoadingScreen />
+      }
+
+      if (
+        state.offerCreationDebounceState === LoadingState.COMPLETED &&
+        state.offerCreationLoadingState === LoadingState.COMPLETED
+      ) {
+        return <Redirect to="/offer" />
+      }
+
+      return null
+    }}
+  </ChatScreenContainer>
+)

--- a/src/pages/Chat/containers/ChatScreenContainer.test.tsx
+++ b/src/pages/Chat/containers/ChatScreenContainer.test.tsx
@@ -1,0 +1,47 @@
+import { mount } from 'enzyme'
+import * as React from 'react'
+import { ChatScreenContainer, LoadingState } from './ChatScreenContainer'
+
+jest.useFakeTimers()
+it('performs debounced loading', () => {
+  const wrapper = mount(
+    <ChatScreenContainer>
+      {(state) => (
+        <>
+          <div id="debounce">{state.offerCreationDebounceState}</div>
+          <div id="loading">{state.offerCreationLoadingState}</div>
+          <button id="trigger-debounce" onClick={() => state.beginDebounce()} />
+          <button
+            id="trigger-loading"
+            onClick={() => state.beginCreateOffer()}
+          />
+          <button
+            id="trigger-finished"
+            onClick={() => state.createOfferSuccess()}
+          />
+        </>
+      )}
+    </ChatScreenContainer>,
+  )
+
+  expect(wrapper.find('#debounce').text()).toBe(
+    String(LoadingState.NOT_LOADING),
+  )
+  expect(wrapper.find('#loading').text()).toBe(String(LoadingState.NOT_LOADING))
+
+  wrapper.find('#trigger-debounce').simulate('click')
+  expect(wrapper.find('#debounce').text()).toBe(String(LoadingState.LOADING))
+  expect(wrapper.find('#loading').text()).toBe(String(LoadingState.NOT_LOADING))
+
+  wrapper.find('#trigger-loading').simulate('click')
+  expect(wrapper.find('#debounce').text()).toBe(String(LoadingState.LOADING))
+  expect(wrapper.find('#loading').text()).toBe(String(LoadingState.LOADING))
+
+  jest.runAllTimers()
+  expect(wrapper.find('#debounce').text()).toBe(String(LoadingState.COMPLETED))
+  expect(wrapper.find('#loading').text()).toBe(String(LoadingState.LOADING))
+
+  wrapper.find('#trigger-finished').simulate('click')
+  expect(wrapper.find('#debounce').text()).toBe(String(LoadingState.COMPLETED))
+  expect(wrapper.find('#loading').text()).toBe(String(LoadingState.COMPLETED))
+})

--- a/src/pages/Chat/containers/ChatScreenContainer.tsx
+++ b/src/pages/Chat/containers/ChatScreenContainer.tsx
@@ -33,7 +33,10 @@ export const ChatScreenContainer: React.SFC<ChatContainerProps> = ({
   children,
 }) => (
   <Container<State, ActionMap<State, Actions>, {}, Effects>
-    initialState={{ offerCreationDebounceState: LoadingState.NOT_LOADING }}
+    initialState={{
+      offerCreationDebounceState: LoadingState.NOT_LOADING,
+      offerCreationLoadingState: LoadingState.NOT_LOADING,
+    }}
     actions={{
       beginCreateOffer: () => ({
         offerCreationLoadingState: LoadingState.LOADING,

--- a/src/pages/Chat/containers/ChatScreenContainer.tsx
+++ b/src/pages/Chat/containers/ChatScreenContainer.tsx
@@ -1,0 +1,72 @@
+import { ActionMap, Container } from 'constate'
+import * as React from 'react'
+
+const DEBOUNCE_DELAY = 5000
+
+export enum LoadingState {
+  NOT_LOADING,
+  LOADING,
+  COMPLETED,
+}
+
+interface State {
+  debounceLoadingTimer?: number
+  offerCreationDebounceState: LoadingState
+  offerCreationLoadingState: LoadingState
+}
+interface Actions {
+  beginCreateOffer: () => void
+  createOfferSuccess: () => void
+}
+interface Effects {
+  beginDebounce: () => void
+  abortDebounce: () => void
+}
+
+export type ChatState = State & Actions & Effects
+
+export interface ChatContainerProps {
+  children: (state: ChatState) => React.ReactNode
+}
+
+export const ChatScreenContainer: React.SFC<ChatContainerProps> = ({
+  children,
+}) => (
+  <Container<State, ActionMap<State, Actions>, {}, Effects>
+    initialState={{ offerCreationDebounceState: LoadingState.NOT_LOADING }}
+    actions={{
+      beginCreateOffer: () => ({
+        offerCreationLoadingState: LoadingState.LOADING,
+      }),
+      createOfferSuccess: () => ({
+        offerCreationLoadingState: LoadingState.COMPLETED,
+      }),
+    }}
+    effects={{
+      beginDebounce: () => ({ setState }) => {
+        const debounceLoadingTimer = window.setTimeout(() => {
+          setState({
+            offerCreationDebounceState: LoadingState.COMPLETED,
+            debounceLoadingTimer: undefined,
+          })
+        }, DEBOUNCE_DELAY)
+        setState({
+          debounceLoadingTimer,
+          offerCreationDebounceState: LoadingState.LOADING,
+        })
+      },
+      abortDebounce: () => ({ state, setState }) => {
+        if (!state.debounceLoadingTimer) {
+          return
+        }
+        clearTimeout(state.debounceLoadingTimer)
+        setState({
+          debounceLoadingTimer: undefined,
+          offerCreationDebounceState: LoadingState.NOT_LOADING,
+        })
+      },
+    }}
+    context="chatScreen"
+    children={children}
+  />
+)

--- a/src/pages/Chat/containers/CreateOfferContainer.tsx
+++ b/src/pages/Chat/containers/CreateOfferContainer.tsx
@@ -3,7 +3,9 @@ import { DocumentNode } from 'graphql'
 import gql from 'graphql-tag'
 import * as React from 'react'
 import { Mutation } from 'react-apollo'
+import { Unmount } from 'react-lifecycle-components'
 import { State as ChatState } from '../state'
+import { ChatScreenContainer } from './ChatScreenContainer'
 
 export interface CreateOfferMutationVariables {
   firstName: string
@@ -78,21 +80,33 @@ interface CreateOfferContainerProps {
 export const CreateOfferContainer: React.SFC<CreateOfferContainerProps> = ({
   children,
 }) => (
-  <Mutation<{ createOffer: string }, CreateOfferMutationVariables>
-    mutation={CREATE_OFFER_MUTATION}
-  >
-    {(mutate, { data, loading, error, called }) =>
-      children(
-        (variables) => {
-          mutate({ variables })
-        },
-        {
-          data: data && data.createOffer,
-          loading,
-          error,
-          called,
-        },
-      )
-    }
-  </Mutation>
+  <ChatScreenContainer>
+    {(chatScreenState) => (
+      <Unmount
+        on={() => {
+          chatScreenState.abortDebounce()
+        }}
+      >
+        <Mutation<{ createOffer: string }, CreateOfferMutationVariables>
+          mutation={CREATE_OFFER_MUTATION}
+        >
+          {(mutate, { data, loading, error, called }) =>
+            children(
+              (variables) => {
+                mutate({ variables })
+                chatScreenState.beginCreateOffer()
+                chatScreenState.beginDebounce()
+              },
+              {
+                data: data && data.createOffer,
+                loading,
+                error,
+                called,
+              },
+            )
+          }
+        </Mutation>
+      </Unmount>
+    )}
+  </ChatScreenContainer>
 )

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -3,7 +3,13 @@ import * as React from 'react'
 import Helmet from 'react-helmet-async'
 import { TopBar, TopBarFiller } from '../../components/TopBar'
 import { ChatConversation } from './ChatConversation'
+import { LoadingScreen } from './components/LoadingScreen'
+import {
+  ChatScreenContainer,
+  LoadingState,
+} from './containers/ChatScreenContainer'
 import { ResetButton } from './ResetButton'
+import { Redirect } from 'react-router-dom'
 
 export const Chat: React.SFC = () => (
   <>
@@ -15,5 +21,24 @@ export const Chat: React.SFC = () => (
     <TopBarFiller />
     <ResetButton />
     <ChatConversation />
+    <ChatScreenContainer>
+      {(state) => {
+        if (
+          state.offerCreationDebounceState === LoadingState.LOADING ||
+          state.offerCreationLoadingState === LoadingState.LOADING
+        ) {
+          return <LoadingScreen />
+        }
+
+        if (
+          state.offerCreationDebounceState === LoadingState.COMPLETED &&
+          state.offerCreationLoadingState === LoadingState.COMPLETED
+        ) {
+          return <Redirect to="/offer" />
+        }
+
+        return null
+      }}
+    </ChatScreenContainer>
   </>
 )

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -3,13 +3,8 @@ import * as React from 'react'
 import Helmet from 'react-helmet-async'
 import { TopBar, TopBarFiller } from '../../components/TopBar'
 import { ChatConversation } from './ChatConversation'
-import { LoadingScreen } from './components/LoadingScreen'
-import {
-  ChatScreenContainer,
-  LoadingState,
-} from './containers/ChatScreenContainer'
+import { OfferCreationHandler } from './components/OfferCreationHandler'
 import { ResetButton } from './ResetButton'
-import { Redirect } from 'react-router-dom'
 
 export const Chat: React.SFC = () => (
   <>
@@ -21,24 +16,6 @@ export const Chat: React.SFC = () => (
     <TopBarFiller />
     <ResetButton />
     <ChatConversation />
-    <ChatScreenContainer>
-      {(state) => {
-        if (
-          state.offerCreationDebounceState === LoadingState.LOADING ||
-          state.offerCreationLoadingState === LoadingState.LOADING
-        ) {
-          return <LoadingScreen />
-        }
-
-        if (
-          state.offerCreationDebounceState === LoadingState.COMPLETED &&
-          state.offerCreationLoadingState === LoadingState.COMPLETED
-        ) {
-          return <Redirect to="/offer" />
-        }
-
-        return null
-      }}
-    </ChatScreenContainer>
+    <OfferCreationHandler />
   </>
 )

--- a/src/pages/Chat/steps/CreateOffer.test.tsx
+++ b/src/pages/Chat/steps/CreateOffer.test.tsx
@@ -16,6 +16,10 @@ import { createSession, SESSION_KEY } from 'utils/sessionStorage'
 import { MockStorage } from 'utils/storage/MockStorage'
 import { StorageState } from 'utils/StorageContainer'
 import { mockNetworkWait } from 'utils/test-utils'
+import {
+  ChatScreenContainer,
+  LoadingState,
+} from '../containers/ChatScreenContainer'
 import { createCreateOfferMutationMock, mockState } from '../utils/test-utils'
 import { CreateOffer } from './CreateOffer'
 
@@ -66,20 +70,37 @@ it('creates an offer without 💥', async () => {
         }}
       >
         <CreateOffer />
+        <ChatScreenContainer>
+          {(state) => (
+            <div id="loading-state">{state.offerCreationLoadingState}</div>
+          )}
+        </ChatScreenContainer>
       </Provider>
     </ApolloProvider>,
   )
 
-  expect(wrapper.find('div').text()).toBe('') // loading state = empty
-  await mockNetworkWait(3)
+  expect(
+    wrapper
+      .find('div')
+      .at(0)
+      .text(),
+  ).toBe('') // session loading state = empty
+  await mockNetworkWait()
   await mockNetworkWait(3)
   expect(apolloClient!.subscriptionClient.close).toHaveBeenCalledTimes(1)
   wrapper.update()
+  expect(wrapper.find('#loading-state').text()).toBe(
+    String(LoadingState.NOT_LOADING),
+  )
   wrapper.find('button').simulate('click')
   expect(wrapper.find('button').prop('disabled')).toBe(true)
 
   await mockNetworkWait()
   wrapper.update()
+  expect(wrapper.find('#loading-state').text()).toBe(
+    String(LoadingState.LOADING),
+  )
+
   subscriptionLink.simulateResult({
     result: {
       data: {
@@ -96,5 +117,7 @@ it('creates an offer without 💥', async () => {
   })
   await mockNetworkWait()
   wrapper.update()
-  expect(wrapper.containsMatchingElement(<div>SUCCESS</div>)).toBe(true)
+  expect(wrapper.find('#loading-state').text()).toBe(
+    String(LoadingState.COMPLETED),
+  )
 })

--- a/src/pages/Chat/steps/CreateOffer.test.tsx
+++ b/src/pages/Chat/steps/CreateOffer.test.tsx
@@ -76,7 +76,7 @@ it('creates an offer without 💥', async () => {
   expect(apolloClient!.subscriptionClient.close).toHaveBeenCalledTimes(1)
   wrapper.update()
   wrapper.find('button').simulate('click')
-  expect(wrapper.find('div').contains('loading')).toBe(true)
+  expect(wrapper.find('button').prop('disabled')).toBe(true)
 
   await mockNetworkWait()
   wrapper.update()

--- a/src/pages/Chat/steps/CreateOffer.tsx
+++ b/src/pages/Chat/steps/CreateOffer.tsx
@@ -2,10 +2,10 @@ import { colors } from '@hedviginsurance/brand'
 import { TranslationsConsumer } from '@hedviginsurance/textkeyfy'
 import { FadeIn } from 'components/animations/appearings'
 import { Button } from 'components/buttons'
+import { SessionContainer } from 'containers/SessionContainer'
 import * as React from 'react'
 import styled from 'react-emotion'
-import { Unmount, Update } from 'react-lifecycle-components'
-import { SessionContainer } from '../../../containers/SessionContainer'
+import { Update } from 'react-lifecycle-components'
 import {
   ChatScreenContainer,
   LoadingState,
@@ -54,7 +54,6 @@ export const CreateOffer: React.SFC = () => (
                               watched={{
                                 called: createOfferProps.called,
                                 data: subscriptionMaybe,
-                                hasSessionToken: Boolean(sessionToken),
                               }}
                               was={(_, newWatched) => {
                                 if (
@@ -64,61 +63,45 @@ export const CreateOffer: React.SFC = () => (
                                 ) {
                                   chatScreenState.createOfferSuccess()
                                 }
-
-                                if (
-                                  newWatched.called &&
-                                  !newWatched.data &&
-                                  chatScreenState.offerCreationDebounceState !==
-                                    LoadingState.LOADING
-                                ) {
-                                  chatScreenState.beginDebounce()
-                                  return
-                                }
                               }}
                             >
-                              <Unmount
-                                on={() => {
-                                  chatScreenState.abortDebounce()
-                                }}
-                              >
-                                <Wrapper>
-                                  <CreateOfferCtaWrapper>
-                                    <Button
-                                      background={colors.GREEN}
-                                      foreground={colors.WHITE}
-                                      disabled={
-                                        chatScreenState.offerCreationDebounceState ===
-                                          LoadingState.LOADING ||
-                                        chatScreenState.offerCreationLoadingState ===
-                                          LoadingState.LOADING
-                                      }
-                                      onClick={() => {
-                                        chatScreenState.beginDebounce()
-                                        createOffer(
-                                          getCreateOfferVariablesFromChatState(
-                                            chatState,
-                                          ),
-                                        )
-                                      }}
-                                    >
-                                      <TranslationsConsumer textKey="CHAT_INPUT_CREATE_OFFER">
-                                        {(text) => text}
-                                      </TranslationsConsumer>
-                                    </Button>
-                                  </CreateOfferCtaWrapper>
-                                  <GdprWrapper>
-                                    <TranslationsConsumer textKey="CHAT_INPUT_PERSONAL_DATA_LINK">
-                                      {(link) => (
-                                        <GdprLink href={link} target="_blank">
-                                          <TranslationsConsumer textKey="CHAT_INPUT_PERSONAL_DATA_LABEL">
-                                            {(t) => t}
-                                          </TranslationsConsumer>
-                                        </GdprLink>
-                                      )}
+                              <Wrapper>
+                                <CreateOfferCtaWrapper>
+                                  <Button
+                                    background={colors.GREEN}
+                                    foreground={colors.WHITE}
+                                    disabled={
+                                      chatScreenState.offerCreationDebounceState ===
+                                        LoadingState.LOADING ||
+                                      chatScreenState.offerCreationLoadingState ===
+                                        LoadingState.LOADING
+                                    }
+                                    onClick={() => {
+                                      chatScreenState.beginDebounce()
+                                      createOffer(
+                                        getCreateOfferVariablesFromChatState(
+                                          chatState,
+                                        ),
+                                      )
+                                    }}
+                                  >
+                                    <TranslationsConsumer textKey="CHAT_INPUT_CREATE_OFFER">
+                                      {(text) => text}
                                     </TranslationsConsumer>
-                                  </GdprWrapper>
-                                </Wrapper>
-                              </Unmount>
+                                  </Button>
+                                </CreateOfferCtaWrapper>
+                                <GdprWrapper>
+                                  <TranslationsConsumer textKey="CHAT_INPUT_PERSONAL_DATA_LINK">
+                                    {(link) => (
+                                      <GdprLink href={link} target="_blank">
+                                        <TranslationsConsumer textKey="CHAT_INPUT_PERSONAL_DATA_LABEL">
+                                          {(t) => t}
+                                        </TranslationsConsumer>
+                                      </GdprLink>
+                                    )}
+                                  </TranslationsConsumer>
+                                </GdprWrapper>
+                              </Wrapper>
                             </Update>
                           )}
                         </ChatScreenContainer>

--- a/src/pages/Chat/steps/CreateOffer.tsx
+++ b/src/pages/Chat/steps/CreateOffer.tsx
@@ -4,7 +4,12 @@ import { FadeIn } from 'components/animations/appearings'
 import { Button } from 'components/buttons'
 import * as React from 'react'
 import styled from 'react-emotion'
+import { Unmount, Update } from 'react-lifecycle-components'
 import { SessionContainer } from '../../../containers/SessionContainer'
+import {
+  ChatScreenContainer,
+  LoadingState,
+} from '../containers/ChatScreenContainer'
 import {
   CreateOfferContainer,
   getCreateOfferVariablesFromChatState,
@@ -42,44 +47,81 @@ export const CreateOffer: React.SFC = () => (
                 {(subscriptionMaybe) => (
                   <>
                     <CreateOfferContainer>
-                      {(createOffer, { called }) => (
-                        <Wrapper>
-                          <CreateOfferCtaWrapper>
-                            <Button
-                              background={colors.GREEN}
-                              foreground={colors.WHITE}
-                              onClick={() =>
-                                createOffer(
-                                  getCreateOfferVariablesFromChatState(
-                                    chatState,
-                                  ),
-                                )
-                              }
+                      {(createOffer, createOfferProps) => (
+                        <ChatScreenContainer>
+                          {(chatScreenState) => (
+                            <Update
+                              watched={{
+                                called: createOfferProps.called,
+                                data: subscriptionMaybe,
+                                hasSessionToken: Boolean(sessionToken),
+                              }}
+                              was={(_, newWatched) => {
+                                if (
+                                  newWatched.called &&
+                                  newWatched.data &&
+                                  newWatched.data.offer.status === 'SUCCESS'
+                                ) {
+                                  chatScreenState.createOfferSuccess()
+                                }
+
+                                if (
+                                  newWatched.called &&
+                                  !newWatched.data &&
+                                  chatScreenState.offerCreationDebounceState !==
+                                    LoadingState.LOADING
+                                ) {
+                                  chatScreenState.beginDebounce()
+                                  return
+                                }
+                              }}
                             >
-                              <TranslationsConsumer textKey="CHAT_INPUT_CREATE_OFFER">
-                                {(text) => text}
-                              </TranslationsConsumer>
-                            </Button>
-                            <div>
-                              {subscriptionMaybe
-                                ? subscriptionMaybe.offer.status
-                                : called || !sessionToken
-                                  ? 'loading'
-                                  : null}
-                            </div>
-                          </CreateOfferCtaWrapper>
-                          <GdprWrapper>
-                            <TranslationsConsumer textKey="CHAT_INPUT_PERSONAL_DATA_LINK">
-                              {(link) => (
-                                <GdprLink href={link} target="_blank">
-                                  <TranslationsConsumer textKey="CHAT_INPUT_PERSONAL_DATA_LABEL">
-                                    {(t) => t}
-                                  </TranslationsConsumer>
-                                </GdprLink>
-                              )}
-                            </TranslationsConsumer>
-                          </GdprWrapper>
-                        </Wrapper>
+                              <Unmount
+                                on={() => {
+                                  chatScreenState.abortDebounce()
+                                }}
+                              >
+                                <Wrapper>
+                                  <CreateOfferCtaWrapper>
+                                    <Button
+                                      background={colors.GREEN}
+                                      foreground={colors.WHITE}
+                                      disabled={
+                                        chatScreenState.offerCreationDebounceState ===
+                                          LoadingState.LOADING ||
+                                        chatScreenState.offerCreationLoadingState ===
+                                          LoadingState.LOADING
+                                      }
+                                      onClick={() => {
+                                        chatScreenState.beginDebounce()
+                                        createOffer(
+                                          getCreateOfferVariablesFromChatState(
+                                            chatState,
+                                          ),
+                                        )
+                                      }}
+                                    >
+                                      <TranslationsConsumer textKey="CHAT_INPUT_CREATE_OFFER">
+                                        {(text) => text}
+                                      </TranslationsConsumer>
+                                    </Button>
+                                  </CreateOfferCtaWrapper>
+                                  <GdprWrapper>
+                                    <TranslationsConsumer textKey="CHAT_INPUT_PERSONAL_DATA_LINK">
+                                      {(link) => (
+                                        <GdprLink href={link} target="_blank">
+                                          <TranslationsConsumer textKey="CHAT_INPUT_PERSONAL_DATA_LABEL">
+                                            {(t) => t}
+                                          </TranslationsConsumer>
+                                        </GdprLink>
+                                      )}
+                                    </TranslationsConsumer>
+                                  </GdprWrapper>
+                                </Wrapper>
+                              </Unmount>
+                            </Update>
+                          )}
+                        </ChatScreenContainer>
                       )}
                     </CreateOfferContainer>
                   </>


### PR DESCRIPTION
It's starting to get a little hairy with loads of cross-component dependencies, but imo it's still _acceptable_. However if we start getting more complexity then i think we should start looking into refactoring. Thoughts?

__edit__: realised we still need to run the query for the offer so the cache is warm when the user hits the offer page, but i think its quite minor. Lets implement that once #30 is done?

@HedvigInsurance/clients 