### PR TITLE
Fix / Add offer page link to debugger

### DIFF
--- a/src/client/pages/Debugger/components/Offer.tsx
+++ b/src/client/pages/Debugger/components/Offer.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import { useLocation } from 'react-router'
 import { Form, Formik, FormikProps } from 'formik'
 import { v4 as uuid } from 'uuid'
 import { colorsV3 } from '@hedviginsurance/brand'
@@ -102,8 +101,6 @@ export const Offer: React.FC<OfferProps> = ({ sessionToken }) => {
   const currentLocale = useCurrentLocale()
   const localeIsoCode = getLocaleIsoCode(currentLocale)
   const currentMarket = useMarket()
-  const location = useLocation()
-  console.log('🐐: location', location)
 
   const [quoteType, setQuoteType] = useState(
     quotesByMarket[currentMarket][0].value,
@@ -278,7 +275,7 @@ export const Offer: React.FC<OfferProps> = ({ sessionToken }) => {
               <LinkButton
                 background={colorsV3.gray100}
                 foreground={colorsV3.gray900}
-                to={location.pathname.replace('debugger', 'offer')}
+                to={`/${currentLocale}/new-member/offer`}
               >
                 Go to offer page →
               </LinkButton>

--- a/src/client/pages/Debugger/components/Offer.tsx
+++ b/src/client/pages/Debugger/components/Offer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { useLocation } from 'react-router'
 import { Form, Formik, FormikProps } from 'formik'
 import { v4 as uuid } from 'uuid'
 import { colorsV3 } from '@hedviginsurance/brand'
@@ -13,6 +14,7 @@ import {
   useMarket,
   Market,
 } from 'components/utils/CurrentLocale'
+import { LinkButton } from '../../../components/buttons'
 import { initialSeApartmentValues, SwedishApartment } from './QuoteFormSweden'
 import {
   initialNoHomeValues,
@@ -100,6 +102,8 @@ export const Offer: React.FC<OfferProps> = ({ sessionToken }) => {
   const currentLocale = useCurrentLocale()
   const localeIsoCode = getLocaleIsoCode(currentLocale)
   const currentMarket = useMarket()
+  const location = useLocation()
+  console.log('🐐: location', location)
 
   const [quoteType, setQuoteType] = useState(
     quotesByMarket[currentMarket][0].value,
@@ -269,7 +273,20 @@ export const Offer: React.FC<OfferProps> = ({ sessionToken }) => {
               </Formik>
             </>
           )}
-          {data?.quote && <pre>{JSON.stringify(data, null, 2)}</pre>}
+          {data?.quote && (
+            <>
+              <LinkButton
+                background={colorsV3.gray100}
+                foreground={colorsV3.gray900}
+                to={location.pathname.replace('debugger', 'offer')}
+              >
+                Go to offer page →
+              </LinkButton>
+              <div style={{ padding: '2rem 0' }}>
+                <pre>{JSON.stringify(data, null, 2)}</pre>
+              </div>
+            </>
+          )}
           {quoteCreatingError && (
             <>
               <h2>Something went wrong 😔</h2>


### PR DESCRIPTION
### What?

Add "Go to offer page" `<LinkButton>` in `/Debugger/components/Offer.tsx`. 
This is rendered above the quote data if there's a created quote and it leads to the real offer page `.../new-member/offer`.

<br>

### Why?

It's annoying when you're using the debugger tool to create quotes that you have to go to the address bar and _type stuff_ in order to see your quote data on the real offer page.

<br>

### GIF

**Creating a quote with the debugger and then going to the `/offer` page in _one click_ 😀**

![2020-10-30-go-to-offer-page-debugger](https://user-images.githubusercontent.com/42962286/97697752-bd234d00-1aa7-11eb-91de-97a8c54bf6c1.gif)
