### PR TITLE
Make sure we pass correct quoteIds for danish bundles

### DIFF
--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -377,6 +377,32 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
                           ],
                         })
                       }
+                      if (
+                        store.danishHomeContentsQuoteId &&
+                        store.danishAccidentQuoteId
+                      ) {
+                        storageState.session.setSession({
+                          ...storageState.session.getSession(),
+                          quoteIds: [
+                            store.danishHomeContentsQuoteId,
+                            store.danishAccidentQuoteId,
+                          ],
+                        })
+                      }
+                      if (
+                        store.danishHomeContentsQuoteId &&
+                        store.danishAccidentQuoteId &&
+                        store.danishTravelQuoteId
+                      ) {
+                        storageState.session.setSession({
+                          ...storageState.session.getSession(),
+                          quoteIds: [
+                            store.danishHomeContentsQuoteId,
+                            store.danishAccidentQuoteId,
+                            store.danishTravelQuoteId,
+                          ],
+                        })
+                      }
                     }}
                   >
                     <Embark


### PR DESCRIPTION
## What?

Pass correct quoteIds for danish bundles. Not the smartest solution, but it works and enable us to have a test session :)


## Why?

Since we used named quoteIds when creating multiple quotes, we need to pass them down to `EmbarkProvider` them explicitly.
