### PR TITLE
DK Embark flow

### DIFF
--- a/src/client/pages/Landing/Landing.tsx
+++ b/src/client/pages/Landing/Landing.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import React from 'react'
 import Helmet from 'react-helmet-async'
+import { Redirect } from 'react-router'
 import { LinkButton } from 'components/buttons'
 import { TopBar, TopBarFiller } from 'components/TopBar'
 import {
@@ -194,6 +195,11 @@ export const Landing: React.FC<{ language: string }> = ({ language }) => {
   const market = useMarket()
   const currentLocale = useCurrentLocale()
   const variation = useVariation()
+
+  if (currentLocale === 'dk' || currentLocale === 'dk-en') {
+    return <Redirect to={`/${currentLocale}/new-member/contents`} />
+  }
+
   return (
     <Page>
       <Global

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -148,12 +148,12 @@ export const reactPageRoutes: ReactPageRoute[] = [
           case 'dk':
             return {
               baseUrl: '/dk/new-member/contents',
-              name: 'Web Onboarding DK - Danish Contents',
+              name: 'Web Onboarding DK - Contents',
             }
           case 'dk-en':
             return {
               baseUrl: '/dk-en/new-member/contents',
-              name: 'Web Onboarding DK - Danish Contents',
+              name: 'Web Onboarding DK - Contents',
             }
           case 'no':
             switch (match.params.name) {


### PR DESCRIPTION
- Redirect from `/(dk|dk-en)/new-member` directly into the `contents` flow
- Fetch correct story from embark

We'll also need to update the giraffe schema to include an option to pass the `locale` so we can fetch either DK or EN, but let's do that in giraffe first and then here. Will do in a separate PR.