### PR TITLE
HVG-126 Enable adyen in Denmark

### DIFF
--- a/src/client/pages/ConnectPayment/sections/ConnectPayment.tsx
+++ b/src/client/pages/ConnectPayment/sections/ConnectPayment.tsx
@@ -125,7 +125,9 @@ export const ConnectPaymentPage: React.FC = () => {
           </Header>
           <ConnectText>{textKeys.ONBOARDING_CONNECT_DD_BODY()}</ConnectText>
           {market === Market.Se && <TrustlyCheckout onSuccess={onSuccess} />}
-          {market === Market.No && <AdyenCheckout onSuccess={onSuccess} />}
+          {(market === Market.No || market === Market.Dk) && (
+            <AdyenCheckout onSuccess={onSuccess} />
+          )}
           <ErrorModal />
         </TextColumn>
         <ImageColumn>


### PR DESCRIPTION
The same origin key is used for both Norway and Denmark so no configuration was required, as we first thought.
Everything is solved in the backend.