### PR TITLE
Chore / Improved Sentry logging of Underwriting limits hits

### DIFF
--- a/src/client/pages/OfferNew/Checkout/CheckoutContent.tsx
+++ b/src/client/pages/OfferNew/Checkout/CheckoutContent.tsx
@@ -81,7 +81,7 @@ export const CheckoutContent: React.FC<Props> = ({
 
   useUnderwritingLimitsHitReporter(
     editQuoteResult.data?.editQuote?.__typename === 'UnderwritingLimitsHit' &&
-      editQuoteResult.data.editQuote.limits.map((limit) => limit.description),
+      editQuoteResult.data.editQuote.limits.map((limit) => limit.code),
     quoteIds,
   )
 


### PR DESCRIPTION

## What?

<!-- What changes are made? If there are many changes, a list might be a good format. -->

Update what arguments we pass to `useUnderwritingLimitsHitReporter` in `CheckoutContent`.


## Why?

We currently pass an array of the `description` property of the `limits` objects, but that one is deprecated and won't give any info. So it's replaced with to an array of the limits' `code`s.


~_Referenced ticket(s): []_~
<!-- If there is a Jira issue, add the id between brackets, and a link to that issue will be created. -->


<!-- Finally, if that makes sense, add screenshots and/or screen recordings below, preferably with headlines and/or descriptions -->

## Screenshots

**new error**
![image](https://user-images.githubusercontent.com/42962286/116422272-df700a80-a83f-11eb-8681-594032cf116b.png)


**old/current error**
![image](https://user-images.githubusercontent.com/42962286/116422355-f3b40780-a83f-11eb-9c56-63437e421aa0.png)

