### PR TITLE
Omit credentials on graphql endpoint from apollo client

### DIFF
--- a/src/client/apolloClient.ts
+++ b/src/client/apolloClient.ts
@@ -56,7 +56,7 @@ export const apolloClient = (() => {
     }
   })
   const httpLink = new HttpLink({
-    credentials: 'include',
+    credentials: 'omit',
     uri: window.hedvigClientConfig.giraffeEndpoint,
     headers: {
       authorization: authorizationToken,


### PR DESCRIPTION
<!-- 
If there is one, add the ID of the Jira issue to the Pull Request title.
E.g. "[HVG-123] Make the Pull Request template great again" 
-->

## What?

<!-- What changes are made? If there are many significant changes, a list might be a good format. -->
Don't include  the `basic` authorization and cookie headers, as we set the `authorization` hedar directly from the client

## Why?

<!-- Why are these changes made? -->
The browsers behave a bit differently apparently, but ios safari for example overrides the `authorization` header with the `basic` credentials, whereas chrome and firefox override the `basic` credentials with the manually set `authorization` header.

<!-- If there is one, add a link to the Jira ticket below. -->
<strike>_Referenced ticket [here]()_</strike>


<!-- And, if that makes sense, add screenshots and/or GIF's below -->


[HVG-123]: https://hedvig.atlassian.net/browse/HVG-123