### PR TITLE
Update trustpilot scores

### DIFF
--- a/src/pages/OfferNew/Compare/mock.ts
+++ b/src/pages/OfferNew/Compare/mock.ts
@@ -33,7 +33,7 @@ export const otherCompanies: CompanyProperties[] = [
     liabilityProtection: true,
     legalProtection: true,
     drulle: false,
-    trustpilotScore: 2.1,
+    trustpilotScore: 2.2,
   },
   {
     name: 'If Hem',
@@ -110,6 +110,6 @@ export const otherCompanies: CompanyProperties[] = [
     liabilityProtection: true,
     legalProtection: true,
     drulle: false,
-    trustpilotScore: 1.6,
+    trustpilotScore: 2.1,
   },
 ]

--- a/src/pages/OfferNew/Compare/mock.ts
+++ b/src/pages/OfferNew/Compare/mock.ts
@@ -9,7 +9,7 @@ export const hedvigCompany: CompanyProperties = {
   liabilityProtection: true,
   legalProtection: true,
   drulle: true,
-  trustpilotScore: 4.5,
+  trustpilotScore: 4.6,
 }
 
 export const otherCompanies: CompanyProperties[] = [
@@ -33,7 +33,7 @@ export const otherCompanies: CompanyProperties[] = [
     liabilityProtection: true,
     legalProtection: true,
     drulle: false,
-    trustpilotScore: 1.2,
+    trustpilotScore: 2.1,
   },
   {
     name: 'If Hem',
@@ -44,7 +44,7 @@ export const otherCompanies: CompanyProperties[] = [
     liabilityProtection: true,
     legalProtection: true,
     drulle: false,
-    trustpilotScore: 1.6,
+    trustpilotScore: 4.3,
   },
   {
     name: 'Ica',
@@ -55,7 +55,7 @@ export const otherCompanies: CompanyProperties[] = [
     liabilityProtection: true,
     legalProtection: true,
     drulle: true,
-    trustpilotScore: 3.6,
+    trustpilotScore: 3.3,
   },
   {
     name: 'Länsförsäkringar',
@@ -66,7 +66,7 @@ export const otherCompanies: CompanyProperties[] = [
     liabilityProtection: true,
     legalProtection: true,
     drulle: false,
-    trustpilotScore: 1.6,
+    trustpilotScore: 1.5,
   },
   {
     name: 'Moderna Försäkringar Grundskydd',
@@ -77,7 +77,7 @@ export const otherCompanies: CompanyProperties[] = [
     liabilityProtection: true,
     legalProtection: true,
     drulle: false,
-    trustpilotScore: 1.9,
+    trustpilotScore: 3.5,
   },
   {
     name: 'Vardia Hemförsäkring',
@@ -110,6 +110,6 @@ export const otherCompanies: CompanyProperties[] = [
     liabilityProtection: true,
     legalProtection: true,
     drulle: false,
-    trustpilotScore: 2.1,
+    trustpilotScore: 1.6,
   },
 ]


### PR DESCRIPTION
- Hedvig: 4.5 -> 4.6
- Trygg Hansa: 1.2 -> 2.2
- If Hem: 1.6 -> 4.3 
- Ica: 3.6 -> 3.3
- Länsförsäkringar: 1.6 -> 1.5
- Moderna: 1.9 -> 3.5