### PR TITLE
Remove getPickedLocaleFromCurrentLocale

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -2,10 +2,7 @@ import { Provider } from 'constate'
 import React from 'react'
 import { hot } from 'react-hot-loader'
 import { Route, Switch, useHistory } from 'react-router-dom'
-import {
-  getLocaleIsoCode,
-  useCurrentLocale,
-} from 'components/utils/CurrentLocale'
+import { getIsoLocale, useCurrentLocale } from 'components/utils/CurrentLocale'
 import { TextKeyProvider } from 'utils/textKeys'
 import { reactPageRoutes } from '../routes'
 import { AppTokenRetrieval } from './utils/AppTokenRetrieval'
@@ -25,7 +22,7 @@ export const App: React.ComponentType<StorageState> = ({ session }) => {
     <>
       <GlobalCss />
       <TextKeyProvider
-        locale={getLocaleIsoCode(currentLocale)}
+        locale={getIsoLocale(currentLocale)}
         locationSearch={history.location.search}
       >
         <Provider<WithStorageProps>

--- a/src/client/components/utils/CurrentLocale.tsx
+++ b/src/client/components/utils/CurrentLocale.tsx
@@ -4,7 +4,7 @@ import { matchPath, useLocation } from 'react-router'
 import { Locale } from 'data/graphql'
 import { LOCALE_PATH_PATTERN } from 'shared/locale'
 
-export const getLocaleIsoCode = (locale: string): Locale => {
+export const getIsoLocale = (locale: string): Locale => {
   switch (locale) {
     case 'dk':
       return Locale.DaDk

--- a/src/client/components/utils/CurrentLocale.tsx
+++ b/src/client/components/utils/CurrentLocale.tsx
@@ -66,15 +66,3 @@ export const useMarket = (): Market => {
     ['dk-en', Market.Dk],
   ])(currentLocale)!
 }
-
-export const getPickedLocaleFromCurrentLocale = (
-  currentLocale: string,
-): Locale =>
-  match<string, Locale>([
-    ['sv_SE', Locale.SvSe],
-    ['en_SE', Locale.EnSe],
-    ['nb_NO', Locale.NbNo],
-    ['en_NO', Locale.EnNo],
-    ['da_DK', Locale.DaDk],
-    ['en_DK', Locale.EnDk],
-  ])(getLocaleIsoCode(currentLocale))!

--- a/src/client/containers/SessionContainer.tsx
+++ b/src/client/containers/SessionContainer.tsx
@@ -7,7 +7,7 @@ import { Mount } from 'react-lifecycle-components'
 import { afterTick } from 'pages/Embark/utils'
 import { Locale, UpdatePickedLocaleDocument } from 'data/graphql'
 import {
-  getPickedLocaleFromCurrentLocale,
+  getLocaleIsoCode,
   useCurrentLocale,
 } from 'components/utils/CurrentLocale'
 import { captureSentryError } from 'utils/sentry-client'
@@ -78,7 +78,7 @@ export const setupSession = async (
 export const SessionContainer: React.SFC<SessionContainerProps> = ({
   children,
 }) => {
-  const pickedLocale = getPickedLocaleFromCurrentLocale(useCurrentLocale())
+  const pickedLocale = getLocaleIsoCode(useCurrentLocale())
   const [createSessionCalled, setCreateSessionCalled] = React.useState(false)
   const client = useApolloClient()
 

--- a/src/client/containers/SessionContainer.tsx
+++ b/src/client/containers/SessionContainer.tsx
@@ -6,10 +6,7 @@ import React from 'react'
 import { Mount } from 'react-lifecycle-components'
 import { afterTick } from 'pages/Embark/utils'
 import { Locale, UpdatePickedLocaleDocument } from 'data/graphql'
-import {
-  getLocaleIsoCode,
-  useCurrentLocale,
-} from 'components/utils/CurrentLocale'
+import { getIsoLocale, useCurrentLocale } from 'components/utils/CurrentLocale'
 import { captureSentryError } from 'utils/sentry-client'
 import { Storage, StorageContainer } from 'utils/StorageContainer'
 import {
@@ -78,7 +75,7 @@ export const setupSession = async (
 export const SessionContainer: React.SFC<SessionContainerProps> = ({
   children,
 }) => {
-  const pickedLocale = getLocaleIsoCode(useCurrentLocale())
+  const pickedLocale = getIsoLocale(useCurrentLocale())
   const [createSessionCalled, setCreateSessionCalled] = React.useState(false)
   const client = useApolloClient()
 

--- a/src/client/pages/ConnectPayment/components/AdyenCheckout.tsx
+++ b/src/client/pages/ConnectPayment/components/AdyenCheckout.tsx
@@ -6,10 +6,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useHistory } from 'react-router'
 import { useTextKeys } from 'utils/textKeys'
 import { Spinner } from 'components/utils'
-import {
-  getLocaleIsoCode,
-  useCurrentLocale,
-} from 'components/utils/CurrentLocale'
+import { getIsoLocale, useCurrentLocale } from 'components/utils/CurrentLocale'
 import {
   Scalars,
   SubmitAdditionalPaymentDetialsMutationFn,
@@ -205,7 +202,7 @@ const createAdyenCheckout = ({
     ['en_SE', 'en-US'],
     ['nb_NO', 'no-NO'],
     ['en_NO', 'en-US'],
-  ])(getLocaleIsoCode(currentLocale))
+  ])(getIsoLocale(currentLocale))
 
   const returnUrl = `${window.location.origin}/${currentLocale}/new-member/connect-payment/adyen-callback`
 

--- a/src/client/pages/Debugger/components/Offer.tsx
+++ b/src/client/pages/Debugger/components/Offer.tsx
@@ -14,7 +14,7 @@ import { Button, LinkButton } from 'components/buttons'
 import { InputField } from 'components/inputs'
 import { StorageContainer, useStorage } from 'utils/StorageContainer'
 import {
-  getLocaleIsoCode,
+  getIsoLocale,
   useCurrentLocale,
   useMarket,
   Market,
@@ -133,7 +133,7 @@ export const Offer: React.FC<OfferProps> = ({ sessionToken }) => {
   )
   const storageState = useStorage()
   const currentLocale = useCurrentLocale()
-  const localeIsoCode = getLocaleIsoCode(currentLocale)
+  const localeIsoCode = getIsoLocale(currentLocale)
   const currentMarket = useMarket()
 
   const [quoteType, setQuoteType] = useState(

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -14,10 +14,7 @@ import { colorsV3 } from '@hedviginsurance/brand'
 import gql from 'graphql-tag'
 import Helmet from 'react-helmet-async'
 import { apolloClient } from 'apolloClient'
-import {
-  getLocaleIsoCode,
-  useCurrentLocale,
-} from 'components/utils/CurrentLocale'
+import { getIsoLocale, useCurrentLocale } from 'components/utils/CurrentLocale'
 import { useVariation, Variation } from 'utils/hooks/useVariation'
 import { useTextKeys } from 'utils/textKeys'
 import { StorageContainer } from '../../utils/StorageContainer'
@@ -215,7 +212,7 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
     [key: string]: any
   }>()
   const currentLocale = useCurrentLocale()
-  const localeIsoCode = getLocaleIsoCode(currentLocale)
+  const localeIsoCode = getIsoLocale(currentLocale)
 
   const textKeys = useTextKeys()
 
@@ -329,17 +326,17 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
                     resolvers={{
                       graphqlQuery: graphQLQuery(
                         storageState,
-                        getLocaleIsoCode(currentLocale),
+                        getIsoLocale(currentLocale),
                       ),
                       graphqlMutation: graphQLMutation(
                         storageState,
-                        getLocaleIsoCode(currentLocale),
+                        getIsoLocale(currentLocale),
                       ),
                       personalInformationApi: resolvePersonalInformation,
                       houseInformation: resolveHouseInformation,
                       createQuote: createQuote(
                         storageState,
-                        getLocaleIsoCode(currentLocale),
+                        getIsoLocale(currentLocale),
                       ),
                       externalInsuranceProviderProviderStatus: resolveExternalInsuranceProviderProviderStatus,
                       externalInsuranceProviderStartSession: resolveExternalInsuranceProviderStartSession,

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -15,7 +15,7 @@ import gql from 'graphql-tag'
 import Helmet from 'react-helmet-async'
 import { apolloClient } from 'apolloClient'
 import {
-  getPickedLocaleFromCurrentLocale,
+  getLocaleIsoCode,
   useCurrentLocale,
 } from 'components/utils/CurrentLocale'
 import { useVariation, Variation } from 'utils/hooks/useVariation'
@@ -215,7 +215,7 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
     [key: string]: any
   }>()
   const currentLocale = useCurrentLocale()
-  const localeIsoCode = getPickedLocaleFromCurrentLocale(currentLocale)
+  const localeIsoCode = getLocaleIsoCode(currentLocale)
 
   const textKeys = useTextKeys()
 
@@ -329,17 +329,17 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
                     resolvers={{
                       graphqlQuery: graphQLQuery(
                         storageState,
-                        getPickedLocaleFromCurrentLocale(currentLocale),
+                        getLocaleIsoCode(currentLocale),
                       ),
                       graphqlMutation: graphQLMutation(
                         storageState,
-                        getPickedLocaleFromCurrentLocale(currentLocale),
+                        getLocaleIsoCode(currentLocale),
                       ),
                       personalInformationApi: resolvePersonalInformation,
                       houseInformation: resolveHouseInformation,
                       createQuote: createQuote(
                         storageState,
-                        getPickedLocaleFromCurrentLocale(currentLocale),
+                        getLocaleIsoCode(currentLocale),
                       ),
                       externalInsuranceProviderProviderStatus: resolveExternalInsuranceProviderProviderStatus,
                       externalInsuranceProviderStartSession: resolveExternalInsuranceProviderStartSession,

--- a/src/client/pages/Forever/index.tsx
+++ b/src/client/pages/Forever/index.tsx
@@ -7,7 +7,7 @@ import { RouteComponentProps } from 'react-router'
 import { Route, Switch } from 'react-router-dom'
 import { HedvigLogo } from 'components/icons/HedvigLogo'
 import {
-  getPickedLocaleFromCurrentLocale,
+  getLocaleIsoCode,
   useCurrentLocale,
 } from 'components/utils/CurrentLocale'
 import { Page } from 'components/utils/Page'
@@ -66,7 +66,7 @@ export const Forever: React.FC<ForeverProps> = ({
   const { handleSubmit } = useRedeemCode()
   const [updatePickedLocale] = useUpdatePickedLocaleMutation({
     variables: {
-      pickedLocale: getPickedLocaleFromCurrentLocale(currentLocale),
+      pickedLocale: getLocaleIsoCode(currentLocale),
     },
   })
   const storage = useStorage()

--- a/src/client/pages/Forever/index.tsx
+++ b/src/client/pages/Forever/index.tsx
@@ -6,10 +6,7 @@ import Helmet from 'react-helmet-async'
 import { RouteComponentProps } from 'react-router'
 import { Route, Switch } from 'react-router-dom'
 import { HedvigLogo } from 'components/icons/HedvigLogo'
-import {
-  getLocaleIsoCode,
-  useCurrentLocale,
-} from 'components/utils/CurrentLocale'
+import { getIsoLocale, useCurrentLocale } from 'components/utils/CurrentLocale'
 import { Page } from 'components/utils/Page'
 import { SessionContainer } from 'containers/SessionContainer'
 import { useUpdatePickedLocaleMutation } from 'data/graphql'
@@ -66,7 +63,7 @@ export const Forever: React.FC<ForeverProps> = ({
   const { handleSubmit } = useRedeemCode()
   const [updatePickedLocale] = useUpdatePickedLocaleMutation({
     variables: {
-      pickedLocale: getLocaleIsoCode(currentLocale),
+      pickedLocale: getIsoLocale(currentLocale),
     },
   })
   const storage = useStorage()

--- a/src/client/pages/OfferNew/FaqSection.tsx
+++ b/src/client/pages/OfferNew/FaqSection.tsx
@@ -5,10 +5,7 @@ import React from 'react'
 import AnimateHeight from 'react-animate-height'
 import ReactMarkdown from 'react-markdown/with-html'
 import { useFaqsQuery } from 'data/graphql'
-import {
-  getLocaleIsoCode,
-  useCurrentLocale,
-} from 'components/utils/CurrentLocale'
+import { getIsoLocale, useCurrentLocale } from 'components/utils/CurrentLocale'
 import { useTextKeys } from 'utils/textKeys'
 import {
   Column,
@@ -140,7 +137,7 @@ export const Accordion: React.FC<AccordionProps> = ({ headline, body }) => {
 
 export const FaqSection: React.FC = () => {
   const pathLocale = useCurrentLocale()
-  const language = getLocaleIsoCode(pathLocale)
+  const language = getIsoLocale(pathLocale)
   const faqs = useFaqsQuery({ variables: { language } })
   const languageData = faqs?.data?.languages[0]
   const textKeys = useTextKeys()

--- a/src/client/pages/OfferNew/index.tsx
+++ b/src/client/pages/OfferNew/index.tsx
@@ -5,7 +5,7 @@ import { Redirect, useHistory, useRouteMatch } from 'react-router'
 import { LoadingPage } from 'components/LoadingPage'
 import { TopBar } from 'components/TopBar'
 import {
-  getLocaleIsoCode,
+  getIsoLocale,
   useCurrentLocale,
   Market,
   useMarket,
@@ -40,7 +40,7 @@ const createToggleCheckout = (history: History<any>, locale?: string) => (
 
 export const OfferNew: React.FC = () => {
   const currentLocale = useCurrentLocale()
-  const localeIsoCode = getLocaleIsoCode(currentLocale)
+  const localeIsoCode = getIsoLocale(currentLocale)
   const currentMarket = useMarket()
   const variation = useVariation()
   const history = useHistory()

--- a/src/client/pages/SignLoading.tsx
+++ b/src/client/pages/SignLoading.tsx
@@ -5,10 +5,7 @@ import React, { useEffect, useState } from 'react'
 import { Redirect } from 'react-router'
 import { LinkButton } from 'components/buttons'
 import { LoadingPage } from 'components/LoadingPage'
-import {
-  getLocaleIsoCode,
-  useCurrentLocale,
-} from 'components/utils/CurrentLocale'
+import { getIsoLocale, useCurrentLocale } from 'components/utils/CurrentLocale'
 import {
   QuoteBundle,
   SignState,
@@ -39,7 +36,7 @@ export const SignLoading: React.FC = () => {
   const textKeys = useTextKeys()
   const currentLocale = useCurrentLocale()
   const variation = useVariation()
-  const localeIsoCode = getLocaleIsoCode(currentLocale)
+  const localeIsoCode = getIsoLocale(currentLocale)
   const { isLoading: quoteIdsIsLoading, quoteIds } = useQuoteIds()
   const { data: quoteBundleData } = useQuoteBundleQuery({
     variables: {


### PR DESCRIPTION
## What?
Suggestion:
Remove `getPickedLocaleFromCurrentLocale ` function in favour of `getLocaleIsoCode`


## Why?

Since `getLocaleIsoCode` takes the same input and returns `Locale` it seems overkill to have two functions for this. But if can we do something to make it more clear what the function is used for and what it returns please come with suggestions. 

localeIsoCode is referring to the iso standard of locales like `sv, nb, da, en` but `Locale` also consist of the country code `SE, NO, DK`. It's clear-ish for me 😄

