### PR TITLE
White list trustly's test environment as valid postmessage origin

### DIFF
--- a/src/client/components/Modal.tsx
+++ b/src/client/components/Modal.tsx
@@ -70,6 +70,7 @@ const Modal: React.FC<Props> = ({ isOpen, setIsOpen, style, children }) => (
       style={{
         overlay: {
           ...defaultStyle.overlay,
+          zIndex: 9999,
           ...(style ? style.overlay : {}),
         },
         content: {

--- a/src/client/pages/ConnectPayment/components/TrustlyModal.tsx
+++ b/src/client/pages/ConnectPayment/components/TrustlyModal.tsx
@@ -59,7 +59,8 @@ export const TrustlyModal: React.FC<Props> = ({
           See https://github.com/jsdom/jsdom/issues/2745
          */
         process.env.NODE_ENV !== 'test' &&
-        e.origin !== 'https://trustly.com'
+        e.origin !== 'https://trustly.com' &&
+        e.origin !== 'https://test.trustly.com'
       ) {
         return
       }


### PR DESCRIPTION
also put the modal on top of the header