### PR TITLE
Clean up environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,5 @@ CONTENT_SERVICE_ENDPOINT=<giraffe host only (but including protocol)>
 # Required to use Adyen in Norway
 ADYEN_ORIGIN_KEY=pub.v2.something-kinda-secret
 ADYEN_ENVIRONMENT=<test|live>
+
+APP_ENVIRONMENT=<development|staging|production>

--- a/app.json
+++ b/app.json
@@ -14,24 +14,6 @@
     },
     "GIRAFFE_WS_ENDPOINT": {
       "required": true
-    },
-    "FIREBASE_LINK_DOMAIN": {
-      "required": true
-    },
-    "ANDROID_PACKAGE_NAME": {
-      "required": true
-    },
-    "ANDROID_MINIMUM_VERSION": {
-      "required": true
-    },
-    "APPLE_BUNDLE_ID": {
-      "required": true
-    },
-    "APP_STORE_ID": {
-      "required": true
-    },
-    "IOS_MINIMUM_VERSION": {
-      "required": true
     }
   },
   "addons": [],

--- a/app.json
+++ b/app.json
@@ -14,6 +14,14 @@
     },
     "GIRAFFE_WS_ENDPOINT": {
       "required": true
+    },
+    "APP_ENVIRONMENT": "development",
+    "CONTENT_SERVICE_ENDPOINT": {
+      "required": true
+    },
+    "ADYEN_ENVIRONMENT": "test",
+    "ADYEN_ORIGIN_KEY": {
+      "required": true
     }
   },
   "addons": [],

--- a/src/client/apolloClient.ts
+++ b/src/client/apolloClient.ts
@@ -21,7 +21,7 @@ export const apolloClient = (() => {
     throw new Error("typeof WebSocket is undefined, can't connect to remote")
   }
   const subscriptionClient = new SubscriptionClient(
-    (window as any).GIRAFFE_WS_ENDPOINT,
+    window.hedvigClientConfig.giraffeWsEndpoint,
     {
       reconnect: true,
       connectionParams: () => ({

--- a/src/client/pages/ConnectPayment/components/AdyenCheckout.tsx
+++ b/src/client/pages/ConnectPayment/components/AdyenCheckout.tsx
@@ -207,8 +207,8 @@ const createAdyenCheckout = ({
 
   const configuration = {
     locale,
-    environment: (window as any).ADYEN_ENVIRONMENT,
-    originKey: (window as any).ADYEN_ORIGIN_KEY,
+    environment: window.hedvigClientConfig.adyenEnvironment,
+    originKey: window.hedvigClientConfig.adyenOriginKey,
     paymentMethodsResponse: JSON.parse(paymentMethodsResponse),
     paymentMethodsConfiguration: {
       card: {

--- a/src/client/pages/Debugger/index.tsx
+++ b/src/client/pages/Debugger/index.tsx
@@ -7,6 +7,10 @@ const ActualDebugger = React.lazy(() =>
 )
 
 export const Debugger: React.FC = () => {
+  if (window.hedvigClientConfig.appEnvironment === 'production') {
+    return null
+  }
+
   return (
     <React.Suspense fallback="loading">
       <ActualDebugger />

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -7,7 +7,7 @@ import {
   useEmbark,
 } from '@hedviginsurance/embark'
 import { AnimatePresence, motion } from 'framer-motion'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useHistory } from 'react-router'
 
 import { colorsV3 } from '@hedviginsurance/brand'
@@ -250,6 +250,20 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
       setInitialStore({})
     }
   }, [props.name])
+
+  const isDenmarkInProduction =
+    (currentLocale === 'dk' || currentLocale === 'dk-en') &&
+    window.hedvigClientConfig.appEnvironment === 'production'
+
+  useEffect(() => {
+    if (isDenmarkInProduction) {
+      window.location.pathname = `/${currentLocale}`
+    }
+  }, [isDenmarkInProduction])
+
+  if (isDenmarkInProduction) {
+    return null
+  }
 
   return (
     <EmbarkStyling>

--- a/src/client/pages/OfferNew/Perils/index.tsx
+++ b/src/client/pages/OfferNew/Perils/index.tsx
@@ -37,7 +37,7 @@ export const getIconUrl = (iconPath: string) => {
     return ''
   }
 
-  return `${(window as any).CONTENT_SERVICE_ENDPOINT}${iconPath}`
+  return `${window.hedvigClientConfig.contentServiceEndpoint}${iconPath}`
 }
 
 export const Perils: React.FC<Props> = ({ offerData }) => {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -17,3 +17,5 @@ export const CONTENT_SERVICE_ENDPOINT =
 
 export const ADYEN_ORIGIN_KEY = process.env.ADYEN_ORIGIN_KEY!
 export const ADYEN_ENVIRONMENT = process.env.ADYEN_ENVIRONMENT!
+
+export const APP_ENVIRONMENT = process.env.APP_ENVIRONMENT ?? 'development'

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { min as createMinifiedSegmentSnippet } from '@segment/snippet'
 import escapeHTML from 'escape-html'
 import Router from 'koa-router'
+import { ClientConfig } from 'shared/clientConfig'
 import { sentryConfig } from '../client/utils/sentry-server'
 import { ServerCookieStorage } from '../client/utils/storage/ServerCookieStorage'
 import { ServerSideRoute } from '../routes'
@@ -14,6 +15,7 @@ import {
 import {
   ADYEN_ENVIRONMENT,
   ADYEN_ORIGIN_KEY,
+  APP_ENVIRONMENT,
   CONTENT_SERVICE_ENDPOINT,
   GIRAFFE_ENDPOINT,
   GIRAFFE_WS_ENDPOINT,
@@ -38,6 +40,15 @@ const segmentSnippet = createMinifiedSegmentSnippet({
   page: true,
   load: true,
 })
+
+const clientConfig: ClientConfig = {
+  adyenEnvironment: ADYEN_ENVIRONMENT,
+  adyenOriginKey: ADYEN_ORIGIN_KEY,
+  contentServiceEndpoint: CONTENT_SERVICE_ENDPOINT,
+  giraffeEndpoint: GIRAFFE_ENDPOINT,
+  giraffeWsEndpoint: GIRAFFE_WS_ENDPOINT,
+  appEnvironment: APP_ENVIRONMENT,
+}
 
 const template = (
   route: ServerSideRoute,
@@ -99,13 +110,10 @@ const template = (
     <div id="react-root"></div>
 
     <script>
-      window.GIRAFFE_WS_ENDPOINT = ${JSON.stringify(GIRAFFE_WS_ENDPOINT)};
-      window.GIRAFFE_ENDPOINT = ${JSON.stringify(GIRAFFE_ENDPOINT)};
-      window.CONTENT_SERVICE_ENDPOINT = ${JSON.stringify(
-        CONTENT_SERVICE_ENDPOINT,
-      )};
-      window.ADYEN_ORIGIN_KEY = ${JSON.stringify(ADYEN_ORIGIN_KEY)};
-      window.ADYEN_ENVIRONMENT = ${JSON.stringify(ADYEN_ENVIRONMENT)};
+      Object.defineProperty(window, 'hedvigClientConfig', {
+        value: Object.freeze(${JSON.stringify(clientConfig)}),
+        writable: false,
+      })
     </script>
     <script src="${scriptLocation}"></script>
   </body>

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -47,7 +47,7 @@ const clientConfig: ClientConfig = {
   contentServiceEndpoint: CONTENT_SERVICE_ENDPOINT,
   giraffeEndpoint: GIRAFFE_ENDPOINT,
   giraffeWsEndpoint: GIRAFFE_WS_ENDPOINT,
-  appEnvironment: APP_ENVIRONMENT,
+  appEnvironment: APP_ENVIRONMENT as ClientConfig['appEnvironment'],
 }
 
 const template = (

--- a/src/shared/clientConfig.ts
+++ b/src/shared/clientConfig.ts
@@ -1,0 +1,14 @@
+export interface ClientConfig {
+  adyenEnvironment: string
+  adyenOriginKey: string
+  contentServiceEndpoint: string
+  giraffeEndpoint: string
+  giraffeWsEndpoint: string
+  appEnvironment: 'development' | 'staging' | 'production'
+}
+
+declare global {
+  interface Window {
+    hedvigClientConfig: ClientConfig
+  }
+}

--- a/webpack/webpack.config.server.js
+++ b/webpack/webpack.config.server.js
@@ -1,5 +1,5 @@
-const webpack = require('webpack')
 const path = require('path')
+const webpack = require('webpack')
 const { StatsWriterPlugin } = require('webpack-stats-plugin')
 const webpackConfig = require('./webpack.config.base')
 
@@ -21,12 +21,6 @@ const whiteListedEnvVars = [
   'SENTRY_ENVIRONMENT',
   'HEROKU_SLUG_COMMIT',
   'HEROKU_DYNO_ID',
-  'FIREBASE_LINK_DOMAIN',
-  'ANDROID_PACKAGE_NAME',
-  'ANDROID_MINIMUM_VERSION',
-  'APPLE_BUNDLE_ID',
-  'APP_STORE_ID',
-  'IOS_MINIMUM_VERSION',
   'ADYEN_ORIGIN_KEY',
   'ADYEN_ENVIRONMENT',
   'NODE_ENV',


### PR DESCRIPTION
✅ Make passing environment variables from the server to the client more smooth
✅ Add correct deps to `app.json` making it possible to create review apps again
✅ Disable DK flow for production
✅ Disable debugger for production

**🤔 but why not just change `process.env.NODE_ENV`?**

`NODE_ENV` is used during build time and is then substituted to its value in the build, so anywhere in the code `process.env.NODE_ENV` appears will actually say `"production"` once built. Since we use the same bundle for staging and production (and imo that's desirable, so the code we test is the code we deploy) and it's with the current setup not possible to make custom builds for staging and production we need to make that "decision" runtime instead. How we do this is we set environment variables on the server, and then forward them to the browser via the `window` object whenever the browser loads a page (you can see this little dance [here](https://github.com/HedvigInsurance/web-onboarding/pull/415/files#diff-e2488cd41c99b3beafe59ebbf87b9ac81dcbdd1e6f6e363cfd016905eea3e1cfR113-R116)).