### PR TITLE
Remove home-accident-travel bundle route (DK)

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -15,6 +15,23 @@ import { LoginApp } from './client/pages/LoginApp'
 import { OfferNew } from './client/pages/OfferNew'
 import { SignLoading } from './client/pages/SignLoading'
 
+enum EmbarkStory {
+  DenmarkContents = 'Web Onboarding DK - Contents',
+  DenmarkContentsAccident = 'Web Onboarding DK - Danish Contents-Accident',
+
+  NorwayContentsNorwegian = 'Web Onboarding NO - Norwegian Contents',
+  NorwayContentsEnglish = 'Web Onboarding NO - English Contents',
+  NorwayTravelNorwegian = 'Web Onboarding NO - Norwegian Travel',
+  NorwayTravelEnglish = 'Web Onboarding NO - English Travel',
+  NorwayComboNorwegian = 'Web Onboarding NO - Norwegian Combo',
+  NorwayComboEnglish = 'Web Onboarding NO - English Combo',
+
+  SwedenNeederSwedish = 'Web Onboarding - Swedish Needer',
+  SwedenNeederEnglish = 'Web Onboarding - English Needer',
+  SwedenSwitcherSwedish = 'Web Onboarding - Swedish Switcher',
+  SwedenSwitcherEnglish = 'Web Onboarding - English Switcher',
+}
+
 export interface ServerSideRoute {
   path: string | RegExp
   titleTextKey: string
@@ -162,12 +179,12 @@ export const reactPageRoutes: ReactPageRoute[] = [
               case 'home':
                 return {
                   baseUrl: `/${locale}/new-member/home`,
-                  name: 'Web Onboarding DK - Contents',
+                  name: EmbarkStory.DenmarkContents,
                 }
               case 'home-accident':
                 return {
                   baseUrl: `/${locale}/new-member/home-accident`,
-                  name: 'Web Onboarding DK - Danish Contents-Accident',
+                  name: EmbarkStory.DenmarkContentsAccident,
                 }
             }
             break
@@ -177,23 +194,26 @@ export const reactPageRoutes: ReactPageRoute[] = [
               case 'contents':
                 return {
                   baseUrl: `/${locale}/new-member/contents`,
-                  name: `Web Onboarding NO - ${
-                    locale === 'no' ? 'Norwegian Contents' : 'English Contents'
-                  }`,
+                  name:
+                    locale === 'no'
+                      ? EmbarkStory.NorwayContentsNorwegian
+                      : EmbarkStory.NorwayContentsEnglish,
                 }
               case 'travel':
                 return {
                   baseUrl: `/${locale}/new-member/travel`,
-                  name: `Web Onboarding NO - ${
-                    locale === 'no' ? 'Norwegian Travel' : 'English Travel'
-                  }`,
+                  name:
+                    locale === 'no'
+                      ? EmbarkStory.NorwayTravelNorwegian
+                      : EmbarkStory.NorwayTravelEnglish,
                 }
               case 'combo':
                 return {
                   baseUrl: `/${locale}/new-member/combo`,
-                  name: `Web Onboarding NO - ${
-                    locale === 'no' ? 'Norwegian Combo' : 'English Combo'
-                  }`,
+                  name:
+                    locale === 'no'
+                      ? EmbarkStory.NorwayComboNorwegian
+                      : EmbarkStory.NorwayComboEnglish,
                 }
             }
             break
@@ -203,16 +223,18 @@ export const reactPageRoutes: ReactPageRoute[] = [
               case 'new':
                 return {
                   baseUrl: `/${locale}/new-member/new`,
-                  name: `Web Onboarding - ${
-                    locale === 'se' ? 'Swedish Needer' : 'English Needer'
-                  }`,
+                  name:
+                    locale === 'no'
+                      ? EmbarkStory.SwedenNeederSwedish
+                      : EmbarkStory.SwedenNeederEnglish,
                 }
               case 'switch':
                 return {
                   baseUrl: `/${locale}/new-member/switch`,
-                  name: `Web Onboarding - ${
-                    locale === 'se' ? 'Swedish Switcher' : 'English Switcher'
-                  }`,
+                  name:
+                    locale === 'no'
+                      ? EmbarkStory.SwedenSwitcherSwedish
+                      : EmbarkStory.SwedenSwitcherEnglish,
                 }
             }
             break

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -169,84 +169,53 @@ export const reactPageRoutes: ReactPageRoute[] = [
                   baseUrl: `/${locale}/new-member/home-accident`,
                   name: 'Web Onboarding DK - Danish Contents-Accident',
                 }
-              case 'home-accident-travel':
-                return {
-                  baseUrl: `/${locale}/new-member/home-accident-travel`,
-                  name: 'Web Onboarding DK - Danish Contents-Accident-Travel',
-                }
             }
             break
           case 'no':
-            switch (name) {
-              case 'contents':
-                return {
-                  baseUrl: '/no/new-member/contents',
-                  name: 'Web Onboarding NO - Norwegian Contents',
-                }
-              case 'travel':
-                return {
-                  baseUrl: '/no/new-member/travel',
-                  name: 'Web Onboarding NO - Norwegian Travel',
-                }
-              case 'combo':
-                return {
-                  baseUrl: '/no/new-member/combo',
-                  name: 'Web Onboarding NO - Norwegian Combo',
-                }
-            }
-            break
           case 'no-en':
             switch (name) {
               case 'contents':
                 return {
-                  baseUrl: '/no-en/new-member/contents',
-                  name: 'Web Onboarding NO - English Contents',
+                  baseUrl: `/${locale}/new-member/contents`,
+                  name: `Web Onboarding NO - ${
+                    locale === 'no' ? 'Norwegian Contents' : 'English Contents'
+                  }`,
                 }
               case 'travel':
                 return {
-                  baseUrl: '/no-en/new-member/travel',
-                  name: 'Web Onboarding NO - English Travel',
+                  baseUrl: `/${locale}/new-member/travel`,
+                  name: `Web Onboarding NO - ${
+                    locale === 'no' ? 'Norwegian Travel' : 'English Travel'
+                  }`,
                 }
               case 'combo':
                 return {
-                  baseUrl: '/no-en/new-member/combo',
-                  name: 'Web Onboarding NO - English Combo',
+                  baseUrl: `/${locale}/new-member/combo`,
+                  name: `Web Onboarding NO - ${
+                    locale === 'no' ? 'Norwegian Combo' : 'English Combo'
+                  }`,
                 }
             }
             break
+          case 'se':
           case 'se-en':
             switch (name) {
               case 'new':
                 return {
-                  baseUrl: '/se-en/new-member/new',
-                  name: 'Web Onboarding - English Needer',
+                  baseUrl: `/${locale}/new-member/new`,
+                  name: `Web Onboarding - ${
+                    locale === 'se' ? 'Swedish Needer' : 'English Needer'
+                  }`,
                 }
               case 'switch':
                 return {
-                  baseUrl: '/se-en/new-member/switch',
-                  name: 'Web Onboarding - English Switcher',
+                  baseUrl: `/${locale}/new-member/switch`,
+                  name: `Web Onboarding - ${
+                    locale === 'se' ? 'Swedish Switcher' : 'English Switcher'
+                  }`,
                 }
             }
             break
-          default:
-            switch (name) {
-              case 'new':
-                return {
-                  baseUrl: '/se/new-member/new',
-                  name: 'Web Onboarding - Swedish Needer',
-                }
-              case 'switch':
-                return {
-                  baseUrl: '/se/new-member/switch',
-                  name: 'Web Onboarding - Swedish Switcher',
-                }
-              // TODO: Remove this or? 👇
-              case 'switch-beta':
-                return {
-                  baseUrl: '/se/new-member/switch-beta',
-                  name: 'Switcher Onboarding Playground',
-                }
-            }
         }
 
         return null
@@ -257,8 +226,8 @@ export const reactPageRoutes: ReactPageRoute[] = [
       return (
         <EmbarkRoot
           language={match.params.locale}
-          name={(props && props.name) || undefined}
-          baseUrl={(props && props.baseUrl) || undefined}
+          name={props?.name}
+          baseUrl={props?.baseUrl}
           showLanding={!props}
         />
       )

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { RouteComponentProps } from 'react-router'
+import { Redirect, RouteComponentProps } from 'react-router'
 
 import { LOCALE_PATH_PATTERN } from 'shared/locale'
 import { ConnectPayment } from './client/pages/ConnectPayment'
@@ -168,7 +168,19 @@ export const reactPageRoutes: ReactPageRoute[] = [
     exact: true,
   },
   {
-    path: LOCALE_PATH_PATTERN + '/new-member/:name?/:id?',
+    path: LOCALE_PATH_PATTERN + '/new-member',
+    render: ({ match }: RouteComponentProps<any>) => (
+      <EmbarkRoot
+        language={match.params.locale}
+        name={undefined}
+        baseUrl={undefined}
+        showLanding={true}
+      />
+    ),
+    exact: true,
+  },
+  {
+    path: LOCALE_PATH_PATTERN + '/new-member/:name/:id?',
     render: ({ match }: RouteComponentProps<any>) => {
       const getProps = () => {
         const { locale, name } = match.params
@@ -245,12 +257,15 @@ export const reactPageRoutes: ReactPageRoute[] = [
 
       const props = getProps()
 
+      if (props === null) {
+        return <Redirect to={`/${match.params.locale}/new-member`} />
+      }
+
       return (
         <EmbarkRoot
           language={match.params.locale}
-          name={props?.name}
-          baseUrl={props?.baseUrl}
-          showLanding={!props}
+          name={props.name}
+          baseUrl={props.baseUrl}
         />
       )
     },

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -236,7 +236,7 @@ export const reactPageRoutes: ReactPageRoute[] = [
                 return {
                   baseUrl: `/${locale}/new-member/new`,
                   name:
-                    locale === 'no'
+                    locale === 'se'
                       ? EmbarkStory.SwedenNeederSwedish
                       : EmbarkStory.SwedenNeederEnglish,
                 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -244,7 +244,7 @@ export const reactPageRoutes: ReactPageRoute[] = [
                 return {
                   baseUrl: `/${locale}/new-member/switch`,
                   name:
-                    locale === 'no'
+                    locale === 'se'
                       ? EmbarkStory.SwedenSwitcherSwedish
                       : EmbarkStory.SwedenSwitcherEnglish,
                 }


### PR DESCRIPTION
## What?

Remove home-accident-travel bundle route for DK.
Combine no + no-en embark routes.
Use optional chaining to access props.
Redirect to landing page for URLs that don't match existing offers.

_Referenced ticket(s): [GRW-294]_

## Why?

Will not go live with that offer.

[GRW-294]: https://hedvig.atlassian.net/browse/GRW-294