### PR TITLE
Enable dev tools for Constate in non-prod envs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,10 @@ export const App: React.SFC<StorageState> = ({ session }) => (
   <>
     <GlobalCss />
     <TranslationsProvider code="sv_SE" project={Project.WebOnboarding}>
-      <Provider<WithStorageProps> initialState={{ storage: { session } }}>
+      <Provider<WithStorageProps>
+        initialState={{ storage: { session } }}
+        devtools={process.env.NODE_ENV !== 'production'}
+      >
         <Switch>
           {reactPageRoutes.map(({ path, exact, Component }) => (
             <Route key={path} path={path} exact={exact} component={Component} />


### PR DESCRIPTION
Setting `devtools=true` on the Constate `<Provider />` lets it interact
with `redux-devtools`, which makes for pleasant development.