### PR TITLE
Fix CSP for ad script

### DIFF
--- a/src/server/middleware/helmet.ts
+++ b/src/server/middleware/helmet.ts
@@ -31,7 +31,7 @@ const defaultSrc = [
   'sc-static.net',
   'analytics.twitter.com',
   'online.adservicemedia.dk',
-  'online.adservicemedia.dk.*',
+  '*.9270fc4b.id.opendns.com',
   '*.doubleclick.net',
   GIRAFFE_ENDPOINT,
   GIRAFFE_WS_ENDPOINT,

--- a/src/server/middleware/helmet.ts
+++ b/src/server/middleware/helmet.ts
@@ -31,6 +31,7 @@ const defaultSrc = [
   'sc-static.net',
   'analytics.twitter.com',
   'online.adservicemedia.dk',
+  'online.adservicemedia.dk.*',
   '*.doubleclick.net',
   GIRAFFE_ENDPOINT,
   GIRAFFE_WS_ENDPOINT,


### PR DESCRIPTION
The online.adservicemedia.dk script from Google tag manager got blocked by the CSP directive 'script-src-elem'. 'Script-src-elem' should fallback to 'script-src' which we already have in the helmet, so the problem was the URL which had some bits and pieces ahead of its 'online.adservicemedia.dk'. At the top was '9270fc4b.id.opendns.com', so scripts with this url suffix are now allowed.