### PR TITLE
Fix remove double import from graphql/data in SwedishDetails

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
         ],
       },
     ],
+    'import/no-duplicates': 'error',
     'react/prop-types': 'off',
     'react/display-name': 'off',
     'react-hooks/rules-of-hooks': 'error',
@@ -61,4 +62,12 @@ module.exports = {
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
   },
+  overrides: [
+    {
+      files: ['src/client/data/graphql.tsx'],
+      rules: {
+        'import/no-duplicates': 'off',
+      },
+    },
+  ],
 }

--- a/src/client/pages/Debugger/components/Offer.tsx
+++ b/src/client/pages/Debugger/components/Offer.tsx
@@ -4,7 +4,7 @@ import { v4 as uuid } from 'uuid'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { CreateQuoteInput, useQuoteLazyQuery } from 'data/graphql'
 import { createQuote } from 'pages/Embark/createQuote'
-import { Button } from 'components/buttons'
+import { Button, LinkButton } from 'components/buttons'
 import { InputField } from 'components/inputs'
 import { StorageContainer, useStorage } from 'utils/StorageContainer'
 import {
@@ -13,7 +13,6 @@ import {
   useMarket,
   Market,
 } from 'components/utils/CurrentLocale'
-import { LinkButton } from '../../../components/buttons'
 import { initialSeApartmentValues, SwedishApartment } from './QuoteFormSweden'
 import {
   initialNoHomeValues,

--- a/src/client/pages/OfferNew/Introduction/Sidebar/DetailsModal/Details/SwedishDetails.tsx
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/DetailsModal/Details/SwedishDetails.tsx
@@ -5,8 +5,11 @@ import {
   InputGroupDeleteButton,
   InputGroupRow,
 } from 'components/inputs'
-import { ExtraBuildingInput, ExtraBuildingType } from 'data/graphql'
-import { EditQuoteInput } from 'data/graphql'
+import {
+  ExtraBuildingInput,
+  ExtraBuildingType,
+  EditQuoteInput,
+} from 'data/graphql'
 import { useTextKeys } from 'utils/textKeys'
 import {
   isSwedishApartmentFieldSchema,


### PR DESCRIPTION

## What?
Fix Removed double import from graphql/data in SwedishDetails

## Why?

Because someone had a quick trigger finger on merge..The linter should have caught this?

