### PR TITLE
Fixed height by adding height: 100%  property

### DIFF
--- a/src/client/pages/ConnectPayment/sections/ConnectPayment.tsx
+++ b/src/client/pages/ConnectPayment/sections/ConnectPayment.tsx
@@ -54,7 +54,6 @@ const ImageColumn = styled.div`
   display: flex;
   justify-content: center;
   margin-top: 0.5rem;
-
   ${MEDIUM_SCREEN_MEDIA_QUERY} {
     justify-content: flex-start;
     width: 40%;
@@ -113,8 +112,8 @@ const InstructionWrapper = styled(ConnectText)`
 const ConnectPaymentImage = styled.img`
   display: block;
   width: 40%;
+  height: 100%;
   margin-bottom: 2rem;
-
   ${MEDIUM_SCREEN_MEDIA_QUERY} {
     width: 80%;
   }


### PR DESCRIPTION
Fix Image looking strange on Iphone simulator

**Please test staging with you iphone if this problem exists!**

## What?
Added height property

## Why?


**Without height:**
![image](https://user-images.githubusercontent.com/19462389/105177661-45edda00-5b27-11eb-8867-20579a5d2374.png)


**With:** 

![image](https://user-images.githubusercontent.com/19462389/105177564-22c32a80-5b27-11eb-8607-b8f6330b5316.png)
