### PR TITLE
Chore / React hooks ESLint plugin / SignLoading.tsx

### DIFF
--- a/src/client/pages/SignLoading.tsx
+++ b/src/client/pages/SignLoading.tsx
@@ -32,7 +32,6 @@ const TextWrapper = styled('div')`
 `
 
 export const SignLoading: React.FC = () => {
-  const [timer, setTimer] = useState<number | null>(null)
   const [hasTakenLong, setHasTakenLong] = useState(false)
   const signStatusQuery = useSignStatusQuery({
     pollInterval: 1000,
@@ -61,9 +60,9 @@ export const SignLoading: React.FC = () => {
   })
 
   useEffect(() => {
-    setTimer(window.setTimeout(() => setHasTakenLong(true), 10000))
+    const timer = window.setTimeout(() => setHasTakenLong(true), 10000)
     return () => {
-      window.clearTimeout(timer!)
+      window.clearTimeout(timer)
     }
   }, [])
 
@@ -74,7 +73,11 @@ export const SignLoading: React.FC = () => {
     if (variation === Variation.AVY) {
       handleSignedEvent(member.data?.member ?? null)
     }
-  }, [signStatusQuery.data?.signStatus?.signState])
+  }, [
+    signStatusQuery.data?.signStatus?.signState,
+    member.data?.member,
+    variation,
+  ])
 
   const failureReturnUrl = currentLocale
     ? `/${currentLocale}/new-member/offer?sign-error=yes`


### PR DESCRIPTION
### What?

Fix `eslint-plugin-react-hooks` warnings in `SignLoading.tsx` 😇

1. Fix `setTimeout` in `useEffect` so that `timer` state can be removed and hence is not needed as a dependency to this `useEffect`.
2. Add dependencies to other `useEffect` dependency array.

<br>

_Referenced ticket [here](https://hedvig.atlassian.net/browse/HVG-248)_ 