### PR TITLE
Add CSP rule for bnc.lt

### DIFF
--- a/src/server/middleware/helmet.ts
+++ b/src/server/middleware/helmet.ts
@@ -35,6 +35,7 @@ const defaultSrc = [
   '*.branch.io',
   'https://adtr.io',
   'https://track.adtraction.com',
+  'bnc.lt',
   'app.link',
   'hedvig.app.link',
   'hedvig.test-app.link',


### PR DESCRIPTION
Apparently, branch.io requires another CSP rule for its `sendSMS` to function correctly...