### PR TITLE
Fix / Correct privacy policy links in Sign Disclaimer

### DIFF
--- a/src/translations/da_DK.json
+++ b/src/translations/da_DK.json
@@ -66,7 +66,7 @@
   "CHECKOUT_EMAIL_PLACEHOLDER": "din.email@her.dk",
   "CHECKOUT_SUMMARY_TITLE": "Dine oplysninger",
   "CHECKOUT_SIGN_BUTTON_TEXT": "Underskriv med NemID",
-  "CHECKOUT_SIGN_DISCLAIMER": "Ved at underskrive tilkendegiver jeg, at jeg har læst [produktinformation]({IPID_LINK}) og [betingelser]({TERMS_LINK}), og jeg accepterer at Hedvig behandler [mine personoplysninger](https:\/\/www.hedvig.com\/privacy).",
+  "CHECKOUT_SIGN_DISCLAIMER": "Ved at underskrive tilkendegiver jeg, at jeg har læst [produktinformation]({IPID_LINK}) og [betingelser]({TERMS_LINK}), og jeg accepterer at Hedvig behandler [mine personoplysninger](https:\/\/www.hedvig.com\/dk\/privacy).",
   "CHECKOUT_DETAILS_ADDRESS": "Adresse",
   "CHECKOUT_DETAILS_ZIPCODE": "Postnummer",
   "CHECKOUT_DETAILS_QUOTE_TYPE": "Boligtype",

--- a/src/translations/en_DK.json
+++ b/src/translations/en_DK.json
@@ -66,7 +66,7 @@
   "CHECKOUT_EMAIL_PLACEHOLDER": "your.email@here.com",
   "CHECKOUT_SUMMARY_TITLE": "Your details",
   "CHECKOUT_SIGN_BUTTON_TEXT": "Sign with NemID",
-  "CHECKOUT_SIGN_DISCLAIMER": "By signing I confirm that I have read and understood the [{TERMS_TITLE}]({TERMS_LINK}) and the [{IPID_TITLE}]({IPID_LINK}), and that Hedvig handles my [personal information](https:\/\/www.hedvig.com\/privacy).",
+  "CHECKOUT_SIGN_DISCLAIMER": "By signing I confirm that I have read and understood the [{TERMS_TITLE}]({TERMS_LINK}) and the [{IPID_TITLE}]({IPID_LINK}), and that Hedvig handles my [personal information](https:\/\/www.hedvig.com\/dk-en\/privacy).",
   "CHECKOUT_DETAILS_ADDRESS": "Address",
   "CHECKOUT_DETAILS_ZIPCODE": "Post code",
   "CHECKOUT_DETAILS_QUOTE_TYPE": "Apartment type",

--- a/src/translations/en_SE.json
+++ b/src/translations/en_SE.json
@@ -66,7 +66,7 @@
   "CHECKOUT_EMAIL_PLACEHOLDER": "your.email@here.com",
   "CHECKOUT_SUMMARY_TITLE": "Your details",
   "CHECKOUT_SIGN_BUTTON_TEXT": "Sign with mobile BankID",
-  "CHECKOUT_SIGN_DISCLAIMER": "By signing I confirm that I have read and understood the [{TERMS_TITLE}]({TERMS_LINK}) and the [{IPID_TITLE}]({IPID_LINK}), and that Hedvig handles my [personal information](https:\/\/www.hedvig.com\/privacy).",
+  "CHECKOUT_SIGN_DISCLAIMER": "By signing I confirm that I have read and understood the [{TERMS_TITLE}]({TERMS_LINK}) and the [{IPID_TITLE}]({IPID_LINK}), and that Hedvig handles my [personal information](https:\/\/www.hedvig.com\/se-en\/privacy).",
   "CHECKOUT_DETAILS_ADDRESS": "Address",
   "CHECKOUT_DETAILS_ZIPCODE": "Post code",
   "CHECKOUT_DETAILS_QUOTE_TYPE": "Apartment type",


### PR DESCRIPTION
## What?

<!-- What changes are made? If there are many changes, a list might be a good format. -->

New sign disclaimer "translations" with correct links to privacy policy for `/se-en` (plus `/dk` and `dk-en` but those pages don't exist yet).

## Why?

<!-- Why are these changes made? -->

The links were incorrect.


~_Referenced ticket(s):_~
<!-- If there is a Jira issue, add the id between brackets, and a link to that issue will be created. -->


<!-- Finally, if that makes sense, add screenshots and/or screen recordings below, preferably with headlines and/or descriptions -->
