### PR TITLE
[HVG-908] Add script to format generated code after its creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "test": "NODE_ENV=test jest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
-    "codegen": "graphql-codegen --config codegen.yml",
-    "codegen-formatted": "yarn codegen && yarn prettier --write src/client/data/graphql.tsx",
+    "codegen": "graphql-codegen --config codegen.yml && yarn prettier --write src/client/data/graphql.tsx",
     "storybook": "start-storybook -p 6008",
     "build-storybook": "build-storybook",
     "download-translations": "./bin/download-translations.sh"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "NODE_ENV=test jest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
-    "gen": "graphql-codegen --config codegen.yml",
+    "codegen": "graphql-codegen --config codegen.yml",
+    "codegen-formatted": "yarn codegen && yarn prettier --write src/client/data/graphql.tsx",
     "storybook": "start-storybook -p 6008",
     "build-storybook": "build-storybook",
     "download-translations": "./bin/download-translations.sh"


### PR DESCRIPTION

## What?

1. Change name of `gen` script to `codegen` since I think `gen` is a bit too generic (no pun intended 🙈) 
2. Add `codegen-formatted` script which formats the generated file with Prettier once it's been created.


## Why?

Since the format of the file created with the GraphQL Code Generator differs from the format we enforce with Prettier in our code base, it will look as if almost everything changed when you re-generate this file `src/client/data/graphql.tsx`. Which can be very confusing.


## Question

Would we rather like to have the formatting of this file to be run in the `codegen` script instead of having a separate script that does it? 

<!-- If there is one, add a link to the Jira ticket below. -->



<!-- And, if that makes sense, add screenshots and/or GIF's below -->
