### PR TITLE
Fix/set secure cookie

### DIFF
--- a/src/client/utils/storage/ServerCookieStorage.ts
+++ b/src/client/utils/storage/ServerCookieStorage.ts
@@ -23,6 +23,8 @@ export class ServerCookieStorage implements MinimalStorage {
       signed: false,
       expires: undefined,
       path: '/',
+      sameSite: 'None',
+      secure: true,
       httpOnly: false,
     })
   }

--- a/src/client/utils/storage/ServerCookieStorage.ts
+++ b/src/client/utils/storage/ServerCookieStorage.ts
@@ -23,9 +23,11 @@ export class ServerCookieStorage implements MinimalStorage {
       signed: false,
       expires: undefined,
       path: '/',
-      sameSite: 'None',
-      secure: true,
       httpOnly: false,
+      ...(process.env.NODE_ENV !== 'development' && {
+        sameSite: 'None',
+        secure: true,
+      }),
     })
   }
 

--- a/src/server/serverEntry.tsx
+++ b/src/server/serverEntry.tsx
@@ -41,6 +41,7 @@ const router = new Router()
 
 configureAssets(app)
 
+app.proxy = true
 appLogger.info(`Booting server on ${getPort()} 👢`)
 appLogger.info(
   `Sentry is ${

--- a/src/shared/sessionStorage.ts
+++ b/src/shared/sessionStorage.ts
@@ -80,6 +80,12 @@ export const createSession = <T>(
   },
   keepAlive: () => {
     clearExpiredSession(storage, storageKey)
-    storage.setItem(KA_SESSION_KEY, String(Date.now()), { path: '/' })
+    storage.setItem(KA_SESSION_KEY, String(Date.now()), {
+      path: '/',
+      ...(process.env.NODE_ENV !== 'development' && {
+        sameSite: 'None',
+        secure: true,
+      }),
+    })
   },
 })

--- a/src/shared/sessionStorage.ts
+++ b/src/shared/sessionStorage.ts
@@ -64,8 +64,10 @@ export const createSession = <T>(
   setSession: (value: T): void => {
     storage.setItem(storageKey, JSON.stringify(value), {
       path: '/',
-      secure: true,
-      sameSite: 'None',
+      ...(process.env.NODE_ENV !== 'development' && {
+        sameSite: 'None',
+        secure: true,
+      }),
     })
   },
   getSession: (): T | undefined => {


### PR DESCRIPTION
## What 
Attempt to fix the issue https://sentry.io/organizations/hedvig/issues/2358727634/?project=1308938 that came up after specifying `sameSite` attribute in this PR https://github.com/HedvigInsurance/web-onboarding/pull/505

The problem is that we cannot set secure cookies over unsecure connections. We have tried to reproduce the problem locally but only managed to reproduce it once so very hard to tell what causes the issue and to know if this fix actually does anything...

Adding the `app.proxy = true` sounded like it should fix the problem but hard to tell. Reading similar issues makes me think no :/ https://github.com/koajs/koa/issues/974 & https://github.com/webpack/webpack-dev-server/issues/933

Also, we should specify the same attribute for all cookies we set.

