### PR TITLE
Fix so peril images shrink in chrome

### DIFF
--- a/src/pages/OfferNew/Perils/PerilCollection/PerilItem.tsx
+++ b/src/pages/OfferNew/Perils/PerilCollection/PerilItem.tsx
@@ -52,15 +52,17 @@ const Container = styled.span`
     border: 1px solid ${colorsV2.lightgray};
   }
 
-  svg {
+  img {
     width: 2rem;
     height: 2rem;
     margin-right: 0.5rem;
 
     @media (min-width: 400px) {
       margin-right: 0;
-      width: 3rem;
+      width: 100%;
       height: 3rem;
+      min-width: 0;
+      min-height: 0;
     }
   }
 


### PR DESCRIPTION
So this fix makes no sense, but it does fix this issue:

# BEFORE
![Screenshot 2020-04-08 at 09 36 15](https://user-images.githubusercontent.com/3954425/78757445-cf5b6380-797c-11ea-8369-34e16ac56539.png)

# AFTER
![Screenshot 2020-04-08 at 09 36 06](https://user-images.githubusercontent.com/3954425/78757444-ce2a3680-797c-11ea-8047-261ccff98968.png)

i love css

(and yes, we need to shorten the titles a bit but i guess this is a bit less sucky) (and ping @gustaveen btw you might want to fix this in web-next also)