### PR TITLE
Fix / Offer page discount modal Terms & Conditions link

### DIFF
--- a/src/client/pages/OfferNew/Introduction/Sidebar/DiscountCodeModal.tsx
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/DiscountCodeModal.tsx
@@ -22,7 +22,7 @@ const Wrapper = styled.div<{ isOpen: boolean }>`
   width: 100%;
   height: 100%;
   position: absolute;
-  background: ${hexToRgba(colorsV3.white, 0.8)};
+  background: ${hexToRgba(colorsV3.white, 0.85)};
   top: 0;
   left: 0;
   transition: all 0.2s;
@@ -30,7 +30,7 @@ const Wrapper = styled.div<{ isOpen: boolean }>`
   opacity: ${(props) => (props.isOpen ? 1 : 0)};
   padding: 1rem;
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   border-radius: 8px;
 `
 
@@ -49,8 +49,8 @@ const CloseButton = styled.button`
   width: 1.5rem;
   height: 1.5rem;
   position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
+  top: 1rem;
+  right: 1rem;
   padding: 0;
   display: flex;
   align-items: center;
@@ -90,10 +90,6 @@ const Paragraph = styled.div`
   margin-bottom: 1rem;
 `
 
-const DiscountInputWrapper = styled.div`
-  margin: 0 -0.5rem;
-`
-
 const Footer = styled.div`
   width: 100%;
   display: flex;
@@ -101,23 +97,6 @@ const Footer = styled.div`
   align-items: center;
   justify-content: center;
   margin-top: 1rem;
-`
-
-const Terms = styled.div`
-  font-size: 0.75rem;
-  line-height: 1rem;
-  text-align: center;
-  color: ${colorsV3.gray700};
-  margin-top: 1rem;
-`
-
-const TermsLink = styled.a`
-  color: ${colorsV3.purple500};
-  text-decoration: none;
-
-  :hover {
-    color: ${colorsV3.purple500};
-  }
 `
 
 const discountSchema = Yup.object({
@@ -194,28 +173,20 @@ export const DiscountCodeModal: React.FC<Props> = ({
         >
           {({ touched, errors, values }) => (
             <Form>
-              <DiscountInputWrapper>
-                <InputField
-                  label={textKeys.SIDEBAR_ADD_DISCOUNT_CELL_LABEL()}
-                  placeholder={textKeys.SIDEBAR_ADD_DISCOUNT_CELL_PLACEHOLDER()}
-                  name="code"
-                  type="text"
-                  autoComplete="off"
-                  touched={touched.code}
-                  errors={errors.code ? textKeys[errors.code]() : ''}
-                />
-              </DiscountInputWrapper>
+              <InputField
+                label={textKeys.SIDEBAR_ADD_DISCOUNT_CELL_LABEL()}
+                placeholder={textKeys.SIDEBAR_ADD_DISCOUNT_CELL_PLACEHOLDER()}
+                name="code"
+                type="text"
+                autoComplete="off"
+                touched={touched.code}
+                errors={errors.code ? textKeys[errors.code]() : ''}
+              />
 
               <Footer>
                 <Button type="submit" fullWidth disabled={!values.code}>
                   {textKeys.SIDEBAR_ADD_DISCOUNT_BUTTON()}
                 </Button>
-                <Terms>
-                  {`${textKeys.SIDEBAR_ADD_DISCOUNT_FINEPRINT()} `}
-                  <TermsLink href="" target="_blank" rel="noreferrer noopener">
-                    {textKeys.SIDEBAR_ADD_DISCOUNT_FINEPRINT_LINK_TEXT()}
-                  </TermsLink>
-                </Terms>
               </Footer>
             </Form>
           )}


### PR DESCRIPTION
## What?

- The section in the Discount Modal with the text about accepting "Terms & Conditions" and a dead link to said T&C's is removed
-  Styling is tweaked since it was affected by the removal

## Why?

The link is dead (the `href` attribute is just set to an empty string) and has been for the entire time I've been working on Hedvig, and it comes up regularly as a bug report. But it's unclear to everyone I've talked to what "Terms & Conditions" we even mean here and why you would need to accept them by adding a discount code 🤷‍♀️ 

_Referenced ticket(s): [GRW-206]_
<!-- If there is a Jira issue, add the id between brackets, and a link to that issue will be created. -->


<!-- Finally, if that makes sense, add screenshots and/or screen recordings below, preferably with headlines and/or descriptions -->

## Screenshots

### currently (with the dead link):
<img width="690" alt="discount-code-modal-missing-link" src="https://user-images.githubusercontent.com/42962286/116376345-7329e280-a810-11eb-92d0-d96554636139.png">
<img width="502" alt="discount-code-modal-missing-link-code" src="https://user-images.githubusercontent.com/42962286/116376351-74f3a600-a810-11eb-9230-b86ee866af76.png">

<br />

### with the changes made in this branch:

**/se**
<img width="828" alt="2021-04-28-dicount-modal-SE" src="https://user-images.githubusercontent.com/42962286/116376529-a4a2ae00-a810-11eb-88ca-184d70ddd168.png">

![2021-04-28-discount-modal-SE](https://user-images.githubusercontent.com/42962286/116378574-8fc71a00-a812-11eb-8919-460d7f270ee2.gif)


**/dk**
<img width="777" alt="2021-04-28-dicount-modal-DK" src="https://user-images.githubusercontent.com/42962286/116376545-a7050800-a810-11eb-9b2d-82c30cabdb5f.png">


[GRW-206]: https://hedvig.atlassian.net/browse/GRW-206