### PR TITLE
Bump embark

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.23",
     "@hedviginsurance/brand": "^4.0.2",
-    "@hedviginsurance/embark": "^2.0.8",
+    "@hedviginsurance/embark": "^2.0.10",
     "@segment/snippet": "^4.4.0",
     "@sentry/node": "^5.27.6",
     "@types/dayzed": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1618,10 +1618,10 @@
   resolved "https://registry.yarnpkg.com/@hedviginsurance/brand/-/brand-4.0.3.tgz#60d222f6e08db65a5403e832d525147ab3cde956"
   integrity sha512-G6NjFFTg7rj4eVNj/QZc7xrupyJ41CTYUPVTzjkt0R7QWD3CqXStWkVKwgR8rRli51swpVY7xhlk7HX1mlJ8WQ==
 
-"@hedviginsurance/embark@^2.0.8":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.0.9.tgz#65b407eec8a8afbd473721d8b654a6555923a0f9"
-  integrity sha512-BbUp0bdIWZzvQAq/VeUGOBstHzJ7JY7imDSxQLhI966Iwe+X6gV2nt5zmJWArcFICZVdqiP3HFyiaPhc+dwxmw==
+"@hedviginsurance/embark@^2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.0.10.tgz#101b69624c8f6f8205ab23643d1d6730daa301f8"
+  integrity sha512-a1NdVinIs6iNu0OrkFByQKlYLq7hU9wBJJBEFQm2ASo02U5CFSpY5qjQhaSn4z6MujM9P88BH191yaQ0fcw9kA==
   dependencies:
     "@emotion/babel-plugin" "^11.0.0-next.12"
     "@emotion/core" "^10.0.21"


### PR DESCRIPTION
## What?

Bump embark package version


## Why?

Haven't been released in about 3 months, see diff in embark here: https://github.com/HedvigInsurance/embark/compare/abbd1127ecf3ae0464552d85cd43a9246d0f45d2...master

This might fix Insurely flow for ICA and others as well as adding computed store values to embark

