### PR TITLE
Fix / Danish T&C links

### DIFF
--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
@@ -30,8 +30,11 @@ type GetUrlParams = {
 }
 
 const getUrl = ({ currentLocale, termType, urlFromBackend }: GetUrlParams) => {
-  const temporaryTermsLink = getTemporaryTermsLink(currentLocale)
-  // 👆 This link is temporary since we can't get the correct ones from content-service right now
+  const temporaryTermsLink = getTemporaryTermsLink({
+    currentLocale,
+    urlFromBackend,
+  })
+  // 👆 This is temporary since we can't get the correct ones from back-end for all markets right now
 
   if (termType === 'TERMS_AND_CONDITIONS') {
     return temporaryTermsLink

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
@@ -5,7 +5,7 @@ import { InsuranceTerm, InsuranceTermType } from 'data/graphql'
 import { useCurrentLocale } from 'components/utils/CurrentLocale'
 import { OfferData, OfferQuote } from '../types'
 import { checkIfMainQuote } from '../utils'
-import { getTermsLink } from '../Perils/InsuranceValues'
+import { getTemporaryTermsLink } from '../Perils/InsuranceValues'
 import { Group, Row } from './InsuranceSummary'
 
 const linkColor = colorsV3.gray700
@@ -30,7 +30,7 @@ type GetUrlParams = {
 }
 
 const getUrl = ({ currentLocale, termType, urlFromBackend }: GetUrlParams) => {
-  const temporaryTermsLink = getTermsLink(currentLocale)
+  const temporaryTermsLink = getTemporaryTermsLink(currentLocale)
   // 👆 This link is temporary since we can't get the correct ones from content-service right now
 
   if (termType === 'TERMS_AND_CONDITIONS') {

--- a/src/client/pages/OfferNew/Perils/InsuranceValues/index.tsx
+++ b/src/client/pages/OfferNew/Perils/InsuranceValues/index.tsx
@@ -70,9 +70,18 @@ const Link = styled.a`
   }
 `
 
-export const getTemporaryTermsLink = (currentLocale: string) => {
+type GetTemporaryTermsLinkParams = {
+  currentLocale: string
+  urlFromBackend: string
+}
+
+export const getTemporaryTermsLink = ({
+  currentLocale,
+  urlFromBackend,
+}: GetTemporaryTermsLinkParams) => {
   const baseUrl = 'https://www.hedvig.com'
 
+  // 👇 The hard coded urls are temporary since we don't get the correct ones from back-end for all markets right now
   switch (currentLocale) {
     case 'se':
       return `${baseUrl}/${currentLocale}/villkor`
@@ -82,6 +91,9 @@ export const getTemporaryTermsLink = (currentLocale: string) => {
       return `${baseUrl}/${currentLocale}/terms`
     case 'no-en':
       return `${baseUrl}/${currentLocale}/terms`
+    case 'dk':
+    case 'dk-en':
+      return urlFromBackend
     default:
       return `${baseUrl}/${currentLocale}/404`
   }
@@ -95,9 +107,6 @@ export const InsuranceValues: React.FC<Props> = ({ offerQuote }) => {
   const textKeys = useTextKeys()
 
   const currentLocale = useCurrentLocale()
-
-  const temporaryTermsLink = getTemporaryTermsLink(currentLocale)
-  // 👆 This link is only temporary since we can't get the correct ones from content-service right now
 
   return (
     <Wrapper>
@@ -116,7 +125,10 @@ export const InsuranceValues: React.FC<Props> = ({ offerQuote }) => {
                 key={insuranceTermType}
                 href={
                   insuranceTermType === InsuranceTermType.TermsAndConditions
-                    ? temporaryTermsLink
+                    ? getTemporaryTermsLink({
+                        currentLocale,
+                        urlFromBackend: insuranceTerm.url,
+                      })
                     : insuranceTerm.url
                 }
                 target="_blank"

--- a/src/client/pages/OfferNew/Perils/InsuranceValues/index.tsx
+++ b/src/client/pages/OfferNew/Perils/InsuranceValues/index.tsx
@@ -70,7 +70,7 @@ const Link = styled.a`
   }
 `
 
-export const getTermsLink = (currentLocale: string) => {
+export const getTemporaryTermsLink = (currentLocale: string) => {
   const baseUrl = 'https://www.hedvig.com'
 
   switch (currentLocale) {
@@ -96,7 +96,7 @@ export const InsuranceValues: React.FC<Props> = ({ offerQuote }) => {
 
   const currentLocale = useCurrentLocale()
 
-  const temporaryTermsLink = getTermsLink(currentLocale)
+  const temporaryTermsLink = getTemporaryTermsLink(currentLocale)
   // 👆 This link is only temporary since we can't get the correct ones from content-service right now
 
   return (


### PR DESCRIPTION
## What?

<!-- What changes are made? If there are many changes, a list might be a good format. -->
- `/dk` and `/dk-en` are added to switch statement in `getTemporaryTermsLink` function (FKA `getTermsLink`) in `/InsuranceValues/index.tsx`
- In order to be able to return the url we get from back-end (since for Denmark we actually get the correct ones) in `getTemporaryTermsLink`, a `urlFromBackend` parameter is added to it


## Why?

Apparently Danes need T&C's too 😄 


_Referenced ticket(s): [GRW-305]_
<!-- If there is a Jira issue, add the id between brackets, and a link to that issue will be created. -->


<!-- Finally, if that makes sense, add screenshots and/or screen recordings below, preferably with headlines and/or descriptions -->

## Screen recording

_clicking all the T&C links for **/dk** and **/dk-en**:_

https://user-images.githubusercontent.com/42962286/117447021-3d39dc00-af3d-11eb-9893-c5a573b633a2.mp4





[GRW-305]: https://hedvig.atlassian.net/browse/GRW-305