### PR TITLE
Put back price comparison for switcher

### DIFF
--- a/src/client/pages/OfferNew/Introduction/ExternalInsuranceProvider/Compare.tsx
+++ b/src/client/pages/OfferNew/Introduction/ExternalInsuranceProvider/Compare.tsx
@@ -3,11 +3,8 @@ import { colorsV3 } from '@hedviginsurance/brand'
 import { externalInsuranceProviders } from '@hedviginsurance/embark'
 import React from 'react'
 import { HedvigLogo } from 'components/icons/HedvigLogo'
-import { useTextKeys } from 'utils/textKeys'
 import { InsuranceCost, InsuranceDataCollection } from 'data/graphql'
 import { Price } from '../../components'
-
-import { hedvigCompany, otherCompanies } from '../../Compare/mock'
 
 const Wrapper = styled.div`
   display: flex;
@@ -49,20 +46,10 @@ const CompareBoxTitle = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.25rem;
 `
 
 const Spacer = styled.div`
   width: 1.25rem;
-`
-
-const TrustpilotScoreWrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
-`
-
-const TrustpilotScoreName = styled.span`
-  color: ${colorsV3.gray500};
 `
 
 interface Props {
@@ -71,15 +58,11 @@ interface Props {
 }
 
 export const Compare: React.FC<Props> = ({ insuranceDataCollection, cost }) => {
-  const textKeys = useTextKeys()
   const externalInsuranceProvider = externalInsuranceProviders.find(
     (provider: { externalCollectionId?: string }) =>
       provider.externalCollectionId ===
       insuranceDataCollection.insuranceProvider?.toUpperCase(),
   )
-  const externalTrustpilotScore = otherCompanies.find(
-    (company) => externalInsuranceProvider?.id === company.id,
-  )?.trustpilotScore
 
   return (
     <Wrapper>
@@ -93,16 +76,6 @@ export const Compare: React.FC<Props> = ({ insuranceDataCollection, cost }) => {
             monthlyNet={cost.monthlyNet}
           />
         </CompareBoxTitle>
-        <TrustpilotScoreWrapper>
-          <TrustpilotScoreName>
-            {textKeys.EXTERNAL_PROVIDER_TRUSTPILOT_SCORE()}
-          </TrustpilotScoreName>
-          <span>
-            {textKeys.EXTERNAL_PROVIDER_TRUSTPILOT_SCORE_VALUE({
-              value: hedvigCompany.trustpilotScore,
-            })}
-          </span>
-        </TrustpilotScoreWrapper>
       </CompareBox>
       <Spacer />
       <CompareBox isExternalProvider>
@@ -124,16 +97,6 @@ export const Compare: React.FC<Props> = ({ insuranceDataCollection, cost }) => {
             }
           />
         </CompareBoxTitle>
-        <TrustpilotScoreWrapper>
-          <TrustpilotScoreName>
-            {textKeys.EXTERNAL_PROVIDER_TRUSTPILOT_SCORE()}
-          </TrustpilotScoreName>
-          <span>
-            {textKeys.EXTERNAL_PROVIDER_TRUSTPILOT_SCORE_VALUE({
-              value: externalTrustpilotScore,
-            })}
-          </span>
-        </TrustpilotScoreWrapper>
       </CompareBox>
     </Wrapper>
   )

--- a/src/client/pages/OfferNew/Introduction/ExternalInsuranceProvider/Compare.tsx
+++ b/src/client/pages/OfferNew/Introduction/ExternalInsuranceProvider/Compare.tsx
@@ -49,6 +49,7 @@ const CompareBoxTitle = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  margin-bottom: 0.25rem;
 `
 
 const Spacer = styled.div`

--- a/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
+++ b/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
@@ -16,11 +16,11 @@ type QuoteWithStreet = {
 }
 
 const Container = styled.div`
-  padding: 2rem 0;
+  padding: 2rem 0 1rem;
   color: ${colorsV3.white};
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
-    padding: 0;
+    padding-top: 0;
   }
 `
 

--- a/src/client/pages/OfferNew/Introduction/index.tsx
+++ b/src/client/pages/OfferNew/Introduction/index.tsx
@@ -23,16 +23,20 @@ const HERO_HEIGHT = '400px'
 
 const Hero = styled.div`
   width: 100%;
-  height: ${HERO_HEIGHT};
   display: flex;
   flex-direction: column;
   align-items: center;
+  background-color: ${colorsV3.gray100};
+
+  ${LARGE_SCREEN_MEDIA_QUERY} {
+    height: ${HERO_HEIGHT};
+  }
 `
 
 const HeroImageWrapper = styled.div`
   width: 100vw;
   height: ${HERO_HEIGHT};
-  background: ${colorsV3.gray900};
+  background-color: ${colorsV3.gray900};
   overflow: hidden;
   position: absolute;
 `
@@ -53,7 +57,7 @@ const HeroImage = styled.img<HeroImageProps>`
 const HeroContentWrapper = styled.div`
   width: 100%;
   max-width: 80rem;
-  position: absolute;
+  position: relative;
   padding-top: 3rem;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {

--- a/src/client/pages/OfferNew/Introduction/index.tsx
+++ b/src/client/pages/OfferNew/Introduction/index.tsx
@@ -4,8 +4,10 @@ import { colorsV3 } from '@hedviginsurance/brand'
 import { Section } from 'pages/OfferNew/components'
 import { OfferData } from 'pages/OfferNew/types'
 import { LARGE_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
+import { isBundle } from '../utils'
 import { HeroOfferDetails } from './HeroOfferDetails'
 import { Sidebar } from './Sidebar'
+import { ExternalInsuranceProvider } from './ExternalInsuranceProvider'
 
 type Props = {
   offerData: OfferData
@@ -59,6 +61,10 @@ const HeroContentWrapper = styled.div`
   }
 `
 
+const HeroOfferDetailsContainer = styled.div`
+  width: 100%;
+`
+
 const ContentContainer = styled.div`
   width: 100%;
   padding: 0 1rem;
@@ -80,6 +86,9 @@ export const Introduction: React.FC<Props> = ({
 }) => {
   const [hasHeroImageLoaded, setHasHeroImageLoaded] = useState(false)
 
+  const hasDataCollection =
+    !isBundle(offerData) && !!offerData.quotes[0].dataCollectionId
+
   return (
     <Section>
       <Hero>
@@ -97,7 +106,15 @@ export const Introduction: React.FC<Props> = ({
         </HeroImageWrapper>
         <HeroContentWrapper>
           <ContentContainer>
-            <HeroOfferDetails offerData={offerData} />
+            <HeroOfferDetailsContainer>
+              <HeroOfferDetails offerData={offerData} />
+              {hasDataCollection && (
+                <ExternalInsuranceProvider
+                  dataCollectionId={offerData.quotes[0].dataCollectionId || ''}
+                  offerData={offerData}
+                />
+              )}
+            </HeroOfferDetailsContainer>
             <Sidebar
               offerData={offerData}
               refetchOfferData={refetch}

--- a/src/client/pages/OfferNew/Perils/index.tsx
+++ b/src/client/pages/OfferNew/Perils/index.tsx
@@ -20,7 +20,7 @@ interface Props {
 }
 
 const Wrapper = styled.div`
-  padding: 16rem 0 5rem 0;
+  padding: 3rem 0 5rem;
   background-color: ${colorsV3.gray100};
   display: flex;
 


### PR DESCRIPTION
## What?

Add price comparison for switchers


## Why?

Intermediate fix until we have de new design in place for price comparison. Not the most beautiful thing but it should do the trick over the weekend 😄

Commit for reference: https://github.com/HedvigInsurance/web-onboarding/pull/460/commits/ff4d1d852c7db7297446cadf74a1ffbc8f4ed151
Unlike the previous implementation, we don't need to shift content in mobile and desktop.

Will need someone to verify this that can compare insurances, setting up a review app. I mocked the data locally

<img width="1246" alt="Screenshot 2021-01-15 at 15 22 49" src="https://user-images.githubusercontent.com/6661511/104739999-b40d5800-5747-11eb-859e-2b8ada5e1eff.png">

<img width="431" alt="Screenshot 2021-01-15 at 15 26 06" src="https://user-images.githubusercontent.com/6661511/104740012-b66fb200-5747-11eb-87ab-2495b45635f8.png">

<img width="423" alt="Screenshot 2021-01-15 at 15 27 33" src="https://user-images.githubusercontent.com/6661511/104740020-b8d20c00-5747-11eb-9c46-c57da8b878f8.png">

<img width="1238" alt="Screenshot 2021-01-15 at 15 27 45" src="https://user-images.githubusercontent.com/6661511/104740022-b96aa280-5747-11eb-9aa2-e0c8ee5a359d.png">



