### PR TITLE
Allow choosing start date to be when previous insurance expires

### DIFF
--- a/src/new-components/DateInput/index.tsx
+++ b/src/new-components/DateInput/index.tsx
@@ -8,6 +8,7 @@ import { addYears, subDays } from 'date-fns'
 import Dayzed, { RenderProps as DayzedCalendarProps } from 'dayzed'
 import { motion } from 'framer-motion'
 import * as React from 'react'
+import { TextButton } from '../buttons'
 import { AnimationDirection, Animator } from './Animator'
 import { useMeasure } from './useMeasure'
 
@@ -154,11 +155,19 @@ const CalendarContainer = styled.div`
   text-align: center;
 `
 
+const AtStartDateContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 0 0 1.875rem;
+`
+
 interface DateInputProps {
   open: boolean
   setOpen: (open: boolean) => void
   date: Date
-  setDate: (date: Date) => void
+  setDate: (date: Date | null) => void
+  hasCurrentInsurer: boolean
 }
 
 const Calendar: React.FC<DayzedCalendarProps> = ({
@@ -301,6 +310,7 @@ export const DateInput: React.FC<DateInputProps> = ({
   setOpen,
   date,
   setDate,
+  hasCurrentInsurer,
 }) => {
   return (
     <Wrapper
@@ -345,6 +355,18 @@ export const DateInput: React.FC<DateInputProps> = ({
           }}
           render={(dayzedData) => <Calendar {...dayzedData} />}
         />
+        {hasCurrentInsurer ? (
+          <AtStartDateContainer>
+            <TextButton
+              onClick={() => {
+                setDate(null)
+                setOpen(false)
+              }}
+            >
+              När min gamla försäkring löper ut
+            </TextButton>
+          </AtStartDateContainer>
+        ) : null}
       </Container>
     </Wrapper>
   )

--- a/src/new-components/DateInput/index.tsx
+++ b/src/new-components/DateInput/index.tsx
@@ -355,7 +355,7 @@ export const DateInput: React.FC<DateInputProps> = ({
           }}
           render={(dayzedData) => <Calendar {...dayzedData} />}
         />
-        {hasCurrentInsurer ? (
+        {hasCurrentInsurer && (
           <AtStartDateContainer>
             <TextButton
               onClick={() => {
@@ -366,7 +366,7 @@ export const DateInput: React.FC<DateInputProps> = ({
               När min gamla försäkring löper ut
             </TextButton>
           </AtStartDateContainer>
-        ) : null}
+        )}
       </Container>
     </Wrapper>
   )

--- a/src/new-components/DateInput/index.tsx
+++ b/src/new-components/DateInput/index.tsx
@@ -8,6 +8,7 @@ import { addYears, subDays } from 'date-fns'
 import Dayzed, { RenderProps as DayzedCalendarProps } from 'dayzed'
 import { motion } from 'framer-motion'
 import * as React from 'react'
+import { useTextKeys } from 'utils/hooks/useTextKeys'
 import { TextButton } from '../buttons'
 import { AnimationDirection, Animator } from './Animator'
 import { useMeasure } from './useMeasure'
@@ -311,6 +312,8 @@ export const DateInput: React.FC<DateInputProps> = ({
   setDate,
   hasCurrentInsurer,
 }) => {
+  const textKeys = useTextKeys()
+
   return (
     <Wrapper
       aria-hidden={!open}
@@ -362,7 +365,7 @@ export const DateInput: React.FC<DateInputProps> = ({
                 setOpen(false)
               }}
             >
-              När min gamla försäkring löper ut
+              {textKeys.START_DATE_WHEN_OLD_EXPIRES()}
             </TextButton>
           </AtStartDateContainer>
         )}

--- a/src/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
+++ b/src/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
@@ -233,12 +233,20 @@ export const StartDate: React.FC<Props> = ({
         setDate={(newDateValue) => {
           setDateValue(newDateValue)
           setShowError(false)
-          setStartDate({
-            variables: {
-              quoteId: offerId,
-              date: newDateValue ? format(newDateValue, gqlDateFormat) : null,
-            },
-          }).catch(handleFail)
+          if (newDateValue === null) {
+            removeStartDate({
+              variables: {
+                quoteId: offerId,
+              },
+            }).catch(handleFail)
+          } else {
+            setStartDate({
+              variables: {
+                quoteId: offerId,
+                date: newDateValue ? format(newDateValue, gqlDateFormat) : null,
+              },
+            }).catch(handleFail)
+          }
         }}
         hasCurrentInsurer={currentInsurer !== null}
       />

--- a/src/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
+++ b/src/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
@@ -236,10 +236,11 @@ export const StartDate: React.FC<Props> = ({
           setStartDate({
             variables: {
               quoteId: offerId,
-              date: format(newDateValue, gqlDateFormat),
+              date: newDateValue ? format(newDateValue, gqlDateFormat) : null,
             },
           }).catch(handleFail)
         }}
+        hasCurrentInsurer={currentInsurer !== null}
       />
       {currentInsurer?.switchable && (
         <HandleSwitchingWrapper>

--- a/src/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
+++ b/src/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
@@ -243,7 +243,7 @@ export const StartDate: React.FC<Props> = ({
             setStartDate({
               variables: {
                 quoteId: offerId,
-                date: newDateValue ? format(newDateValue, gqlDateFormat) : null,
+                date: format(newDateValue, gqlDateFormat),
               },
             }).catch(handleFail)
           }


### PR DESCRIPTION
There's one outstanding issue in this PR: How will the backend respond if we send null on editQuote for startDate? Will it ignore it, or will it explicitly set the data to be null?

EDIT: I've updated this code to use `removeStartDate` 🙂 