### PR TITLE
Add support for Danish locale in AydenCheckout

### DIFF
--- a/src/client/pages/ConnectPayment/components/AdyenCheckout.tsx
+++ b/src/client/pages/ConnectPayment/components/AdyenCheckout.tsx
@@ -199,9 +199,9 @@ const createAdyenCheckout = ({
 }: AdyenCheckoutProps) => {
   const locale = match([
     ['sv_SE', 'sv-SE'],
-    ['en_SE', 'en-US'],
     ['nb_NO', 'no-NO'],
-    ['en_NO', 'en-US'],
+    ['da_DK', 'da-DK'],
+    [match.any(), 'en-US'],
   ])(getIsoLocale(currentLocale))
 
   const returnUrl = `${window.location.origin}/${currentLocale}/new-member/connect-payment/adyen-callback`
@@ -224,6 +224,9 @@ const createAdyenCheckout = ({
     locale,
     translations: {
       'no-NO': {
+        payButton: payButtonText,
+      },
+      'da-DK': {
         payButton: payButtonText,
       },
       'en-US': {

--- a/src/client/pages/ConnectPayment/components/AdyenCheckout.tsx
+++ b/src/client/pages/ConnectPayment/components/AdyenCheckout.tsx
@@ -198,7 +198,6 @@ const createAdyenCheckout = ({
   },
 }: AdyenCheckoutProps) => {
   const locale = match([
-    ['sv_SE', 'sv-SE'],
     ['nb_NO', 'no-NO'],
     ['da_DK', 'da-DK'],
     [match.any(), 'en-US'],


### PR DESCRIPTION
## What?

Add support for Danish locale in AydenCheckout component.
Make en-US default locale.

![Screenshot 2021-05-04 at 11 12 56](https://user-images.githubusercontent.com/1220232/116984920-19bc2a80-accc-11eb-912f-68c4858a75ff.png)

(We haven't figured out how to localize "Credit Card" label...)