### PR TITLE
Add support for danish in Forever language picker

### DIFF
--- a/src/client/pages/Embark/languagePickerData.ts
+++ b/src/client/pages/Embark/languagePickerData.ts
@@ -7,24 +7,56 @@ const LANGUAGE_TITLES = {
   danish: 'Dansk',
 }
 
+const SHORT_LANGUAGE_TITLES = {
+  english: 'En',
+  swedish: 'Sv',
+  norwegian: 'No',
+  danish: 'Da',
+}
+
 type Options = {
   linkTo: LocalePath
   title: string
+  shortTitle: string
 }[]
 
 type LanguagePickerData = Record<Market, Options>
 
 export const languagePickerData: LanguagePickerData = {
   SE: [
-    { linkTo: 'se', title: LANGUAGE_TITLES.swedish },
-    { linkTo: 'se-en', title: LANGUAGE_TITLES.english },
+    {
+      linkTo: 'se',
+      title: LANGUAGE_TITLES.swedish,
+      shortTitle: SHORT_LANGUAGE_TITLES.swedish,
+    },
+    {
+      linkTo: 'se-en',
+      title: LANGUAGE_TITLES.english,
+      shortTitle: SHORT_LANGUAGE_TITLES.english,
+    },
   ],
   NO: [
-    { linkTo: 'no', title: LANGUAGE_TITLES.norwegian },
-    { linkTo: 'no-en', title: LANGUAGE_TITLES.english },
+    {
+      linkTo: 'no',
+      title: LANGUAGE_TITLES.norwegian,
+      shortTitle: SHORT_LANGUAGE_TITLES.norwegian,
+    },
+    {
+      linkTo: 'no-en',
+      title: LANGUAGE_TITLES.english,
+      shortTitle: SHORT_LANGUAGE_TITLES.english,
+    },
   ],
   DK: [
-    { linkTo: 'dk', title: LANGUAGE_TITLES.danish },
-    { linkTo: 'dk-en', title: LANGUAGE_TITLES.english },
+    {
+      linkTo: 'dk',
+      title: LANGUAGE_TITLES.danish,
+      shortTitle: SHORT_LANGUAGE_TITLES.danish,
+    },
+    {
+      linkTo: 'dk-en',
+      title: LANGUAGE_TITLES.english,
+      shortTitle: SHORT_LANGUAGE_TITLES.english,
+    },
   ],
 }

--- a/src/client/pages/Forever/components/LanguagePicker.tsx
+++ b/src/client/pages/Forever/components/LanguagePicker.tsx
@@ -38,19 +38,14 @@ export const LanguagePicker: React.FC = () => {
 
   return (
     <LanguagePickerWrapper>
-      {languagePickerData[market]
-        .map((item) => (
-          <Language key={item.linkTo} to={`/${item.linkTo}/forever/${code}`}>
+      {languagePickerData[market].map((item, index) => (
+        <React.Fragment key={item.linkTo}>
+          {index !== 0 && <Divider />}
+          <Language to={`/${item.linkTo}/forever/${code}`}>
             {item.shortTitle}
           </Language>
-        ))
-        .reduce((prevOptions, option) => (
-          <>
-            {prevOptions}
-            <Divider />
-            {option}
-          </>
-        ))}
+        </React.Fragment>
+      ))}
     </LanguagePickerWrapper>
   )
 }

--- a/src/client/pages/Forever/components/LanguagePicker.tsx
+++ b/src/client/pages/Forever/components/LanguagePicker.tsx
@@ -3,7 +3,8 @@ import { colorsV3 } from '@hedviginsurance/brand'
 import React from 'react'
 import { useParams } from 'react-router'
 import { NavLink } from 'react-router-dom'
-import { Market, useMarket } from 'components/utils/CurrentLocale'
+import { useMarket } from 'components/utils/CurrentLocale'
+import { languagePickerData } from '../../Embark/languagePickerData'
 
 const LanguagePickerWrapper = styled.div`
   display: flex;
@@ -35,20 +36,21 @@ export const LanguagePicker: React.FC = () => {
   const urlParams: { locale: string; code?: string } = useParams()
   const code = urlParams.code ? urlParams.code : ''
 
-  if (market === Market.No) {
-    return (
-      <LanguagePickerWrapper>
-        <Language to={`/no/forever/${code}`}>No</Language>
-        <Divider />
-        <Language to={`/no-en/forever/${code}`}>En</Language>
-      </LanguagePickerWrapper>
-    )
-  }
   return (
     <LanguagePickerWrapper>
-      <Language to={`/se/forever/${code}`}>Sv</Language>
-      <Divider />
-      <Language to={`/se-en/forever/${code}`}>En</Language>
+      {languagePickerData[market]
+        .map((item) => (
+          <Language key={item.linkTo} to={`/${item.linkTo}/forever/${code}`}>
+            {item.shortTitle}
+          </Language>
+        ))
+        .reduce((prevOptions, option) => (
+          <>
+            {prevOptions}
+            <Divider />
+            {option}
+          </>
+        ))}
     </LanguagePickerWrapper>
   )
 }


### PR DESCRIPTION
## What?

Centralize language options by market.
Dynamically render language options on "Forever" page.

## Why?

This change was missed likely because we have two isolated language pickers. So I thought it made sense to centralize the language options so when we add the next language we only need to do it in one place.

Perhaps these changes should be moved to the `locales.ts` module @styrelius is working on.