### PR TITLE
Chore / react hooks ESLint plugin / install and setup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'prettier/@typescript-eslint',
     'plugin:import/typescript',
+    'plugin:react-hooks/recommended',
     'plugin:prettier/recommended',
   ],
   parser: '@typescript-eslint/parser',
@@ -21,7 +22,7 @@ module.exports = {
       jsx: true,
     },
   },
-  plugins: ['import', 'react', '@typescript-eslint', 'prettier'],
+  plugins: ['import', 'react', 'react-hooks', '@typescript-eslint', 'prettier'],
   settings: {
     react: {
       version: 'detect',
@@ -50,6 +51,8 @@ module.exports = {
     ],
     'react/prop-types': 'off',
     'react/display-name': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.21.2",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "husky": "^0.14.3",
     "jest": "^26.0.1",
     "lint-staged": "^7.3.0",

--- a/src/client/utils/textKeys.tsx
+++ b/src/client/utils/textKeys.tsx
@@ -140,7 +140,8 @@ export const TextKeyProvider: React.FC<{
         setIsDebugmode(false)
       }
     }
-  }, [locationSearch?.includes(DEBUG_TEXTKEYS_QUERY)])
+  }, [locationSearch])
+
   useEffect(() => {
     sessionStorage.setItem(DEBUG_LOCAL_STORAGE_KEY, JSON.stringify(isDebugMode))
   }, [isDebugMode])

--- a/yarn.lock
+++ b/yarn.lock
@@ -6875,6 +6875,11 @@ eslint-plugin-prettier@^3.1.4:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+
 eslint-plugin-react@^7.21.2:
   version "7.21.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.21.4.tgz#31060b2e5ff82b12e24a3cc33edb7d12f904775c"


### PR DESCRIPTION
### What?

First step towards using the `eslint-plugin-react-hooks`, in order for us to use hooks the way they say you should 😇

1) Install `eslint-plugin-react-hooks` and add some config to `.eslintrc.js`.
2) Modify dependency array of `useEffect` in `textKeys.tsx` since it caused ESLint to crash completely.


<br>

### Why?

It's probably not a good idea to use hooks in another way than they are intended to. 😅

_Referenced ticket [here](https://hedvig.atlassian.net/browse/HVG-248)_ 