### PR TITLE
Update ssn input type and ad maxlength

### DIFF
--- a/src/client/pages/OfferNew/Checkout/UserDetailsForm.tsx
+++ b/src/client/pages/OfferNew/Checkout/UserDetailsForm.tsx
@@ -4,7 +4,7 @@ import * as yup from 'yup'
 import { RawInputField } from 'components/inputs'
 import { Market, useMarket } from 'components/utils/CurrentLocale'
 import { WithEmailForm, WithSsnForm } from 'pages/OfferNew/types'
-import { createSsnValidator } from 'pages/OfferNew/utils'
+import { createSsnValidator, ssnLengthByMarket } from 'pages/OfferNew/utils'
 import { useTextKeys } from 'utils/textKeys'
 
 const BottomSpacedRawInputField = styled(RawInputField)`
@@ -41,6 +41,7 @@ export const UserDetailsForm: React.FC<Props> = ({
 
   // FIXME should we pick which ssn validation to use in a different way? or not really?
   const market = useMarket()
+  const ssnMaxLength = ssnLengthByMarket[market]
   const isValidSsn = createSsnValidator(market!)
 
   const handleSsnChange = (event: React.FormEvent<HTMLInputElement>) => {
@@ -111,6 +112,7 @@ export const UserDetailsForm: React.FC<Props> = ({
           type="text"
           inputMode="numeric"
           pattern="[0-9]*"
+          maxLength={ssnMaxLength}
           value={ssn}
           // errors={ssnError ? textKeys.SIGN_SSN_CHECK() : undefined} TODO error handling?
           onChange={handleSsnChange}

--- a/src/client/pages/OfferNew/Checkout/UserDetailsForm.tsx
+++ b/src/client/pages/OfferNew/Checkout/UserDetailsForm.tsx
@@ -43,7 +43,11 @@ export const UserDetailsForm: React.FC<Props> = ({
   const market = useMarket()
   const isValidSsn = createSsnValidator(market!)
 
-  const setSsn = (newSsn: string) => {
+  const handleSsnChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const { value } = event.currentTarget
+    const nonNumbersRegex = /\D/
+    const newSsn = value.replace(nonNumbersRegex, '')
+
     if (ssnChangeTimout) {
       window.clearTimeout(ssnChangeTimout)
       setSsnChangeTimout(null)
@@ -104,14 +108,12 @@ export const UserDetailsForm: React.FC<Props> = ({
           placeholder={textKeys.CHECKOUT_SSN_PLACEHOLDER()}
           name="ssn"
           id="ssn"
-          type="number"
+          type="text"
           inputMode="numeric"
           pattern="[0-9]*"
           value={ssn}
           // errors={ssnError ? textKeys.SIGN_SSN_CHECK() : undefined} TODO error handling?
-          onChange={(e: React.ChangeEvent<any>) => {
-            setSsn(e.target.value)
-          }}
+          onChange={handleSsnChange}
           onBlur={() => {
             if (!isValidSsn(ssn) || ssn === initialSsn) {
               return

--- a/src/client/pages/OfferNew/utils.ts
+++ b/src/client/pages/OfferNew/utils.ts
@@ -234,6 +234,12 @@ export const maskAndFormatRawSsn = (ssn: string) => {
   return ssn.substr(CENTURY_LENGTH, DATE_LENGTH) + '-****'
 }
 
+export const ssnLengthByMarket: Record<Market, number> = {
+  SE: 12,
+  NO: 11,
+  DK: 10,
+}
+
 export const createSsnValidator = (market: Market) => (
   ssn: string,
 ): boolean => {


### PR DESCRIPTION
## What?

Change input type to `type=text` and set maxlength on input based on ssn length for the specific market


## Why?
Input `type=number` is not optimal to use for ssn since it will increment on scroll or arrow clicks and can't have a max length. So in order to only input numbers we filter out all non-digit characters
