### PR TITLE
Don't use proxy for text keys if it doesn't exist in global scope

### DIFF
--- a/src/pages/Referral/util.ts
+++ b/src/pages/Referral/util.ts
@@ -96,7 +96,7 @@ export const getAppStoreId = () => {
   }
 
   throw Error(
-    'Unable to find apple bundle id - specify with envvar `APPLE_BUNDLE_ID`',
+    'Unable to find app store id - specify with envvar `APP_STORE_ID`',
   )
 }
 

--- a/src/utils/hooks/useTextKeys.ts
+++ b/src/utils/hooks/useTextKeys.ts
@@ -12,32 +12,49 @@ interface TextKeyResolver {
 
 export type TextKeyMap = Record<string, TextKeyResolver>
 
-export const makeTextKeyResolver = (textKeys: TextKeys) =>
-  new Proxy<TextKeyMap>(
+const replacePlaceholders = (
+  resolvedKey: string,
+  replacements?: Replacements,
+) => {
+  if (!replacements) {
+    return resolvedKey
+  }
+  const matches = resolvedKey.split(placeholderRegex).filter((value) => value)
+
+  return matches.map((placeholder) => {
+    if (!placeholderKeyRegex.test(placeholder)) {
+      return placeholder
+    }
+    const k = placeholder.match(placeholderKeyRegex)![0]
+
+    const value = replacements[k]
+
+    return value?.toString() ?? placeholder
+  })
+}
+
+export const makeTextKeyResolver = (textKeys: TextKeys) => {
+  if (typeof Proxy === 'undefined') {
+    return Object.entries(textKeys).reduce<Record<string, any>>(
+      (acc, [key, value]) => ({
+        ...acc,
+        [key!]: (replacements?: Replacements) =>
+          replacePlaceholders(value, replacements),
+      }),
+      {},
+    )
+  }
+
+  return new Proxy<TextKeyMap>(
     {},
     {
       get: (_, key: string) => (replacements?: Replacements) => {
         const resolvedKey = textKeys[key] || key
-        if (!replacements) {
-          return resolvedKey
-        }
-        const matches = resolvedKey
-          .split(placeholderRegex)
-          .filter((value) => value)
-
-        return matches.map((placeholder) => {
-          if (!placeholderKeyRegex.test(placeholder)) {
-            return placeholder
-          }
-          const k = placeholder.match(placeholderKeyRegex)![0]
-
-          const value = replacements[k]
-
-          return value?.toString() ?? placeholder
-        })
+        return replacePlaceholders(resolvedKey, replacements)
       },
     },
   )
+}
 
 export const useTextKeys = () => {
   const context = React.useContext(TranslationsContext)


### PR DESCRIPTION
Will fix whitescreen-of-death in ie11 that has appeared