### PR TITLE
Added try catch to catch the iframe access origin error for trustly.

### DIFF
--- a/src/client/pages/ConnectPayment/components/TrustlyModal.tsx
+++ b/src/client/pages/ConnectPayment/components/TrustlyModal.tsx
@@ -94,11 +94,16 @@ export const TrustlyModal: React.FC<Props> = ({
           ref={iframeRef}
           onLoad={async () => {
             const contentWindow = iframeRef.current?.contentWindow
-            await actualHandleIframeLoad(
-              setIsOpen,
-              setIsSuccess,
-              generateTrustlyUrl,
-            )(contentWindow)
+
+            try {
+              await actualHandleIframeLoad(
+                setIsOpen,
+                setIsSuccess,
+                generateTrustlyUrl,
+              )(contentWindow)
+            } catch (e) {
+              console.error(e.message)
+            }
           }}
         />
       )}


### PR DESCRIPTION
Fix "Blocked a frame with origin  from accessing a cross-origin frame" for trustly,
showing up in Sentry

## What?
Bugbash Fix To stop showing "Blocked a frame with origin  from accessing a cross-origin frame" in Sentry
and instead catch it in the frontend.

Added try catch to wrap **actualHandleIframeLoad** 

## Why?
These changes were mad because the iframe shows up, and should not bloat the Sentry issue logs.

![CatchError](https://user-images.githubusercontent.com/19462389/100621848-75027f00-3320-11eb-9d3d-06556e279d46.gif)
