### PR TITLE
Add name to ApolloClient

### DIFF
--- a/src/client/apolloClient.ts
+++ b/src/client/apolloClient.ts
@@ -64,6 +64,7 @@ export const apolloClient = (() => {
   })
 
   const client = new ApolloClient({
+    name: 'Web:Onboarding',
     cache: new InMemoryCache({
       possibleTypes,
       typePolicies: {

--- a/src/client/utils/ExchangeTokenRetrieval.test.tsx
+++ b/src/client/utils/ExchangeTokenRetrieval.test.tsx
@@ -142,6 +142,7 @@ const mountWithApolloClient = (mocks: MockedResponse[], token: string) => {
 
   const link = new MockLink(mocks, true)
   const client = new ApolloClient({
+    name: 'Web:Onboarding',
     link,
     cache: new InMemoryCache({
       possibleTypes,


### PR DESCRIPTION
## What?

`Adding name to ApolloClient`


## Why?

So that Giraffe knows which client caused the originating `Query/Mutation/Subscription`.
