### PR TITLE
Let web reverse-proxy web-onboarding

### DIFF
--- a/hedvig.config.js
+++ b/hedvig.config.js
@@ -8,7 +8,7 @@ module.exports = {
   serverPath: path.resolve(__dirname, 'build/'), // Build asset path
   port: 8038, // The WDS port
   developmentPublicPath: 'http://0.0.0.0:8038/', // Client public path during development, i.e. "http://0.0.0.0:8081/". Port must match the port directive
-  productionPublicPath: undefined, //  Client public path in production, i.e. "/assets/"
+  productionPublicPath: '/new-member-assets/', //  Client public path in production, i.e. "/assets/"
   envVars: [
     'USE_AUTH',
     'AUTH_NAME',

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -137,7 +137,7 @@ export const TopBar: React.SFC<Props> = ({ progress, button }) => (
     <Bar>
       <LogoWrapper>
         <EscapeLink href="https://hedvig.com">
-          <Logo src="/assets/topbar/hedvig-wordmark-solid.svg" />
+          <Logo src="/new-member-assets/topbar/hedvig-wordmark-solid.svg" />
         </EscapeLink>
       </LogoWrapper>
       {progress !== undefined && (
@@ -166,7 +166,7 @@ export const TopBar: React.SFC<Props> = ({ progress, button }) => (
                   )}
                 </TranslationsConsumer>
                 <CheckmarkIcon
-                  src="/assets/topbar/checkmark.svg"
+                  src="/new-member-assets/topbar/checkmark.svg"
                   style={{
                     visibility: progress <= stage.key ? 'hidden' : 'visible',
                   }}

--- a/src/containers/SessionTokenGuard.test.tsx
+++ b/src/containers/SessionTokenGuard.test.tsx
@@ -30,7 +30,7 @@ it('redirects when there is no session', () => {
     </StaticRouter>,
   )
 
-  expect(wrapper.find(Redirect).prop('to')).toBe('/hedvig')
+  expect(wrapper.find(Redirect).prop('to')).toBe('/new-member/hedvig')
 })
 
 it('does not redirect when there is a session token', () => {

--- a/src/containers/SessionTokenGuard.tsx
+++ b/src/containers/SessionTokenGuard.tsx
@@ -8,7 +8,7 @@ export const SessionTokenGuard: React.SFC = ({ children }) => (
       storageState.session.getSession()!.token ? (
         <>{children}</>
       ) : (
-        <Redirect to="/hedvig" />
+        <Redirect to="/new-member/hedvig" />
       )
     }
   </StorageContainer>

--- a/src/pages/Chat/ResetButton.tsx
+++ b/src/pages/Chat/ResetButton.tsx
@@ -31,7 +31,7 @@ export const ResetButton = () => (
     {({ reset }) => (
       <Wrapper>
         <Button onClick={reset}>
-          <Icon src="/assets/topbar/reload.svg" />
+          <Icon src="/new-member-assets/topbar/reload.svg" />
         </Button>
       </Wrapper>
     )}

--- a/src/pages/Chat/components/OfferCreationHandler.test.tsx
+++ b/src/pages/Chat/components/OfferCreationHandler.test.tsx
@@ -47,5 +47,5 @@ it('does nothing when no correct state is set', () => {
   jest.runAllTimers()
   wrapper.update()
 
-  expect(wrapper.find(Redirect).prop('to')).toBe('/offer')
+  expect(wrapper.find(Redirect).prop('to')).toBe('/new-member/offer')
 })

--- a/src/pages/Chat/components/OfferCreationHandler.tsx
+++ b/src/pages/Chat/components/OfferCreationHandler.tsx
@@ -20,7 +20,7 @@ export const OfferCreationHandler = () => (
         state.offerCreationDebounceState === LoadingState.COMPLETED &&
         state.offerCreationLoadingState === LoadingState.COMPLETED
       ) {
-        return <Redirect to="/offer" />
+        return <Redirect to="/new-member/offer" />
       }
 
       return null

--- a/src/pages/Download/sections/DownloadApp.tsx
+++ b/src/pages/Download/sections/DownloadApp.tsx
@@ -71,7 +71,7 @@ const InsuredText = styled('div')({
 export const DownloadApp: React.SFC = () => (
   <Wrapper>
     <InnerWrapper>
-      <DownloadImage src={'/assets/download/success_image.svg'} />
+      <DownloadImage src={'/new-member-assets/download/success_image.svg'} />
       <Header>
         <TranslationsConsumer textKey="DOWNLOAD_HEADER_ONE">
           {(header) => header}

--- a/src/pages/NewMemberLanding.tsx
+++ b/src/pages/NewMemberLanding.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react'
+import { Redirect } from 'react-router-dom'
+
+export const NewMemberLanding: React.SFC = () => <Redirect to="/new-member/hedvig" />

--- a/src/pages/NewMemberLanding.tsx
+++ b/src/pages/NewMemberLanding.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react'
 import { Redirect } from 'react-router-dom'
 
-export const NewMemberLanding: React.SFC = () => <Redirect to="/new-member/hedvig" />
+export const NewMemberLanding: React.SFC = () => (
+  <Redirect to="/new-member/hedvig" />
+)

--- a/src/pages/Offer/index.tsx
+++ b/src/pages/Offer/index.tsx
@@ -102,7 +102,7 @@ export const Offering: React.SFC<{}> = () => (
                         <BarButtonWrapper>
                           <GetInsuredButton>
                             <LinkTag
-                              to={'/hedvig'}
+                              to={'/new-member/hedvig'}
                               onClick={() =>
                                 trackEvent('Checkout Started', {
                                   category: 'offer',

--- a/src/pages/Offer/sections/GetInsured.tsx
+++ b/src/pages/Offer/sections/GetInsured.tsx
@@ -83,7 +83,7 @@ export const GetInsured: React.SFC<Props> = ({
                 {(ctaText) => (
                   <GetInsuredButton>
                     <LinkTag
-                      to={'/sign'}
+                      to={'/new-member/sign'}
                       onClick={() =>
                         trackEvent('Checkout Started', {
                           category: 'offer',

--- a/src/pages/Offer/sections/HedvigInfo.tsx
+++ b/src/pages/Offer/sections/HedvigInfo.tsx
@@ -94,7 +94,7 @@ export const HedvigInfo: React.SFC = () => (
           </HeaderWrapper>
           <Row>
             <Col>
-              <Image src="/assets/offering/enkel-overblick.svg" />
+              <Image src="/new-member-assets/offering/enkel-overblick.svg" />
               <Title>
                 <TranslationsConsumer textKey="OFFER_INFO_COL_ONE_TITLE">
                   {(title) => title}
@@ -107,7 +107,7 @@ export const HedvigInfo: React.SFC = () => (
               </Paragraph>
             </Col>
             <Col>
-              <Image src="/assets/offering/snabbt-svar.svg" />
+              <Image src="/new-member-assets/offering/snabbt-svar.svg" />
               <Title>
                 <TranslationsConsumer textKey="OFFER_INFO_COL_TWO_TITLE">
                   {(title) => title}
@@ -120,7 +120,7 @@ export const HedvigInfo: React.SFC = () => (
               </Paragraph>
             </Col>
             <Col>
-              <Image src="/assets/offering/anmal-skador.svg" />
+              <Image src="/new-member-assets/offering/anmal-skador.svg" />
               <Title>
                 <TranslationsConsumer textKey="OFFER_INFO_COL_THREE_TITLE">
                   {(title) => title}

--- a/src/pages/Offer/sections/HedvigSwitch.tsx
+++ b/src/pages/Offer/sections/HedvigSwitch.tsx
@@ -80,21 +80,21 @@ const COLUMNS = [
   {
     key: 0,
     title: '1',
-    image: 'assets/offering/hedvig-dot-1.svg',
+    image: '/new-member-assets/offering/hedvig-dot-1.svg',
     paragraph:
       'Hedvig kontaktar ditt försäkringsbolag och säger upp din gamla försäkring',
   },
   {
     key: 1,
     title: '2',
-    image: 'assets/offering/hedvig-dot-2.svg',
+    image: '/new-member-assets/offering/hedvig-dot-2.svg',
     paragraph:
       'Vi håller dig uppdaterad och så fort vi vet när din bindningstid tar slut meddlar vi dig',
   },
   {
     key: 2,
     title: '3',
-    image: 'assets/offering/hedvig-dot-3.svg',
+    image: '/new-member-assets/offering/hedvig-dot-3.svg',
     paragraph:
       'Din Hedvig-försäkring aktiveras samma dag som din gamla försäkring går ut',
   },

--- a/src/pages/Offer/sections/InsuranceCoverage.tsx
+++ b/src/pages/Offer/sections/InsuranceCoverage.tsx
@@ -120,56 +120,56 @@ const PERILS = [
       {
         key: 0,
         title: 'Eldsvåda',
-        icon: '/assets/offering/eldsvada2.svg',
-        iconGrey: '/assets/offering/eldsvada2-grey.svg',
+        icon: '/new-member-assets/offering/eldsvada2.svg',
+        iconGrey: '/new-member-assets/offering/eldsvada2-grey.svg',
         expandableText:
           'En överhettad mobilladdare eller ett misslyckat försök att fritera pommes frites, bränder uppstår på de mest vardagliga vis. Om det börjar brinna i din lägenhet får du ersättning för brand- och rökskador.',
       },
       {
         key: 1,
         title: 'Inbrott',
-        icon: '/assets/offering/inbrott.svg',
-        iconGrey: '/assets/offering/inbrott-grey.svg',
+        icon: '/new-member-assets/offering/inbrott.svg',
+        iconGrey: '/new-member-assets/offering/inbrott-grey.svg',
         expandableText:
           'Ditt hem är din borg. Skulle inkräktare bryta sig in för att stjäla dina saker så ersätter Hedvig dig för det.',
       },
       {
         key: 2,
         title: 'Oväder',
-        icon: '/assets/offering/ovader2.svg',
-        iconGrey: '/assets/offering/ovader2-grey.svg',
+        icon: '/new-member-assets/offering/ovader2.svg',
+        iconGrey: '/new-member-assets/offering/ovader2-grey.svg',
         expandableText:
           'En storm kan vara mäktig så länge den håller sig utanför fönstret. När åskan tar kol på din nya TV och skyfallet letar sig in och svämmar över ditt källarförråd är det tur att du har Hedvig. Du ersätts om ett oväder orsakat skador.',
       },
       {
         key: 3,
         title: 'Skadegörelse',
-        icon: '/assets/offering/skadegorelse2.svg',
-        iconGrey: '/assets/offering/skadegorelse2-grey.svg',
+        icon: '/new-member-assets/offering/skadegorelse2.svg',
+        iconGrey: '/new-member-assets/offering/skadegorelse2-grey.svg',
         expandableText:
           'Om någon bryter sig in i din lägenhet för att vandalisera och förstöra så ersätter Hedvig dig för skadorna.',
       },
       {
         key: 4,
         title: 'Vattenläcka',
-        icon: '/assets/offering/vattenlacka2.svg',
-        iconGrey: '/assets/offering/vattenlacka2-grey.svg',
+        icon: '/new-member-assets/offering/vattenlacka2.svg',
+        iconGrey: '/new-member-assets/offering/vattenlacka2-grey.svg',
         expandableText:
           'Din diskmaskin går sönder och du kommer hem till en swimmingpool i köket och blöta grannar våningen under. Råkar du ut för en vattenläcka får du ersättning för skadorna.',
       },
       {
         key: 5,
         title: 'Vitvaror',
-        icon: '/assets/offering/vitvaror.svg',
-        iconGrey: '/assets/offering/vitvaror-grey.svg',
+        icon: '/new-member-assets/offering/vitvaror.svg',
+        iconGrey: '/new-member-assets/offering/vitvaror-grey.svg',
         expandableText:
           'Plötsligt tackar din spis för sig eller så blir det kortslutning i din prisbelönta kaffemaskin. Hedvig ersätter skador på dina vitvaror, så länge det inte rör sig om skador som din hyresvärd är skyldig att ersätta.',
       },
       {
         key: 8,
         title: 'Bostadsrättstillägg',
-        icon: '/assets/offering/bostadsrattstillagg.svg',
-        iconGrey: '/assets/offering/bostadsrattstillagg-grey.svg',
+        icon: '/new-member-assets/offering/bostadsrattstillagg.svg',
+        iconGrey: '/new-member-assets/offering/bostadsrattstillagg-grey.svg',
         expandableText:
           'Om man äger sin lägenhet är det skönt att ha en försäkring som täcker själva lägenheten också, inte bara prylarna som finns däri. På försäkringsspråk kallas det för bostadsrättstillägg. Med det täcks skador på fast inredning (typ ditt nya kök) och ytskikt (typ dina nyfixade golv, tak eller väggar). Om du har sagt till Hedvig att du äger din lägenhet ingår bostadsrättstillägget automatiskt. Hedvig ersätter kostnaden för att reparera skador på din lägenhet utan beloppsbegränsning - oavsett om du bor i studentlya eller paradvåning. Skönt!',
       },
@@ -182,32 +182,32 @@ const PERILS = [
       {
         key: 0,
         title: 'Juridisk tvist',
-        icon: '/assets/offering/juridisk-tvist.svg',
-        iconGrey: '/assets/offering/juridisk-tvist-grey.svg',
+        icon: '/new-member-assets/offering/juridisk-tvist.svg',
+        iconGrey: '/new-member-assets/offering/juridisk-tvist-grey.svg',
         expandableText:
           'Om du hamnar i domstol så täcker Hedvig kostnaden för ditt ombud, och andra rättegångskostnader. Hedvig täcker också om någon skulle kräva dig på skadestånd för att du har skadat någon, eller någons saker.',
       },
       {
         key: 1,
         title: 'Resetrubbel',
-        icon: '/assets/offering/resetrubbel.svg',
-        iconGrey: '/assets/offering/resetrubbel-grey.svg',
+        icon: '/new-member-assets/offering/resetrubbel.svg',
+        iconGrey: '/new-member-assets/offering/resetrubbel-grey.svg',
         expandableText:
           'Ibland klaffar inte allt som det ska när du ska ut i världen. Till exempel, om ditt bagage blir försenat ersätter Hedvig dig för att köpa saker du behöver. Och om det skulle bli oroligheter i landet du är i, som vid en naturkatastrof, så evakuerar Hedvig dig hem till Sverige.',
       },
       {
         key: 2,
         title: 'Överfall',
-        icon: '/assets/offering/overfall.svg',
-        iconGrey: '/assets/offering/overfall-grey.svg',
+        icon: '/new-member-assets/offering/overfall.svg',
+        iconGrey: '/new-member-assets/offering/overfall-grey.svg',
         expandableText:
           'En hemförsäkring skyddar även dig personligen. Om någon skulle utsätta dig för ett våldsbrott, till exempel misshandel eller rån ersätts du med ett fast belopp.',
       },
       {
         key: 3,
         title: 'Sjuk på resa',
-        icon: '/assets/offering/sjuk-pa-resa.svg',
-        iconGrey: '/assets/offering/sjuk-pa-resa-grey.svg',
+        icon: '/new-member-assets/offering/sjuk-pa-resa.svg',
+        iconGrey: '/new-member-assets/offering/sjuk-pa-resa-grey.svg',
         expandableText:
           'Få saker är roligare än att utforska världen, men det är mindre kul om man blir sjuk. Eller ännu värre, råkar ut för en olycka. Därför ersätts du både för missade resdagar och sjukhuskostnader. Är det riktigt illa står Hedvig för transporten hem till Sverige. Om du har skadats eller blivit sjuk utomlands och behöver akut vård, ring Hedvig Global Assistance dygnet runt på +45 38 48 94 61.',
       },
@@ -220,32 +220,32 @@ const PERILS = [
       {
         key: 0,
         title: 'Drulle',
-        icon: '/assets/offering/drulle.svg',
-        iconGrey: '/assets/offering/drulle-grey.svg',
+        icon: '/new-member-assets/offering/drulle.svg',
+        iconGrey: '/new-member-assets/offering/drulle-grey.svg',
         expandableText:
           'De flesta känner igen känslan av slow-motion när mobilen glider ur handen och voltar ner mot kall asfalt. "Drulle" kallas ibland för otursförsäkring, och det är just vad det är. Om du har otur och dina prylar går sönder, så ersätts du för dem.',
       },
       {
         key: 1,
         title: 'Stöld',
-        icon: '/assets/offering/stold.svg',
-        iconGrey: '/assets/offering/stold-grey.svg',
+        icon: '/new-member-assets/offering/stold.svg',
+        iconGrey: '/new-member-assets/offering/stold-grey.svg',
         expandableText:
           'Prylar är till för att användas, i synnerhet favoriterna. Älskade väskor och jackor följer med på restaurang, datorn får komma med på kafé, plånboken och cykeln är med överallt. Om något stjäls av dig så ersätts du för det.',
       },
       {
         key: 2,
         title: 'Skadegörelse',
-        icon: '/assets/offering/skadegorelse.svg',
-        iconGrey: '/assets/offering/skadegorelse-grey.svg',
+        icon: '/new-member-assets/offering/skadegorelse.svg',
+        iconGrey: '/new-member-assets/offering/skadegorelse-grey.svg',
         expandableText:
           'Varför vissa väljer att förstöra andras saker är en gåta. Hursomhelst så ersätts du när dina prylar förstörs av skadegörelse, eller i samband med att du blir överfallen.',
       },
       {
         key: 3,
         title: 'Eldsvåda',
-        icon: '/assets/offering/ovader.svg',
-        iconGrey: '/assets/offering/ovader-grey.svg',
+        icon: '/new-member-assets/offering/ovader.svg',
+        iconGrey: '/new-member-assets/offering/ovader-grey.svg',
         expandableText:
           'Om det skulle brinna så ersätter Hedvig utöver skador på din lägenhet även alla prylar som blir förstörda.',
       },
@@ -253,16 +253,16 @@ const PERILS = [
       {
         key: 4,
         title: 'Vattenläcka',
-        icon: '/assets/offering/vattenlacka.svg',
-        iconGrey: '/assets/offering/vattenlacka-grey.svg',
+        icon: '/new-member-assets/offering/vattenlacka.svg',
+        iconGrey: '/new-member-assets/offering/vattenlacka-grey.svg',
         expandableText:
           'Om du har en vattenläcka hemma så ersätter Hedvig utöver skador på din lägenhet även alla prylar som blir förstörda.',
       },
       {
         key: 5,
         title: 'Oväder',
-        icon: '/assets/offering/ovader.svg',
-        iconGrey: '/assets/offering/ovader-grey.svg',
+        icon: '/new-member-assets/offering/ovader.svg',
+        iconGrey: '/new-member-assets/offering/ovader-grey.svg',
         expandableText:
           'Hedvig ersätter dig om ett oväder på något sätt skulle orsaka skador på dina prylar, utöver skador på din lägenhet.',
       },

--- a/src/pages/Offer/sections/Offer.tsx
+++ b/src/pages/Offer/sections/Offer.tsx
@@ -121,17 +121,17 @@ const COLUMNS = [
   {
     key: 0,
     title: 'Lagenhetsskydd',
-    icon: '/assets/offering/lagenhetsskyddet.svg',
+    icon: '/new-member-assets/offering/lagenhetsskyddet.svg',
   },
   {
     key: 1,
     title: 'Personskydd',
-    icon: '/assets/offering/familjeskyddet.svg',
+    icon: '/new-member-assets/offering/familjeskyddet.svg',
   },
   {
     key: 2,
     title: 'Prylskydd',
-    icon: '/assets/offering/prylskyddet.svg',
+    icon: '/new-member-assets/offering/prylskyddet.svg',
   },
 ]
 

--- a/src/pages/Offer/sections/Offer.tsx
+++ b/src/pages/Offer/sections/Offer.tsx
@@ -201,7 +201,7 @@ export const Offer: React.SFC<Props> = ({ signButtonVisibility, offer }) => (
                 <TranslationsConsumer textKey="OFFER_SUMMARY_SIGN_CTA">
                   {(ctaText) => (
                     <LinkTag
-                      to={'/sign'}
+                      to={'/new-member/sign'}
                       onClick={() =>
                         trackEvent('Checkout Started', {
                           category: 'offer',

--- a/src/pages/Offer/sections/PageDown.tsx
+++ b/src/pages/Offer/sections/PageDown.tsx
@@ -17,7 +17,7 @@ const PageDownIcon = styled('img')({
 export const PageDown: React.SFC<{}> = () => (
   <Wrapper>
     <InnerWrapper>
-      <PageDownIcon src={'assets/offering/arrow-down.svg'} />
+      <PageDownIcon src={'/new-member-assets/offering/arrow-down.svg'} />
     </InnerWrapper>
   </Wrapper>
 )

--- a/src/pages/Offer/sections/Terms.tsx
+++ b/src/pages/Offer/sections/Terms.tsx
@@ -97,7 +97,7 @@ export const Terms: React.SFC<TermsProps> = ({ insuranceType }) => (
                 >
                   {(url) => (
                     <PerilLink href={url} target="_blank">
-                      <PerilIcon src="/assets/offering/forkopsinformation.svg" />
+                      <PerilIcon src="/new-member-assets/offering/forkopsinformation.svg" />
 
                       <TranslationsConsumer textKey="TERMS_PERIL_ONE_TITLE">
                         {(title) => <PerilTitle>{title}</PerilTitle>}
@@ -116,7 +116,7 @@ export const Terms: React.SFC<TermsProps> = ({ insuranceType }) => (
                 >
                   {(url) => (
                     <PerilLink href={url} target="_blank">
-                      <PerilIcon src="/assets/offering/forkopsinformation.svg" />
+                      <PerilIcon src="/new-member-assets/offering/forkopsinformation.svg" />
 
                       <TranslationsConsumer textKey="TERMS_PERIL_TWO_TITLE">
                         {(title) => <PerilTitle>{title}</PerilTitle>}

--- a/src/pages/Sign/sections/SignSubscription.tsx
+++ b/src/pages/Sign/sections/SignSubscription.tsx
@@ -190,7 +190,7 @@ const StateComponent: React.SFC<StateComponentProps> = ({
     case SIGNSTATE.COMPLETED:
       if (collectStatus.status === BANKIDSTATUS.COMPLETE) {
         trackEvent('Order Completed', { category: 'sign-up' })
-        return <Redirect to="/download" />
+        return <Redirect to="/new-member/download" />
       }
     case SIGNSTATE.FAILED:
       if (collectStatus.status === BANKIDSTATUS.FAILED) {

--- a/src/pages/Sign/sections/SignUp.test.tsx
+++ b/src/pages/Sign/sections/SignUp.test.tsx
@@ -155,7 +155,7 @@ it('signs without 💥', async () => {
   const client = new ApolloClient({ link, cache: new InMemoryCache() })
   const wrapper = mount(
     <HelmetProvider>
-      <StaticRouter context={{}} location="/sign">
+      <StaticRouter context={{}} location="/new-member/sign">
         <ApolloProvider client={client}>
           <Provider
             initialState={{
@@ -210,7 +210,7 @@ it('signs without 💥', async () => {
   })
   await mockNetworkWait()
   wrapper.update()
-  expect(wrapper.find(Redirect).prop('to')).toBe('/download')
+  expect(wrapper.find(Redirect).prop('to')).toBe('/new-member/download')
 })
 
 it('shows an error when bankid errors', async () => {
@@ -270,7 +270,7 @@ it('shows an error when bankid errors', async () => {
   const client = new ApolloClient({ link, cache: new InMemoryCache() })
   const wrapper = mount(
     <HelmetProvider>
-      <StaticRouter context={{}} location="/sign">
+      <StaticRouter context={{}} location="/new-member/sign">
         <ApolloProvider client={client}>
           <Provider
             initialState={{
@@ -383,7 +383,7 @@ it('renders correct status when sign status query has a status', async () => {
   const client = new ApolloClient({ link, cache: new InMemoryCache() })
   const wrapper = mount(
     <HelmetProvider>
-      <StaticRouter context={{}} location="/sign">
+      <StaticRouter context={{}} location="/new-member/sign">
         <ApolloProvider client={client}>
           <Provider
             initialState={{

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,10 +1,12 @@
 import { Chat } from './pages/Chat'
 import { Download } from './pages/Download'
 import { FourOhFour } from './pages/FourOhFour'
+import { NewMemberLanding } from './pages/NewMemberLanding'
 import { Offering } from './pages/Offer'
 import { Sign } from './pages/Sign'
 
 export const reactPageRoutes = [
+  { path: '/new-member', Component: NewMemberLanding, exact: true },
   { path: '/new-member/hedvig', Component: Chat, exact: true },
   { path: '/new-member/offer', Component: Offering, exact: true },
   { path: '/new-member/download', Component: Download, exact: true },

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -5,9 +5,9 @@ import { Offering } from './pages/Offer'
 import { Sign } from './pages/Sign'
 
 export const reactPageRoutes = [
-  { path: '/hedvig', Component: Chat, exact: true },
-  { path: '/offer', Component: Offering, exact: true },
-  { path: '/download', Component: Download, exact: true },
-  { path: '/sign', Component: Sign, exact: true },
+  { path: '/new-member/hedvig', Component: Chat, exact: true },
+  { path: '/new-member/offer', Component: Offering, exact: true },
+  { path: '/new-member/download', Component: Download, exact: true },
+  { path: '/new-member/sign', Component: Sign, exact: true },
   { path: '/*', Component: FourOhFour },
 ]

--- a/src/serverEntry.tsx
+++ b/src/serverEntry.tsx
@@ -44,7 +44,7 @@ appLogger.info(
 )
 
 const server = createKoaServer({
-  publicPath: '/assets',
+  publicPath: '/new-member-assets',
   assetLocation: __dirname + '/assets',
 })
 server.app.use(setRequestUuidMiddleware)


### PR DESCRIPTION
This simply prefixes the asset urls with `/new-member-assets` and all urls with `/new-member`

coupled with https://github.com/HedvigInsurance/web/tree/feature/web-onboarding