### PR TITLE
Fix date input clipping issue

### DIFF
--- a/src/new-components/DateInput/index.tsx
+++ b/src/new-components/DateInput/index.tsx
@@ -15,7 +15,6 @@ const Wrapper = styled(motion.div)`
   position: absolute;
   left: 0;
   width: 100%;
-  height: 100%;
   padding: 0.625rem 1.25rem;
 `
 
@@ -48,7 +47,7 @@ const CalendarMonth = styled.div`
   display: inline-block;
   width: 100%;
   padding: 0 0.625rem 1.875rem;
-  boxsizing: border-box;
+  box-sizing: border-box;
   user-select: none;
 `
 
@@ -149,7 +148,7 @@ const EmptyDay = styled.div`
 
 const CalendarContainer = styled.div`
   position: relative;
-  maxwidth: 800;
+  max-width: 50rem;
   margin: 0 auto;
   text-align: center;
 `

--- a/src/pages/OfferNew/Introduction/Sidebar/DiscountCodeModal.tsx
+++ b/src/pages/OfferNew/Introduction/Sidebar/DiscountCodeModal.tsx
@@ -31,6 +31,7 @@ const Wrapper = styled.div<{ isOpen: boolean }>`
   padding: 1rem;
   display: flex;
   align-items: center;
+  border-radius: 8px;
 `
 
 const Container = styled(motion.div)`

--- a/src/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
+++ b/src/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
@@ -9,6 +9,7 @@ import {
   useRemoveStartDateMutation,
   useStartDateMutation,
 } from 'generated/graphql'
+import hexToRgba from 'hex-to-rgba'
 import { DateInput } from 'new-components/DateInput'
 import { Switch } from 'new-components/Switch'
 import * as React from 'react'
@@ -122,6 +123,27 @@ const DataCollectedStartDateValue = styled.span`
   font-size: 1rem;
 `
 
+const DateInputModalWrapper = styled.div<{ isOpen: boolean }>`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  background: ${hexToRgba(colorsV2.white, 0.8)};
+  top: 0;
+  left: 0;
+  transition: all 0.2s;
+  visibility: ${(props) => (props.isOpen ? 'visible' : 'hidden')};
+  opacity: ${(props) => (props.isOpen ? 1 : 0)};
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  border-radius: 8px;
+`
+
+const DateInputModal = styled(DateInput)`
+  top: 50%;
+  transform: translateY(-50%);
+`
+
 export const StartDate: React.FC<Props> = ({
   offerId,
   startDate,
@@ -226,21 +248,25 @@ export const StartDate: React.FC<Props> = ({
           />
         </Value>
       </RowButton>
-      <DateInput
-        open={datePickerOpen}
-        setOpen={setDatePickerOpen}
-        date={dateValue || new Date()}
-        setDate={(newDateValue) => {
-          setDateValue(newDateValue)
-          setShowError(false)
-          setStartDate({
-            variables: {
-              quoteId: offerId,
-              date: format(newDateValue, gqlDateFormat),
-            },
-          }).catch(handleFail)
-        }}
-      />
+
+      <DateInputModalWrapper isOpen={datePickerOpen}>
+        <DateInputModal
+          open={datePickerOpen}
+          setOpen={setDatePickerOpen}
+          date={dateValue || new Date()}
+          setDate={(newDateValue) => {
+            setDateValue(newDateValue)
+            setShowError(false)
+            setStartDate({
+              variables: {
+                quoteId: offerId,
+                date: format(newDateValue, gqlDateFormat),
+              },
+            }).catch(handleFail)
+          }}
+        />
+      </DateInputModalWrapper>
+
       {currentInsurer?.switchable && (
         <HandleSwitchingWrapper>
           <HandleSwitchingLabel>


### PR DESCRIPTION
To solve the clipping problem with the date picker, I moved it into a modal within the sidebar. 

<img width="445" alt="Screenshot 2020-01-22 at 14 13 31" src="https://user-images.githubusercontent.com/1573205/72897093-61aa7e80-3d21-11ea-8cf7-7eb246e1c4a0.png">
