### PR TITLE
Fix / make Sign button visible in all browsers

### DIFF
--- a/src/client/pages/OfferNew/Checkout/Sign.tsx
+++ b/src/client/pages/OfferNew/Checkout/Sign.tsx
@@ -20,7 +20,7 @@ const Wrapper = styled('div')<WrapperProps>`
   box-shadow: 0 -1px 4px ${colorsV3.gray500};
   width: 100%;
   padding: 1rem;
-  position: fixed;
+  position: sticky;
   bottom: 0;
   @media screen and (min-width: ${DESKTOP_BREAKPOINT}px) {
     padding: 1.5rem 2rem;

--- a/src/client/pages/OfferNew/Checkout/Sign.tsx
+++ b/src/client/pages/OfferNew/Checkout/Sign.tsx
@@ -20,7 +20,7 @@ const Wrapper = styled('div')<WrapperProps>`
   box-shadow: 0 -1px 4px ${colorsV3.gray500};
   width: 100%;
   padding: 1rem;
-  position: sticky;
+  position: fixed;
   bottom: 0;
   @media screen and (min-width: ${DESKTOP_BREAKPOINT}px) {
     padding: 1.5rem 2rem;

--- a/src/client/pages/OfferNew/Checkout/index.tsx
+++ b/src/client/pages/OfferNew/Checkout/index.tsx
@@ -83,10 +83,6 @@ const ScrollWrapper = styled('div')<ScrollWrapperProps>`
   overflow-y: scroll;
 `
 
-const SignComponentSpacing = styled('div')`
-  height: 112px;
-`
-
 const InnerWrapper = styled('div')`
   display: flex;
   flex-direction: column;
@@ -322,22 +318,21 @@ export const Checkout: React.FC<Props> = ({
 
             <SignDisclaimer offerData={offerData} />
           </InnerWrapper>
-          <SignComponentSpacing />
+          <Sign
+            canInitiateSign={
+              canInitiateSign && !ssnUpdateLoading && !emailUpdateLoading
+            }
+            signUiState={signUiState}
+            signStatus={signStatus}
+            isLoading={
+              signQuotesMutation.loading ||
+              signUiState === SignUiState.STARTED ||
+              signUiState === SignUiState.STARTED_WITH_REDIRECT ||
+              emailUpdateLoading
+            }
+            onSignStart={startSign}
+          />
         </ScrollWrapper>
-        <Sign
-          canInitiateSign={
-            canInitiateSign && !ssnUpdateLoading && !emailUpdateLoading
-          }
-          signUiState={signUiState}
-          signStatus={signStatus}
-          isLoading={
-            signQuotesMutation.loading ||
-            signUiState === SignUiState.STARTED ||
-            signUiState === SignUiState.STARTED_WITH_REDIRECT ||
-            emailUpdateLoading
-          }
-          onSignStart={startSign}
-        />
       </OuterWrapper>
 
       <Backdrop visibilityState={visibilityState} onClick={onClose} />


### PR DESCRIPTION
<!-- 
If there is one, add the ID of the Jira issue to the Pull Request title.
E.g. "[HVG-123] Make the Pull Request template great again" 
-->

## What?

<!-- What changes are made? If there are many significant changes, a list might be a good format. -->

Make the `Sign` component visible in _all_ browsers by moving it (back) into the `<ScrollWrapper>` in `/Checkout/index.tsx`. This might not look _perfect_  in Safari on iOS if you scroll very enthusiastically but it's still the best solution if we're not going to completely remake the way we disable scrolling of the background when the checkout sidebar is open.

## Why?

<!-- Why are these changes made? -->

Apparently the `Sign` component wasn't positioned correctly in Firefox after the very last changes made to these components last week, which resulted in the CTA button actually being completely hidden. Very sad. 🤕 


<!-- If there is one, add a link to the Jira ticket below. -->
~~_Referenced ticket [here]()_~~


<!-- And, if that makes sense, add screenshots and/or GIF's below -->

## Screenshots

### Firefox
<img width="1708" alt="2020-11-30-sign-firefox" src="https://user-images.githubusercontent.com/42962286/100637920-b6505a00-3333-11eb-866b-a3ce4abc519f.png">

### Chrome
<img width="1568" alt="2020-11-30-sign-chrome" src="https://user-images.githubusercontent.com/42962286/100638033-d718af80-3333-11eb-8d08-cb3b39428f16.png">

### Safari
<img width="1436" alt="2020-11-30-sign-safari-mac" src="https://user-images.githubusercontent.com/42962286/100638115-ed267000-3333-11eb-907a-4d0178b9b2ad.png">

### Safari iOS
<img width="1225" alt="2020-11-30-sign-safari-ios" src="https://user-images.githubusercontent.com/42962286/100638131-f44d7e00-3333-11eb-97b5-4dcbec933375.png">



[HVG-123]: https://hedvig.atlassian.net/browse/HVG-123