### PR TITLE
Intercom add to connect payment and fix linter warnings

### DIFF
--- a/src/client/utils/Intercom.tsx
+++ b/src/client/utils/Intercom.tsx
@@ -23,7 +23,8 @@ const createIntercom = () => {
 export const Intercom: React.FC = () => {
   const variation = useVariation()
   const isIntercomMatch = useRouteMatch(
-    LOCALE_PATH_PATTERN + '/new-member/:place(offer|sign|download)',
+    LOCALE_PATH_PATTERN +
+      '/new-member/:place(offer|sign|download|connect-payment)',
   )
   const isDirectConnectPaymentIntercomMatch = useRouteMatch(
     LOCALE_PATH_PATTERN + '/new-member/connect-payment/direct',
@@ -46,7 +47,7 @@ export const Intercom: React.FC = () => {
     } else if (!isDefinitelyIntercomMatch && hasIntercomInstalled) {
       ;(window as any).Intercom('shutdown')
     }
-  }, [isIntercomMatch?.path, isDirectConnectPaymentIntercomMatch?.path])
+  }, [variation, isIntercomMatch, isDirectConnectPaymentIntercomMatch])
 
   return null
 }


### PR DESCRIPTION
[HVG-765] Connect Payment>Add Intercom 


## What?
Adding intercom to the connect-screen


## Why?
Its useful for the user be able to contact IEX From connect payment view if for instance they have questions 
or something went wrong

_Referenced ticket [https://hedvig.atlassian.net/browse/HVG-765]()_

