### PR TITLE
GRW-281 Truncate overflowing peril titles

### DIFF
--- a/src/client/pages/OfferNew/Perils/PerilModal.tsx
+++ b/src/client/pages/OfferNew/Perils/PerilModal.tsx
@@ -68,11 +68,14 @@ const PickerItem = styled('button')`
 `
 
 const PickerItemLabel = styled('div')`
+  width: 6.25rem;
   font-size: 0.9375rem;
   letter-spacing: -0.23px;
   text-align: center;
   white-space: nowrap;
   color: ${colorsV3.gray700};
+  overflow: hidden;
+  text-overflow: ellipsis;
 `
 
 interface PerilItemsContainerProps {


### PR DESCRIPTION

## What?

Truncate overflowing peril titles


## Why?

Brought up a couple of times in the test session so adding this fix since we won't have time to update the peril modal before the first release.

**Before**
![Screenshot 2021-04-30 at 16 57 47](https://user-images.githubusercontent.com/6661511/116713798-6a363e00-a9d5-11eb-9619-9f2613467f5b.png)

**After**
<img width="967" alt="Screenshot 2021-04-30 at 16 50 38" src="https://user-images.githubusercontent.com/6661511/116713816-6efaf200-a9d5-11eb-877d-ab6f1b7c00ac.png">
