### PR TITLE
Fix / Terms links with bundle quotes

### DIFF
--- a/src/client/pages/OfferNew/Checkout/InsuranceSummary.tsx
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummary.tsx
@@ -61,7 +61,7 @@ export const InsuranceSummary: React.FC<Props> = ({ offerData }) => {
       </Table>
       <Title>{textKeys.CHECKOUT_TERMS_HEADLINE()}</Title>
       <Table>
-        <InsuranceSummaryTermsLinks mainQuote={mainQuote} />
+        <InsuranceSummaryTermsLinks offerData={offerData} />
       </Table>
     </Wrapper>
   )

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
@@ -1,63 +1,137 @@
 import {
   noCombo,
+  seApartementBrf,
   insuranceTermsNoHomeContentsMock,
   insuranceTermsNoTravelMock,
-} from '../../../utils/testData/offerDataMock'
+} from 'utils/testData/offerDataMock'
+import { InsuranceTerm, InsuranceTermType } from 'data/graphql'
 import { getInsuranceTerms } from './InsuranceSummaryTermsLinks'
 
+const getPrivacyPolicyTerms = (terms: Terms) => {
+  return terms.filter(
+    ({ termType }) => termType === InsuranceTermType.PrivacyPolicy,
+  )
+}
+
+const getDuplicates = (terms: Terms) => {
+  return terms.filter(({ data }) => {
+    const { displayName, url } = data
+    const occurences = terms.filter(
+      ({ data }) => data.displayName === displayName && data.url === url,
+    )
+
+    return occurences.length > 1
+  })
+}
+
+type Terms = {
+  termType: InsuranceTermType
+  data: InsuranceTerm
+}[]
+
 describe('getInsuranceTerms function', () => {
+  const termsCombo = getInsuranceTerms({ offerData: noCombo })
+  const termsSwedishApartment = getInsuranceTerms({
+    offerData: seApartementBrf,
+  })
+
+  it('returns array of insurance terms objects excluding privacy policy', () => {
+    const privacyPolicyComboTerms = getPrivacyPolicyTerms(termsCombo)
+    const privacyPolicySwedishApartmentTerms = getPrivacyPolicyTerms(
+      termsSwedishApartment,
+    )
+
+    expect(privacyPolicyComboTerms).toHaveLength(0)
+    expect(privacyPolicySwedishApartmentTerms).toHaveLength(0)
+  })
+
+  it('returns array of insurance terms objects without duplicates', () => {
+    const duplicatesInBundleTerms = getDuplicates(termsCombo)
+    const duplicatesInSingleQuoteTerms = getDuplicates(termsSwedishApartment)
+
+    expect(duplicatesInBundleTerms).toHaveLength(0)
+    expect(duplicatesInSingleQuoteTerms).toHaveLength(0)
+  })
+
   describe('with bundle quotes', () => {
-    const termsCombo = getInsuranceTerms({ offerData: noCombo })
-    const termsComboDisplayNames = termsCombo.map(({ data }) => {
-      return data.displayName
-    })
-    const termsComboUrls = termsCombo.map(({ data }) => {
-      return data.url
-    })
-
-    it('returns an array of insurance terms objects where all insurance terms from every quotes exist', () => {
-      const termsNoTravel = [...insuranceTermsNoTravelMock].map(
-        ([termType, data]) => {
-          return { termType, data }
-        },
-      )
-      const termsNoHomeContents = [...insuranceTermsNoHomeContentsMock].map(
-        ([termType, data]) => {
-          return { termType, data }
-        },
-      )
-      const homeContentsTermsMissingFromComboTerms = termsNoHomeContents.filter(
-        ({ data }) => {
-          return (
-            !termsComboDisplayNames.includes(data.displayName) ||
-            !termsComboUrls.includes(data.url)
-          )
-        },
-      )
-      const travelTermsMissingFromComboTerms = termsNoTravel.filter(
-        ({ data }) => {
-          return (
-            !termsComboDisplayNames.includes(data.displayName) ||
-            !termsComboUrls.includes(data.url)
-          )
-        },
-      )
-      expect(homeContentsTermsMissingFromComboTerms).toHaveLength(0)
-      expect(travelTermsMissingFromComboTerms).toHaveLength(0)
-    })
-
-    it('returns an array of insurance terms objects without duplicates', () => {
-      const duplicates = termsCombo.filter(({ data }) => {
-        const { displayName, url } = data
-
-        const occurences = termsCombo.filter(({ data }) => {
-          return data.displayName === displayName && data.url === url
-        })
-
-        return occurences.length > 1
+    it('returns array where every insurance term from all quotes exist, excluding privacy policy', () => {
+      const termsComboDisplayNames = termsCombo.map(({ data }) => {
+        return data.displayName
+      })
+      const termsComboUrls = termsCombo.map(({ data }) => {
+        return data.url
       })
 
-      expect(duplicates).toHaveLength(0)
+      const termsNoTravelMock = [...insuranceTermsNoTravelMock].map(
+        ([termType, data]) => {
+          return { termType, data }
+        },
+      )
+      const termsNoHomeContentsMock = [...insuranceTermsNoHomeContentsMock].map(
+        ([termType, data]) => {
+          return { termType, data }
+        },
+      )
+
+      const homeContentsTermsMissingFromComboTerms = termsNoHomeContentsMock.filter(
+        ({ data }) => {
+          return (
+            !termsComboDisplayNames.includes(data.displayName) ||
+            !termsComboUrls.includes(data.url)
+          )
+        },
+      )
+      const travelTermsMissingFromComboTerms = termsNoTravelMock.filter(
+        ({ data }) => {
+          return (
+            !termsComboDisplayNames.includes(data.displayName) ||
+            !termsComboUrls.includes(data.url)
+          )
+        },
+      )
+
+      const hasPrivacyPolicyInHomeContentTerms = insuranceTermsNoHomeContentsMock.has(
+        InsuranceTermType.PrivacyPolicy,
+      )
+      const hasPrivacyPolicyInTravelTerms = insuranceTermsNoTravelMock.has(
+        InsuranceTermType.PrivacyPolicy,
+      )
+      const privacyPolicyInHomeContentTerms = homeContentsTermsMissingFromComboTerms.find(
+        ({ termType }) => termType === InsuranceTermType.PrivacyPolicy,
+      )
+      const privacyPolicyInTravelTerms = travelTermsMissingFromComboTerms.find(
+        ({ termType }) => termType === InsuranceTermType.PrivacyPolicy,
+      )
+
+      expect(homeContentsTermsMissingFromComboTerms).toHaveLength(
+        hasPrivacyPolicyInHomeContentTerms ? 1 : 0,
+      )
+      expect(travelTermsMissingFromComboTerms).toHaveLength(
+        hasPrivacyPolicyInTravelTerms ? 1 : 0,
+      )
+      expect(privacyPolicyInHomeContentTerms?.termType).toBe(
+        hasPrivacyPolicyInHomeContentTerms
+          ? InsuranceTermType.PrivacyPolicy
+          : undefined,
+      )
+      expect(privacyPolicyInTravelTerms?.termType).toBe(
+        hasPrivacyPolicyInTravelTerms
+          ? InsuranceTermType.PrivacyPolicy
+          : undefined,
+      )
+    })
+  })
+
+  describe('with single quote', () => {
+    it('returns array that has the same length as the size of "insuranceTerms" property on quote', () => {
+      const hasPrivacyPolicy = seApartementBrf.quotes[0].insuranceTerms.has(
+        InsuranceTermType.PrivacyPolicy,
+      )
+      const sizeOfTermsInQuote = seApartementBrf.quotes[0].insuranceTerms.size
+
+      expect(termsSwedishApartment).toHaveLength(
+        hasPrivacyPolicy ? sizeOfTermsInQuote - 1 : sizeOfTermsInQuote,
+      )
     })
   })
 })

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
@@ -6,7 +6,7 @@ import {
 import { getInsuranceTerms } from './InsuranceSummaryTermsLinks'
 
 describe('getInsuranceTerms function', () => {
-  describe('bundle insurance terms', () => {
+  describe('with bundle quotes', () => {
     const termsCombo = getInsuranceTerms({ offerData: noCombo })
     const termsComboDisplayNames = termsCombo.map(({ data }) => {
       return data.displayName
@@ -15,7 +15,7 @@ describe('getInsuranceTerms function', () => {
       return data.url
     })
 
-    it('returns an array with insurance terms objects where all insurance terms from every quotes exist', () => {
+    it('returns an array of insurance terms objects where all insurance terms from every quotes exist', () => {
       const termsNoTravel = [...insuranceTermsNoTravelMock].map(
         ([termType, data]) => {
           return { termType, data }
@@ -44,6 +44,18 @@ describe('getInsuranceTerms function', () => {
       )
       expect(homeContentsTermsMissingFromComboTerms).toHaveLength(0)
       expect(travelTermsMissingFromComboTerms).toHaveLength(0)
+    })
+
+    it('returns an array of insurance terms objects without duplicates', () => {
+      termsCombo.forEach(({ data }) => {
+        const { displayName, url } = data
+
+        const occurences = termsCombo.filter(({ data }) => {
+          return data.displayName === displayName && data.url === url
+        })
+
+        expect(occurences).toHaveLength(1)
+      })
     })
   })
 })

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
@@ -52,10 +52,8 @@ const getDuplicates = (terms: Terms) => {
 }
 
 describe('getInsuranceTerms function', () => {
-  const termsCombo = getInsuranceTerms({ offerData: mockedOfferDataNoCombo })
-  const termsSwedishApartment = getInsuranceTerms({
-    offerData: mockedOfferDataSeApartment,
-  })
+  const termsCombo = getInsuranceTerms(mockedOfferDataNoCombo)
+  const termsSwedishApartment = getInsuranceTerms(mockedOfferDataSeApartment)
 
   it('returns array of insurance terms objects excluding privacy policy', () => {
     const privacyPolicyComboTerms = getPrivacyPolicyTerms(termsCombo)

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
@@ -47,15 +47,17 @@ describe('getInsuranceTerms function', () => {
     })
 
     it('returns an array of insurance terms objects without duplicates', () => {
-      termsCombo.forEach(({ data }) => {
+      const duplicates = termsCombo.filter(({ data }) => {
         const { displayName, url } = data
 
         const occurences = termsCombo.filter(({ data }) => {
           return data.displayName === displayName && data.url === url
         })
 
-        expect(occurences).toHaveLength(1)
+        return occurences.length > 1
       })
+
+      expect(duplicates).toHaveLength(0)
     })
   })
 })

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
@@ -4,16 +4,9 @@ import {
   insuranceTermsNoHomeContentsMock,
   insuranceTermsNoTravelMock,
 } from 'utils/testData/offerDataMock'
-import { InsuranceTerm, InsuranceTermType } from 'data/graphql'
+import { InsuranceTermType } from 'data/graphql'
 import { InsuranceTerms } from '../types'
-import { getInsuranceTerms } from './InsuranceSummaryTermsLinks'
-
-type Term = {
-  termType: InsuranceTermType
-  data: InsuranceTerm
-}
-
-type Terms = Term[]
+import { getInsuranceTerms, Term, Terms } from './InsuranceSummaryTermsLinks'
 
 const getMockedInsuranceTermsArray = (insuranceTerms: InsuranceTerms) => {
   return [...insuranceTerms].map(([termType, data]) => ({
@@ -22,8 +15,10 @@ const getMockedInsuranceTermsArray = (insuranceTerms: InsuranceTerms) => {
   }))
 }
 
+type MockedTerms = Omit<Term, 'quoteId'>[]
+
 type GetTermsMissingParams = {
-  mockedTerms: Terms
+  mockedTerms: MockedTerms
   newTermsArray: Terms
 }
 
@@ -78,6 +73,23 @@ describe('getInsuranceTerms function', () => {
 
     expect(duplicatesInBundleTerms).toHaveLength(0)
     expect(duplicatesInSingleQuoteTerms).toHaveLength(0)
+  })
+
+  it('returns array of insurance terms objects, with terms sorted correctly', () => {
+    // sorting order should be
+    // 1) TERMS_AND_CONDITIONS type from main qoute
+    // 2) Other TERMS_AND_CONDITIONS type
+    // 3) Rest of the terms, no specific order
+
+    expect(termsSwedishApartment[0].termType).toBe('TERMS_AND_CONDITIONS')
+    expect(termsSwedishApartment[0].data.displayName).toBe('Försäkringsvillkor')
+    expect(termsCombo[0].termType).toBe('TERMS_AND_CONDITIONS')
+    expect(termsCombo[0].data.displayName).toBe(
+      'Forsikringsvilkår innboforsikring',
+    )
+    expect(termsCombo[1].data.displayName).toBe(
+      'Forsikringsvilkår reiseforsikring',
+    )
   })
 
   describe('with bundle quotes', () => {

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
@@ -1,6 +1,6 @@
 import {
-  noCombo,
-  seApartementBrf,
+  noCombo as mockedOfferDataNoCombo,
+  seApartementBrf as mockedOfferDataSeApartment,
   insuranceTermsNoHomeContentsMock,
   insuranceTermsNoTravelMock,
 } from 'utils/testData/offerDataMock'
@@ -52,9 +52,9 @@ const getDuplicates = (terms: Terms) => {
 }
 
 describe('getInsuranceTerms function', () => {
-  const termsCombo = getInsuranceTerms({ offerData: noCombo })
+  const termsCombo = getInsuranceTerms({ offerData: mockedOfferDataNoCombo })
   const termsSwedishApartment = getInsuranceTerms({
-    offerData: seApartementBrf,
+    offerData: mockedOfferDataSeApartment,
   })
 
   it('returns array of insurance terms objects excluding privacy policy', () => {
@@ -150,10 +150,10 @@ describe('getInsuranceTerms function', () => {
 
   describe('with single quote', () => {
     const insuranceTermsSeApartmentMock =
-      seApartementBrf.quotes[0].insuranceTerms
+      mockedOfferDataSeApartment.quotes[0].insuranceTerms
 
     it('returns array that has the same length as the size of "insuranceTerms" property on quote', () => {
-      const hasPrivacyPolicy = seApartementBrf.quotes[0].insuranceTerms.has(
+      const hasPrivacyPolicy = mockedOfferDataSeApartment.quotes[0].insuranceTerms.has(
         InsuranceTermType.PrivacyPolicy,
       )
       const sizeOfTermsInQuote = insuranceTermsSeApartmentMock.size

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.test.ts
@@ -1,0 +1,49 @@
+import {
+  noCombo,
+  insuranceTermsNoHomeContentsMock,
+  insuranceTermsNoTravelMock,
+} from '../../../utils/testData/offerDataMock'
+import { getInsuranceTerms } from './InsuranceSummaryTermsLinks'
+
+describe('getInsuranceTerms function', () => {
+  describe('bundle insurance terms', () => {
+    const termsCombo = getInsuranceTerms({ offerData: noCombo })
+    const termsComboDisplayNames = termsCombo.map(({ data }) => {
+      return data.displayName
+    })
+    const termsComboUrls = termsCombo.map(({ data }) => {
+      return data.url
+    })
+
+    it('returns an array with insurance terms objects where all insurance terms from every quotes exist', () => {
+      const termsNoTravel = [...insuranceTermsNoTravelMock].map(
+        ([termType, data]) => {
+          return { termType, data }
+        },
+      )
+      const termsNoHomeContents = [...insuranceTermsNoHomeContentsMock].map(
+        ([termType, data]) => {
+          return { termType, data }
+        },
+      )
+      const homeContentsTermsMissingFromComboTerms = termsNoHomeContents.filter(
+        ({ data }) => {
+          return (
+            !termsComboDisplayNames.includes(data.displayName) ||
+            !termsComboUrls.includes(data.url)
+          )
+        },
+      )
+      const travelTermsMissingFromComboTerms = termsNoTravel.filter(
+        ({ data }) => {
+          return (
+            !termsComboDisplayNames.includes(data.displayName) ||
+            !termsComboUrls.includes(data.url)
+          )
+        },
+      )
+      expect(homeContentsTermsMissingFromComboTerms).toHaveLength(0)
+      expect(travelTermsMissingFromComboTerms).toHaveLength(0)
+    })
+  })
+})

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
@@ -70,7 +70,7 @@ const getSorted = ({ termsArray, offerData }: GetSortedParams) => {
   return [...termsAndConditionsSorted, ...restOfTerms]
 }
 
-export const getInsuranceTerms = ({ offerData }: { offerData: OfferData }) => {
+export const getInsuranceTerms = (offerData: OfferData) => {
   const allQuotesInsuranceTerms = offerData.quotes
     .map((quote) => {
       const quoteId = quote.id
@@ -117,7 +117,7 @@ type Props = {
 export const InsuranceSummaryTermsLinks: React.FC<Props> = ({ offerData }) => {
   const currentLocale = useCurrentLocale()
 
-  const insuranceTerms = getInsuranceTerms({ offerData })
+  const insuranceTerms = getInsuranceTerms(offerData)
 
   return (
     <Group>

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
@@ -83,8 +83,8 @@ export const getInsuranceTerms = ({ offerData }: GetInsuranceTermsParams) => {
         return { quoteId, termType, data }
       })
     })
-    .reduce((acc, cur) => {
-      return [...acc, ...cur]
+    .reduce((termsArray, termsArrayFromQuote) => {
+      return [...termsArray, ...termsArrayFromQuote]
     })
 
   const termsWithoutDuplicates = allQuotesInsuranceTerms.reduce(

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
@@ -42,7 +42,9 @@ type GetAllInsuranceTermsParams = {
   offerData: OfferData
 }
 
-const getInsuranceTerms = ({ offerData }: GetAllInsuranceTermsParams) => {
+export const getInsuranceTerms = ({
+  offerData,
+}: GetAllInsuranceTermsParams) => {
   const allQuotesInsuranceTerms = offerData.quotes
     .map((quote) => {
       const { insuranceTerms } = quote

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
@@ -70,11 +70,7 @@ const getSorted = ({ termsArray, offerData }: GetSortedParams) => {
   return [...termsAndConditionsSorted, ...restOfTerms]
 }
 
-type GetInsuranceTermsParams = {
-  offerData: OfferData
-}
-
-export const getInsuranceTerms = ({ offerData }: GetInsuranceTermsParams) => {
+export const getInsuranceTerms = ({ offerData }: { offerData: OfferData }) => {
   const allQuotesInsuranceTerms = offerData.quotes
     .map((quote) => {
       const quoteId = quote.id

--- a/src/client/pages/OfferNew/types.ts
+++ b/src/client/pages/OfferNew/types.ts
@@ -38,6 +38,8 @@ export type OfferPersonInfo = Pick<
   address: Address | null
 }
 
+export type InsuranceTerms = ReadonlyMap<InsuranceTermType, InsuranceTerm>
+
 export type OfferQuote = Pick<
   BundledQuote,
   | 'id'
@@ -49,7 +51,7 @@ export type OfferQuote = Pick<
 > & {
   contractType: TypeOfContract
   insurableLimits: ReadonlyMap<InsurableLimitType, InsurableLimit>
-  insuranceTerms: ReadonlyMap<InsuranceTermType, InsuranceTerm>
+  insuranceTerms: InsuranceTerms
 }
 
 export interface OfferData {

--- a/src/client/pages/OfferNew/utils.ts
+++ b/src/client/pages/OfferNew/utils.ts
@@ -120,6 +120,14 @@ export const getMainQuote = (offerData: OfferData) => {
   return mainQuote
 }
 
+export const checkIfMainQuote = (
+  offerData: OfferData,
+  quoteId: OfferQuote['id'],
+) => {
+  const mainQuote = getMainQuote(offerData)
+  return mainQuote.id === quoteId
+}
+
 export const getQuoteIds = (offerData: OfferData): string[] =>
   offerData.quotes.map((quote) => quote.id)
 

--- a/src/client/utils/testData/offerDataMock.ts
+++ b/src/client/utils/testData/offerDataMock.ts
@@ -1,7 +1,6 @@
 import {
   InsurableLimit,
   InsurableLimitType,
-  InsuranceTerm,
   InsuranceTermType,
   NorwegianHomeContentsType,
   PerilV2,
@@ -10,7 +9,7 @@ import {
   ApartmentType,
   CurrentInsurer,
 } from 'data/graphql'
-import { OfferData } from '../../pages/OfferNew/types'
+import { InsuranceTerms, OfferData } from '../../pages/OfferNew/types'
 
 const insurableLimitMock = new Map([
   [
@@ -54,7 +53,7 @@ const insuranceTermsMock = new Map([
       __typename: 'InsuranceTerm',
     },
   ],
-]) as ReadonlyMap<InsuranceTermType, InsuranceTerm>
+]) as InsuranceTerms
 
 export const insuranceTermsNoHomeContentsMock = new Map([
   [
@@ -84,7 +83,7 @@ export const insuranceTermsNoHomeContentsMock = new Map([
       __typename: 'InsuranceTerm',
     },
   ],
-]) as ReadonlyMap<InsuranceTermType, InsuranceTerm>
+]) as InsuranceTerms
 
 export const insuranceTermsNoTravelMock = new Map([
   [
@@ -114,7 +113,7 @@ export const insuranceTermsNoTravelMock = new Map([
       __typename: 'InsuranceTerm',
     },
   ],
-]) as ReadonlyMap<InsuranceTermType, InsuranceTerm>
+]) as InsuranceTerms
 
 const perilsMock: PerilV2[] = [
   {

--- a/src/client/utils/testData/offerDataMock.ts
+++ b/src/client/utils/testData/offerDataMock.ts
@@ -36,6 +36,84 @@ const insuranceTermsMock = new Map([
       __typename: 'InsuranceTerm',
     },
   ],
+  [
+    InsuranceTermType.PreSaleInfoEuStandard,
+    {
+      displayName: 'Produktfaktablad',
+      type: 'PRE_SALE_INFO_EU_STANDARD',
+      url: 'https://www.hedvig.com/se/villkor',
+      __typename: 'InsuranceTerm',
+    },
+  ],
+  [
+    InsuranceTermType.PrivacyPolicy,
+    {
+      displayName: 'Personuppgifter',
+      type: 'PRIVACY_POLICY',
+      url: 'https://www.hedvig.com/se/personuppgifter',
+      __typename: 'InsuranceTerm',
+    },
+  ],
+]) as ReadonlyMap<InsuranceTermType, InsuranceTerm>
+
+export const insuranceTermsNoHomeContentsMock = new Map([
+  [
+    InsuranceTermType.TermsAndConditions,
+    {
+      displayName: 'Forsikringsvilkår innboforsikring',
+      type: 'TERMS_AND_CONDITIONS',
+      url: 'https://www.hedvig.com/no/villkar/villkar/innbo.pdf',
+      __typename: 'InsuranceTerm',
+    },
+  ],
+  [
+    InsuranceTermType.GeneralTerms,
+    {
+      displayName: 'Generelle vilkår',
+      type: 'GENERAL_TERMS',
+      url: 'https://www.hedvig.com/no/terms',
+      __typename: 'InsuranceTerm',
+    },
+  ],
+  [
+    InsuranceTermType.PreSaleInfoEuStandard,
+    {
+      displayName: 'Informasjon før kjøpet iht. EU-standard',
+      type: 'PRE_SALE_INFO_EU_STANDARD',
+      url: 'https://www.hedvig.com/no/terms',
+      __typename: 'InsuranceTerm',
+    },
+  ],
+]) as ReadonlyMap<InsuranceTermType, InsuranceTerm>
+
+export const insuranceTermsNoTravelMock = new Map([
+  [
+    InsuranceTermType.TermsAndConditions,
+    {
+      displayName: 'Forsikringsvilkår reiseforsikring',
+      type: 'TERMS_AND_CONDITIONS',
+      url: 'https://www.hedvig.com/no/villkar/villkar/reise.pdf',
+      __typename: 'InsuranceTerm',
+    },
+  ],
+  [
+    InsuranceTermType.GeneralTerms,
+    {
+      displayName: 'Generelle vilkår',
+      type: 'GENERAL_TERMS',
+      url: 'https://www.hedvig.com/no/terms',
+      __typename: 'InsuranceTerm',
+    },
+  ],
+  [
+    InsuranceTermType.PreSaleInfoEuStandard,
+    {
+      displayName: 'Informasjon før kjøpet iht. EU-standard',
+      type: 'PRE_SALE_INFO_EU_STANDARD',
+      url: 'https://www.hedvig.com/no/terms',
+      __typename: 'InsuranceTerm',
+    },
+  ],
 ]) as ReadonlyMap<InsuranceTermType, InsuranceTerm>
 
 const perilsMock: PerilV2[] = [
@@ -168,7 +246,7 @@ export const noComboYouth: OfferData = {
       contractType: TypeOfContract.NoTravelYouth,
       perils: perilsMock,
       insurableLimits: insurableLimitMock,
-      insuranceTerms: insuranceTermsMock,
+      insuranceTerms: insuranceTermsNoTravelMock,
     },
     {
       id: '86f0a15d-6aed-4051-9ec2-fee1daccfb29',
@@ -187,7 +265,7 @@ export const noComboYouth: OfferData = {
       contractType: TypeOfContract.NoHomeContentYouthRent,
       perils: perilsMock,
       insurableLimits: insurableLimitMock,
-      insuranceTerms: insuranceTermsMock,
+      insuranceTerms: insuranceTermsNoHomeContentsMock,
     },
   ],
   cost: {
@@ -238,7 +316,7 @@ export const noCombo: OfferData = {
       contractType: TypeOfContract.NoTravel,
       perils: perilsMock,
       insurableLimits: insurableLimitMock,
-      insuranceTerms: insuranceTermsMock,
+      insuranceTerms: insuranceTermsNoTravelMock,
     },
     {
       id: '86f0a15d-6aed-4051-9ec2-fee1daccfb29',
@@ -257,7 +335,7 @@ export const noCombo: OfferData = {
       contractType: TypeOfContract.NoHomeContentRent,
       perils: perilsMock,
       insurableLimits: insurableLimitMock,
-      insuranceTerms: insuranceTermsMock,
+      insuranceTerms: insuranceTermsNoHomeContentsMock,
     },
   ],
   cost: {


### PR DESCRIPTION
## What?

The list of Terms & Conditions links in checkout is fixed so that it actually contains all links from all quotes:
- All logic of getting the `insuranceTerms` from the quotes into a desirable shape is extracted to its own function `getInsuranceTerms`, in `InsuranceSummaryTermsLinks.tsx`.
- A bunch of tests describing the `getInsuranceTerms` function are added to new test file `InsuranceSummaryTermsLinks.test.ts`
- The list of terms is now also sorted in the following order: 
  1. `TERMS_AND_CONDITIONS` type term from main quote
  2. other `TERMS_AND_CONDITION` type terms (if it's a bundle)
  3. all other terms (still excluding `PRIVACY_POLICY` term types though).

## Why?

The current implementation which luckily enough is not yet in production yet since I realised that it wasn't working properly will only display terms links from the main quote (i.e. Home Content quote in Norway, in the future also Home Content quote in Denmark).


_Referenced ticket(s): [GRW-265]_
<!-- If there is a Jira issue, add the id between brackets, and a link to that issue will be created. -->


<!-- Finally, if that makes sense, add screenshots and/or screen recordings below, preferably with headlines and/or descriptions -->

## Screenshots

### 🇸🇪 Sweden
<img width="542" alt="2021-04-20-terms-links-se" src="https://user-images.githubusercontent.com/42962286/115418377-bd500a00-a1f9-11eb-9133-c48413808f21.png">


### 🇳🇴 Norway
**Kombo:**
<img width="540" alt="2021-04-20-terms-links-no-combo" src="https://user-images.githubusercontent.com/42962286/115417215-bbd21200-a1f8-11eb-9c61-3bd2d7d2efb6.png">


**Innbo:**
<img width="532" alt="2021-04-20-terms-links-no-innbo" src="https://user-images.githubusercontent.com/42962286/115417279-c8ef0100-a1f8-11eb-8e39-2b4df983bbb4.png">


**Reise:**
<img width="536" alt="2021-04-20-terms-links-no-travel" src="https://user-images.githubusercontent.com/42962286/115417348-d4422c80-a1f8-11eb-8de9-d5e14e7b754f.png">


**Bundle**
_Unfortunately the Travel insurance terms and Home Content insurance terms have the same `displayName` in English (which we get from back-end), so it looks like a mistake here but it's not. Will ask for it to be changed on the back-end._
<img width="524" alt="2021-04-20-terms-links-no-en" src="https://user-images.githubusercontent.com/42962286/115418272-a8737680-a1f9-11eb-804b-7e21fda09289.png">


### 🇩🇰 Denmark
_still placeholder data obvi_
<img width="526" alt="2021-04-20-terms-links-dk" src="https://user-images.githubusercontent.com/42962286/115417008-8deccd80-a1f8-11eb-83f6-fc4bdc5c7054.png">




[GRW-265]: https://hedvig.atlassian.net/browse/GRW-265