### PR TITLE
Fix/set same site attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "axios": "^0.21.1",
     "color": "^3.1.2",
     "constate": "0.9.0",
-    "cookie-storage": "^3.2.0",
+    "cookie-storage": "^6.1.0",
     "core-js": "2",
     "dayzed": "^3.1.0",
     "dotenv": "^8.2.0",

--- a/src/shared/sessionStorage.ts
+++ b/src/shared/sessionStorage.ts
@@ -62,7 +62,11 @@ export const createSession = <T>(
   storageKey: string = SESSION_KEY,
 ): IsomorphicSessionStorage<T> => ({
   setSession: (value: T): void => {
-    storage.setItem(storageKey, JSON.stringify(value), { path: '/' })
+    storage.setItem(storageKey, JSON.stringify(value), {
+      path: '/',
+      secure: true,
+      sameSite: 'None',
+    })
   },
   getSession: (): T | undefined => {
     try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5921,10 +5921,10 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie-storage@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/cookie-storage/-/cookie-storage-3.2.0.tgz#ada5f23152eb76f2a1d48777e921ebc2789535b4"
-  integrity sha512-E2IlZrqJ00Y+9GLugfqyumcjXBtCkNWvX0opx0RUqaqvB67i6zzngrrFjeWNkJVhw0cO/ixThKLRDgDOak9eCw==
+cookie-storage@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/cookie-storage/-/cookie-storage-6.1.0.tgz#291b2f662d961be44f999626593421cbfcf23790"
+  integrity sha512-HeVqbVy8BjXhAAuFtL6MTG+witHoLbxfky2jgVh9FmxmyL6IKa9gSSyPNjevXCCCxPu6Tzd9J8+eXTRQzYU/cg==
 
 cookie@0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## What
Set `Same Site` cookie attribute to `None`. Update cookie-storage package

## Why
This is due to an update from Chrome where the default value of the `SameSite` attribute switched from `None` to `Lax`.
This caused problems for NO members when connecting payments via Adyen. We could only recreate the problem when using 3D secure providers. When redirecting back to the onboarding,`hvsession` cookie was missing. 

### Review app
https://web-onboardi-fix-set-sa-o5k9oq.herokuapp.com/no/new-member


https://user-images.githubusercontent.com/6661511/115884495-42802c80-a44f-11eb-995a-7ae37876e568.mov

