### PR TITLE
Upgrade embark

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.23",
     "@hedviginsurance/brand": "^4.0.2",
-    "@hedviginsurance/embark": "^2.0.11",
+    "@hedviginsurance/embark": "^2.0.15",
     "@segment/snippet": "^4.4.0",
     "@sentry/node": "^5.27.6",
     "@types/dayzed": "^2.2.1",

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -311,7 +311,14 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
                 {(storageState) => (
                   <EmbarkProvider
                     externalRedirects={{
-                      Offer: () => {
+                      Offer: (quoteIds) => {
+                        if (quoteIds.length > 0) {
+                          storageState.session.setSession({
+                            ...storageState.session.getSession(),
+                            quoteIds,
+                          })
+                        }
+
                         history.push(
                           (props.language ? '/' + props.language : '') +
                             '/new-member/offer',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1603,10 +1603,10 @@
   resolved "https://registry.yarnpkg.com/@hedviginsurance/brand/-/brand-4.0.3.tgz#60d222f6e08db65a5403e832d525147ab3cde956"
   integrity sha512-G6NjFFTg7rj4eVNj/QZc7xrupyJ41CTYUPVTzjkt0R7QWD3CqXStWkVKwgR8rRli51swpVY7xhlk7HX1mlJ8WQ==
 
-"@hedviginsurance/embark@^2.0.11":
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.0.11.tgz#09428ff6d2790afaea286b64eb4634f30e9d2d9b"
-  integrity sha512-2DuM2Ihq3eRGn8Y7xFiXXKigSptHAc9NK1Ukr0kknptrQxXtF4h+UEn0XNtOmWDT9PdSOXY4PI+7QTvhE3AX4g==
+"@hedviginsurance/embark@^2.0.15":
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.0.15.tgz#830693e7a61dac18ddbf88ab6a4d768a83ecc28b"
+  integrity sha512-dmUtQNrCrIyZHM++7fJ83zog0G+3Q2PxQtTRbDt6mnl0G4BzpO/H2W8UevCw+Pjw8uf1XmprCdINsqsHdeWlIA==
   dependencies:
     "@emotion/babel-plugin" "^11.0.0-next.12"
     "@emotion/core" "^10.0.21"


### PR DESCRIPTION
## What?

- Upgrading Embark to support new tracking filtering, remove `includeAllKeys` support.
- Insert quoteIds received in `ExternalRedirect` handler into session storage, this would down the line make the listeners on store quoteIds unnecessary as these would be defined directly in the embark flow instead (see [L375](https://github.com/HedvigInsurance/web-onboarding/blob/5998027cfe47ca925329d6e4f8908e6fd464233a/src/client/pages/Embark/index.tsx#L375)).

## Why?

### Tracking

We were sending a bunch of unnecessary PII to Mixpanel

### QuoteIDS

We where reluctant to hard-code which store keys correspond to a quote id in the apps, so we came up with a more generic scalable solution to handle that.

_Referenced ticket(s): [APP-143]_


<!-- Finally, if that makes sense, add screenshots and/or screen recordings below, preferably with headlines and/or descriptions -->


[APP-143]: https://hedvig.atlassian.net/browse/APP-143