### PR TITLE
Fixed Sentry undefined error, to enable Sentry to log if 3D security redirect goes to error page.

### DIFF
--- a/src/server/adyenMiddleware.ts
+++ b/src/server/adyenMiddleware.ts
@@ -1,4 +1,4 @@
-import Sentry from '@sentry/node'
+import * as Sentry from '@sentry/node'
 import Axios from 'axios'
 import Router from 'koa-router'
 import { ServerCookieStorage } from 'utils/storage/ServerCookieStorage'


### PR DESCRIPTION
   **[OBS]** Not confirmed if this actually works and works like a better way to log if this is a problem.
  
   Fixed Sentry being undefined by importing Sentry the "correct" way"
   https://github.com/getsentry/sentry-javascript/issues/1723

   **Investigation:**
   The error occurs when the Authorization header is undefined.
   I could not consistently reproduce the error. So the solution is to enable
   Sentry and see if this error occurs for users.

   The header is undefined when the "hvsession" cookie cannot be retrieved.
   It seems that its an async problem when redirecting from Adyens 3D secure. (the cookie is not present here)
   And not being able to reload the cookie in time for the Giraffe request.