### PR TITLE
Fix / ExternalIncuranceData error (for real this time)

### DIFF
--- a/src/client/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
@@ -255,7 +255,7 @@ const DateForm: React.FC<{
       >
         <Value>
           <DateLabel>
-            {!hasStartDate && quote.dataCollectionId && (
+            {!hasStartDate && hasCurrentInsurer(quote) && (
               <StartDateLabelSwitcher
                 dataCollectionId={quote.dataCollectionId}
               />


### PR DESCRIPTION

## What?

<!-- What changes are made? If there are many significant changes, a list might be a good format. -->

Changed condition for rendering `<StartDateLabelSwitcher>` in `StartDate.tsx`:
Instead of checking if `quote` has the `dataCollectionId` property we check if it has `currentInsurer`, since the 'dataCollectionId' is null if we don't have data from Insurely.

## Why?

<!-- Why are these changes made? -->

With the previous, now reverted, implementation the start date label disappeared for switchers where current insurers were not integrated with Insurely. 


<!-- If there is one, add a link to the Jira ticket below. -->
_Referenced ticket [HVG-907]_


<!-- And, if that makes sense, add screenshots and/or GIF's below -->

See [previous PR](https://github.com/HedvigInsurance/web-onboarding/pull/472) for screenshot and screen recording.


[HVG-907]: https://hedvig.atlassian.net/browse/HVG-907