### PR TITLE
Set correct inputmode on ssn field

### DIFF
--- a/src/client/pages/OfferNew/Checkout/UserDetailsForm.tsx
+++ b/src/client/pages/OfferNew/Checkout/UserDetailsForm.tsx
@@ -105,6 +105,8 @@ export const UserDetailsForm: React.FC<Props> = ({
           name="ssn"
           id="ssn"
           type="number"
+          inputMode="numeric"
+          pattern="[0-9]*"
           value={ssn}
           // errors={ssnError ? textKeys.SIGN_SSN_CHECK() : undefined} TODO error handling?
           onChange={(e: React.ChangeEvent<any>) => {


### PR DESCRIPTION
## What?

Change input mode in ssn field to only display numbers in mobile.

`inputmode="numeric"` brings up the numeric keyboard on both Android and iOS. That covers most of our users but to be backwards compatible I added a pattern as well (I've got input from Sam and Oscar on this).


## Why?

Because it's currently not a good solution for mobile users.

### Before
<img src="https://user-images.githubusercontent.com/6661511/100263332-aad4eb80-2f4d-11eb-8293-4ace44361d52.PNG" width="400" />

### After
<img src="https://user-images.githubusercontent.com/6661511/100358863-0e672380-2ff7-11eb-9096-ba899cd1f7ce.PNG" width="400" />
