### PR TITLE
Hvg 101 edit bundle quotes norway

### DIFF
--- a/src/client/pages/OfferNew/Introduction/Sidebar/index.tsx
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/index.tsx
@@ -233,11 +233,9 @@ export const Sidebar = React.forwardRef<HTMLDivElement, Props>(
                     monthlyGross={offerData.cost.monthlyGross}
                     monthlyNet={offerData.cost.monthlyNet}
                   />
-                  {market !== Market.No && (
-                    <TextButton onClick={() => setDetailsModalIsOpen(true)}>
-                      {textKeys.SIDEBAR_SHOW_DETAILS_BUTTON()}
-                    </TextButton>
-                  )}
+                  <TextButton onClick={() => setDetailsModalIsOpen(true)}>
+                    {textKeys.SIDEBAR_SHOW_DETAILS_BUTTON()}
+                  </TextButton>
                 </Header>
                 <Body>
                   <BodyTitle>
@@ -300,14 +298,12 @@ export const Sidebar = React.forwardRef<HTMLDivElement, Props>(
                   refetch={() => refetchAll()}
                 />
               </Container>
-              {market !== Market.No && (
-                <DetailsModal
-                  offerQuote={offerData.quotes[0]}
-                  refetch={refetchAll}
-                  isVisible={detailsModalIsOpen}
-                  onClose={() => setDetailsModalIsOpen(false)}
-                />
-              )}
+              <DetailsModal
+                offerData={offerData}
+                refetch={refetchAll}
+                isVisible={detailsModalIsOpen}
+                onClose={() => setDetailsModalIsOpen(false)}
+              />
             </Wrapper>
           )}
         </ReactVisibilitySensor>


### PR DESCRIPTION
[HVG-100] Modal for editing the bundle quotes for Norway

## What?

#### Summary
Added functionality to edit bundle quote in Details Modal.
* Change Prop in DetailsModal from offerQuote to offerData because we don't want a single but potentially multiple quotes.
* Added util functions to handle bundle quotes.
* Enabled details button and details modal in Norway
#### Details
* Get the main quote from offerData which is  NorwegianHomeContent| DanishHomeContent for quotes bundles, 
they control the underwriterHitLimit. 
* We need to make sure that the editQuote mutation for the main quote gets through without error and no underwriterHitLimit to do the rest of the quotes in the bundle.
* If the first mutation succeed, we can carry on doing the rest of the mutations.
* We also check that there are no errors or underwriterhitLimits in the subsequent editQuite mutations. (I found a backend bug this way)

(Sidenote think it will never get to the errors since we wrap everything in a try catch. But It was there before so I did not want to change that, without input. The underwriterhitLimits can occur since it is "successful" response and not an error )

#### OBS
(If there is an error in the subsequent calls it will potentially cause a missmatch of data points, however we decided to go about it this way and see if those errors occur in sentry)




## Why?
These changes were made to be able to edit quotes in norway and denmark in the future since they can have quote bundles.
The quotes in quote bundles share some attributes and they need to be updated in all quotes when a change is made.
This is not solved in the backend so we need to solve it here with multiple editQuote mutations.


<!-- Why are these changes made? -->

_Referenced ticket [https://hedvig.atlassian.net/browse/HVG-101]()_


<!-- And, if that makes sense, add screenshots and/or GIF's below -->



[HVG-100]: https://hedvig.atlassian.net/browse/HVG-100