### PR TITLE
Adding memberId to gtm script (only when eventName is signed_customer…

### DIFF
--- a/src/client/pages/OfferNew/types.ts
+++ b/src/client/pages/OfferNew/types.ts
@@ -56,6 +56,7 @@ export interface OfferData {
   person: OfferPersonInfo
   quotes: ReadonlyArray<OfferQuote>
   cost: InsuranceCost
+  memberId?: string
 }
 
 export interface WithEmailForm {

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -30,20 +30,17 @@ export const trackOfferGTM = (
   offerData: OfferData,
   referralCodeUsed: boolean,
 ) => {
-  const baseOfferData = {
-    insurance_type: getContractType(offerData),
-    referral_code: referralCodeUsed ? 'yes' : 'no',
-    number_of_people: offerData.person.householdSize,
-    insurance_price: parseFloat(offerData.cost.monthlyNet.amount),
-    currency: offerData.cost.monthlyNet.currency,
-  }
-  const gmtOfferData = (eventName === 'offer_created' || !offerData.memberId
-    ? baseOfferData
-    : { ...baseOfferData, member_id: offerData.memberId }) as GTMOfferData
   try {
     pushToGTMDataLayer({
       event: eventName,
-      offerData: gmtOfferData,
+      offerData: {
+        insurance_type: getContractType(offerData),
+        referral_code: referralCodeUsed ? 'yes' : 'no',
+        number_of_people: offerData.person.householdSize,
+        insurance_price: parseFloat(offerData.cost.monthlyNet.amount),
+        currency: offerData.cost.monthlyNet.currency,
+        member_id: offerData.memberId,
+      },
     })
   } catch (e) {
     captureSentryError(e)

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -39,7 +39,7 @@ export const trackOfferGTM = (
         number_of_people: offerData.person.householdSize,
         insurance_price: parseFloat(offerData.cost.monthlyNet.amount),
         currency: offerData.cost.monthlyNet.currency,
-        member_id: offerData.memberId,
+        ...(offerData.memberId && { member_id: offerData.memberId }),
       },
     })
   } catch (e) {

--- a/src/client/utils/tracking/tracking.ts
+++ b/src/client/utils/tracking/tracking.ts
@@ -169,7 +169,7 @@ export const useTrack = ({ offerData, signState }: TrackProps) => {
 
     trackOfferGTM(
       'signed_customer',
-      offerData,
+      memberId ? { ...offerData, memberId: memberId } : offerData,
       redeemedCampaigns[0]?.incentive?.__typename === 'MonthlyCostDeduction',
     )
 

--- a/src/client/utils/tracking/tracking.ts
+++ b/src/client/utils/tracking/tracking.ts
@@ -169,10 +169,9 @@ export const useTrack = ({ offerData, signState }: TrackProps) => {
 
     trackOfferGTM(
       'signed_customer',
-      memberId ? { ...offerData, memberId: memberId } : offerData,
+      { ...offerData, memberId: memberId || '' },
       redeemedCampaigns[0]?.incentive?.__typename === 'MonthlyCostDeduction',
     )
-
     if (
       redeemedCampaigns?.length > 0 &&
       ['studentkortet', 'stuk2'].includes(


### PR DESCRIPTION
… according to the spec)

  The memberId should only be sent when its signed_customer and memberId is defined.
  One suggestion is to send "MEMBER_ID_UNDEFINED" as member_id if the member_id is undefined
  when the event is signed_customer and not hide it.