### PR TITLE
Reverse order of symbol and label in Card component

### DIFF
--- a/src/client/pages/Landing/components/Card.stories.tsx
+++ b/src/client/pages/Landing/components/Card.stories.tsx
@@ -10,7 +10,7 @@ export default {
 export const Enabled = () => (
   <MemoryRouter initialEntries={['/se/new-member']}>
     <Card to="/se/new-member/offer-1" badge="Best value" key="offer-1">
-      <h1>Home contents & Accident</h1>
+      <h1>Home Contents & Accident</h1>
     </Card>
   </MemoryRouter>
 )
@@ -18,7 +18,15 @@ export const Enabled = () => (
 export const Disabled = () => (
   <MemoryRouter initialEntries={['/se/new-member']}>
     <Card to="" badge="Coming soon" disabled={true} key="offer-2">
-      <h1>Home contents</h1>
+      <h1>Home Contents</h1>
+    </Card>
+  </MemoryRouter>
+)
+
+export const NoBadge = () => (
+  <MemoryRouter initialEntries={['/se/new-member']}>
+    <Card to="/se/new-member/offer-3" key="offer-3">
+      <h1>Home Contents, Accident & Travel</h1>
     </Card>
   </MemoryRouter>
 )

--- a/src/client/pages/Landing/components/Card.tsx
+++ b/src/client/pages/Landing/components/Card.tsx
@@ -80,6 +80,7 @@ const CardHeader = styled.div`
   }
 
   @media (min-width: 1020px) {
+    flex-direction: row-reverse;
     padding-bottom: 3rem;
     svg {
       display: block;

--- a/src/client/pages/Landing/components/Card.tsx
+++ b/src/client/pages/Landing/components/Card.tsx
@@ -71,6 +71,7 @@ const CardHeader = styled.div`
   min-height: 1.5rem;
   padding-bottom: 0.5rem;
 
+  /* HedvigSymbol */
   svg {
     display: none;
   }
@@ -80,12 +81,14 @@ const CardHeader = styled.div`
   }
 
   @media (min-width: 1020px) {
-    flex-direction: row-reverse;
     padding-bottom: 3rem;
+
+    /* HedvigSymbol */
     svg {
       display: block;
       width: 1.5rem;
       height: 1.5rem;
+      margin-left: auto;
     }
   }
 `
@@ -134,12 +137,12 @@ export const Card: React.FC<{
     <>
       <CardContainer disabled={disabled} to={to}>
         <CardHeader>
-          <HedvigSymbol size="1.25rem" />
           {badge && (
             <Badge disabled={disabled} size="lg">
               {badge}
             </Badge>
           )}
+          <HedvigSymbol size="1.25rem" />
         </CardHeader>
         <CardContent>{children}</CardContent>
         {!disabled && (


### PR DESCRIPTION
## What?

Add new Card story without badge.
Reverse flex direction in CardHeader on large viewports.

## Why?

This was the easiest way to accomplish it. Not sure if it's a good or bad idea 😅

![Screenshot 2021-05-06 at 16 01 03](https://user-images.githubusercontent.com/1220232/117352938-dcb08d80-aeaf-11eb-92a6-eea319a21c9e.png)

![Screenshot 2021-05-06 at 16 00 56](https://user-images.githubusercontent.com/1220232/117352935-dc17f700-aeaf-11eb-9c9f-456e1463ef9b.png)

