### PR TITLE
Fix / Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,16 @@ $ yarn
 ## Development
 
 ```sh
+# Compile the source files (only needed the first time)
+$ yarn build
+
 # Start the app
 $ yarn watch
 ```
 
 The app is running on `http://localhost:8080`. Visit [http://localhost:8080/se/new-member/](http://localhost:8080/se/new-member/) to view the first screen of the onboarding flow.
+
+> The port might differ on your machine. Check the logs for this message: `Booting server on 8040 👢`.
 
 ## Analytics
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ $ yarn watch
 
 The app is running on `http://localhost:8040`. Visit [http://localhost:8040/se/new-member/](http://localhost:8040/se/new-member/) to view the first screen of the onboarding flow.
 
-> The port might differ on your machine. Check the logs for this message: `Booting server on 8040 👢`.
-
 ## Analytics
 
 We use Segment, Mixpanel and Google Tag Manager as our analytics tools. You can read about the setup in [Notion](https://www.notion.so/hedviginsurance/Mixpanel-Setup-iOS-Web-Embark-d1abeb9ba7634adea6155f847d32cd8d)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ yarn build
 $ yarn watch
 ```
 
-The app is running on `http://localhost:8080`. Visit [http://localhost:8080/se/new-member/](http://localhost:8080/se/new-member/) to view the first screen of the onboarding flow.
+The app is running on `http://localhost:8040`. Visit [http://localhost:8040/se/new-member/](http://localhost:8040/se/new-member/) to view the first screen of the onboarding flow.
 
 > The port might differ on your machine. Check the logs for this message: `Booting server on 8040 👢`.
 
@@ -59,7 +59,7 @@ Text keys live in [Lokalise](https://lokalise.com/) and are exported from there 
 
 This is the process for updating/adding text keys:
 
-1. Make updates to text keys in Lokalise, i.e. add new text keys or update translations. Preferrably we use the Figma/Sketch
+1. Make updates to text keys in Lokalise, i.e. add new text keys or update translations. Preferably we use the Figma/Sketch
     plugin to export text keys and translations directly from design.
 2. Download updates from Lokalise by using `yarn download-translations`
     1. Ensure you have installed  the [Lokalise CLI tool](https://github.com/lokalise/lokalise-cli-2-go)


### PR DESCRIPTION
## What?

Add build step to initial setup in README.

## Why?

The initial build fails since it doesn't find the build/server.js file.