### PR TITLE
Add GTM dataLayer

### DIFF
--- a/src/client/utils/tracking.ts
+++ b/src/client/utils/tracking.ts
@@ -10,6 +10,7 @@ import { OfferData } from 'pages/OfferNew/types'
 import { isBundle, isYouth } from 'pages/OfferNew/utils'
 import { SegmentAnalyticsJs, setupTrackers } from 'quepasa'
 import React from 'react'
+import { DataLayerObject } from 'src/types/gtm'
 
 const cookie = new CookieStorage()
 
@@ -120,6 +121,11 @@ export const useTrack = ({ offerData, signState }: TrackProps) => {
   const { data: memberData } = useMemberQuery()
   const memberId = memberData?.member.id!
 
+  const pushToGTMDataLayer = (obj: DataLayerObject) => {
+    window.dataLayer = window.dataLayer || []
+    window.dataLayer.push(obj)
+  }
+
   React.useEffect(() => {
     if (process.env.NODE_ENV === 'test') {
       return
@@ -142,6 +148,16 @@ export const useTrack = ({ offerData, signState }: TrackProps) => {
         : null,
       offerData,
     )
+
+    pushToGTMDataLayer({
+      event: 'signed_customer',
+      offerData: {
+        insurance_type: offerData.quotes[0].contractType,
+        campaign_code: redeemedCampaigns?.length > 0 ? 'yes' : 'no',
+        number_of_people: offerData.person.householdSize,
+        insurance_price: parseFloat(offerData.cost.monthlyNet.amount) * 12,
+      },
+    })
 
     if (
       redeemedCampaigns?.length > 0 &&

--- a/src/server/middleware/helmet.ts
+++ b/src/server/middleware/helmet.ts
@@ -100,6 +100,7 @@ export const helmet = koaHelmet({
         'www.googletagmanager.com',
         'www.google-analytics.com',
         'www.gstatic.com',
+        'https://ssl.gstatic.com',
         'www.google.com',
         'www.google.se',
         'www.google.no',

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -108,6 +108,10 @@ const template = (
       Sentry.init(${JSON.stringify(sentryConfig())})
     </script>
 
+    <script nonce="${cspNonce}">
+      dataLayer = [];
+    </script>
+
     <!-- Google Tag Manager -->
     <script nonce="${cspNonce}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/src/types/gtm.d.ts
+++ b/src/types/gtm.d.ts
@@ -1,0 +1,17 @@
+declare global {
+  interface Window {
+    dataLayer?: object[]
+  }
+}
+
+interface OfferData {
+  insurance_type: TypeOfContract
+  campaign_code: 'yes' | 'no'
+  number_of_people: number
+  insurance_price: number
+}
+
+export interface DataLayerObject {
+  event: string
+  offerData?: OfferData
+}


### PR DESCRIPTION
Adding Google tag manager dataLayer as requested by Precis Digital via Carl. (See spec from Precis Digital below) Offer data is sent after signed quote along with the rest of the tracking. 
```
  dataLayer.push({
   ‘insurance_type‘: '[Server Value]'//type of insurance, e.g. sublet, rent, owned apartment, house, etc. - Type: String - Required
   ‘campaign_code‘: '[Server Value]’//were a campaign code used during sign-up, e.g. yes or no - Type: String - Required
   ‘number_of_people‘: '[Server Value]’//Amount of people covered by the insurance - Type: Integer - Required
   ‘insurance_price‘: '[Premium x 12]’//monthly price - Type: Integer - Required
   'event’:’signed_customer’
});
```

Image from GTM debugger:
<img width="353" alt="Screenshot 2020-08-10 at 17 05 32" src="https://user-images.githubusercontent.com/6661511/89797882-c72e5300-db2b-11ea-9a0a-1adff93f77a4.png">

