### PR TITLE
Fix/hide intercom button in mobile checkout

### DIFF
--- a/src/client/pages/OfferNew/index.tsx
+++ b/src/client/pages/OfferNew/index.tsx
@@ -2,6 +2,7 @@ import { History } from 'history'
 import { SemanticEvents } from 'quepasa'
 import React from 'react'
 import { Redirect, useHistory, useRouteMatch } from 'react-router'
+import { useMediaQuery } from 'react-responsive'
 import { LoadingPage } from 'components/LoadingPage'
 import { TopBar } from 'components/TopBar'
 import {
@@ -61,6 +62,7 @@ export const OfferNew: React.FC = () => {
     '/:locale(se-en|se|no-en|no|dk-en|dk)/new-member/sign',
   )
   const toggleCheckout = createToggleCheckout(history, currentLocale)
+  const isMobile = useMediaQuery({ maxWidth: 640 })
 
   if (quoteIds.length === 0) {
     return <Redirect to={`/${currentLocale}/new-member`} />
@@ -78,7 +80,9 @@ export const OfferNew: React.FC = () => {
 
   const handleCheckoutToggle = (open: boolean) => {
     toggleCheckout(open)
-    Intercom('update', { hide_default_launcher: open })
+    if (isMobile) {
+      Intercom('update', { hide_default_launcher: open })
+    }
   }
 
   const offerData = data?.quoteBundle

--- a/src/client/pages/OfferNew/index.tsx
+++ b/src/client/pages/OfferNew/index.tsx
@@ -76,6 +76,11 @@ export const OfferNew: React.FC = () => {
     return <LoadingPage />
   }
 
+  const handleCheckoutToggle = (open: boolean) => {
+    toggleCheckout(open)
+    Intercom('update', { hide_default_launcher: open })
+  }
+
   const offerData = data?.quoteBundle
     ? getOfferData(data?.quoteBundle as QuoteBundle)
     : null
@@ -112,7 +117,7 @@ export const OfferNew: React.FC = () => {
                   offerData={offerData}
                   refetch={refetch as () => Promise<any>}
                   onCheckoutOpen={() => {
-                    toggleCheckout(true)
+                    handleCheckoutToggle(true)
                     track()
                   }}
                 />
@@ -124,7 +129,9 @@ export const OfferNew: React.FC = () => {
             <Checkout
               offerData={offerData}
               isOpen={checkoutMatch !== null}
-              onClose={() => toggleCheckout(false)}
+              onClose={() => {
+                handleCheckoutToggle(false)
+              }}
               refetch={refetch as () => Promise<any>}
             />
           </>


### PR DESCRIPTION
### [HVG-438]
## What?
Hide Intercom button in mobile checkout (screens under 640px in width)

## Why?
It currently covers part of the sign button and GDPR content

![Kapture 2020-11-19 at 15 48 09](https://user-images.githubusercontent.com/6661511/99682639-bcb31c00-2a7f-11eb-995b-bd3667eb04f9.gif)




[HVG-438]: https://hedvig.atlassian.net/browse/HVG-438