### PR TITLE
Fit `Card` headline on single line (as much as possible)

### DIFF
--- a/src/client/pages/Landing/Landing.tsx
+++ b/src/client/pages/Landing/Landing.tsx
@@ -15,7 +15,7 @@ import { useTextKeys } from 'utils/textKeys'
 import { CheckmarkCircle } from 'components/icons/CheckmarkCircle'
 import { LanguagePicker } from '../Embark/LanguagePicker'
 import { alternateLinksData, productsData } from './landingPageData'
-import { Card } from './components/Card'
+import { Card, CardHeadline, CardParagraph } from './components/Card'
 
 const LandingPageContainer = styled.div`
   position: relative;
@@ -139,43 +139,6 @@ const CardContainer = styled.div`
 
   @media (min-width: 1020px) {
     width: 100%;
-  }
-`
-
-const CardHeadline = styled.h2<{ disabled?: boolean }>`
-  width: 100%;
-  margin: 0;
-  font-size: 1.25rem;
-  line-height: 1.2;
-  color: ${(props) => (props.disabled ? colorsV3.gray500 : colorsV3.gray900)};
-
-  @media (min-width: 500px) {
-    margin-bottom: 0.25rem;
-    font-size: 1.5rem;
-    line-height: 1.25;
-  }
-
-  @media (min-width: 850px) {
-    max-width: 13ch;
-    font-size: 2rem;
-    letter-spacing: -0.02em;
-  }
-`
-
-const CardParagraph = styled.p`
-  margin: 0;
-  font-size: 1rem;
-  line-height: 1.5;
-  color: ${colorsV3.gray500};
-
-  @media (min-width: 850px) {
-    max-width: 20ch;
-    font-size: 1.125rem;
-  }
-
-  @media (min-width: 1020px) {
-    font-size: 1.5rem;
-    letter-spacing: -0.02em;
   }
 `
 

--- a/src/client/pages/Landing/Landing.tsx
+++ b/src/client/pages/Landing/Landing.tsx
@@ -135,10 +135,18 @@ const CardContainer = styled.div`
   @media (min-width: 850px) {
     display: flex;
     justify-content: center;
+
+    > * + * {
+      margin-left: 1rem;
+    }
   }
 
   @media (min-width: 1020px) {
     width: 100%;
+
+    > * + * {
+      margin-left: 1.5rem;
+    }
   }
 `
 

--- a/src/client/pages/Landing/components/Card.stories.tsx
+++ b/src/client/pages/Landing/components/Card.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
-import { Card } from './Card'
+import { Card, CardHeadline, CardParagraph } from './Card'
 
 export default {
   title: 'Landing/Card',
@@ -10,7 +10,8 @@ export default {
 export const Enabled = () => (
   <MemoryRouter initialEntries={['/se/new-member']}>
     <Card to="/se/new-member/offer-1" badge="Best value" key="offer-1">
-      <h1>Home Contents & Accident</h1>
+      <CardHeadline>Home Contents & Accident</CardHeadline>
+      <CardParagraph>Get both of them</CardParagraph>
     </Card>
   </MemoryRouter>
 )
@@ -18,7 +19,8 @@ export const Enabled = () => (
 export const Disabled = () => (
   <MemoryRouter initialEntries={['/se/new-member']}>
     <Card to="" badge="Coming soon" disabled={true} key="offer-2">
-      <h1>Home Contents</h1>
+      <CardHeadline>Home Contents</CardHeadline>
+      <CardParagraph>Available soon</CardParagraph>
     </Card>
   </MemoryRouter>
 )
@@ -26,7 +28,8 @@ export const Disabled = () => (
 export const NoBadge = () => (
   <MemoryRouter initialEntries={['/se/new-member']}>
     <Card to="/se/new-member/offer-3" key="offer-3">
-      <h1>Home Contents, Accident & Travel</h1>
+      <CardHeadline>Home Contents, Accident & Travel</CardHeadline>
+      <CardParagraph>Get your price</CardParagraph>
     </Card>
   </MemoryRouter>
 )

--- a/src/client/pages/Landing/components/Card.tsx
+++ b/src/client/pages/Landing/components/Card.tsx
@@ -76,7 +76,7 @@ const CardHeader = styled.div`
     display: none;
   }
 
-  @media (min-height: 620px) {
+  @media (min-height: 600px) {
     padding-bottom: 1rem;
   }
 
@@ -93,27 +93,31 @@ const CardHeader = styled.div`
   }
 `
 
-const CardContent = styled.div`
-  padding-right: 2rem;
-`
+const CardContent = styled.div``
 
 const CardLink = CardComponent.withComponent(Link)
 
 const ArrowWrapper = styled.span`
   position: absolute;
   right: 1.25rem;
-  bottom: 1.25rem;
+  bottom: 0.8rem;
 
   @media (min-width: 600px) {
     right: 1.5rem;
-    bottom: 2rem;
+    bottom: 0.7rem;
+
     svg {
       font-size: 1.75rem;
     }
   }
 
+  @media (min-width: 600px) {
+    bottom: 1.2rem;
+  }
+
   @media (min-width: 1020px) {
     right: 2rem;
+    bottom: 2rem;
   }
 `
 
@@ -128,11 +132,58 @@ const CardContainer: React.FC<{
   )
 }
 
-export const Card: React.FC<{
+export const CardHeadline = styled.h2<{ disabled?: boolean }>`
+  width: 100%;
+  margin: 0;
+  font-size: 1.25rem;
+  line-height: 1.2;
+  color: ${(props) => (props.disabled ? colorsV3.gray500 : colorsV3.gray900)};
+
+  @media (min-width: 600px) {
+    margin-bottom: 0.25rem;
+    font-size: 1.5rem;
+    line-height: 1.25;
+  }
+
+  @media (min-width: 1020px) {
+    font-size: 1.9rem;
+    letter-spacing: -0.02em;
+  }
+`
+
+export const CardParagraph = styled.p`
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: ${colorsV3.gray500};
+
+  @media (min-width: 600px) {
+    font-size: 1.125rem;
+  }
+
+  @media (min-width: 850px) {
+    max-width: 25ch;
+  }
+
+  @media (min-width: 1020px) {
+    font-size: 1.5rem;
+    letter-spacing: -0.02em;
+    max-width: 21ch;
+  }
+`
+
+interface Props {
   to: string
   badge?: string
   disabled?: boolean
-}> = ({ badge, to, children, disabled = false }) => {
+}
+
+export const Card: React.FC<Props> = ({
+  badge,
+  to,
+  children,
+  disabled = false,
+}) => {
   return (
     <>
       <CardContainer disabled={disabled} to={to}>

--- a/src/client/pages/Landing/components/Card.tsx
+++ b/src/client/pages/Landing/components/Card.tsx
@@ -76,7 +76,7 @@ const CardHeader = styled.div`
     display: none;
   }
 
-  @media (min-height: 600px) {
+  @media (min-height: 620px) {
     padding-bottom: 1rem;
   }
 
@@ -121,17 +121,6 @@ const ArrowWrapper = styled.span`
   }
 `
 
-const CardContainer: React.FC<{
-  disabled: boolean
-  to: string
-}> = ({ children, disabled, to }) => {
-  return disabled ? (
-    <CardComponent disabled={disabled}>{children}</CardComponent>
-  ) : (
-    <CardLink to={to}>{children}</CardLink>
-  )
-}
-
 export const CardHeadline = styled.h2<{ disabled?: boolean }>`
   width: 100%;
   margin: 0;
@@ -171,6 +160,17 @@ export const CardParagraph = styled.p`
     max-width: 21ch;
   }
 `
+
+const CardContainer: React.FC<{
+  disabled: boolean
+  to: string
+}> = ({ children, disabled, to }) => {
+  return disabled ? (
+    <CardComponent disabled={disabled}>{children}</CardComponent>
+  ) : (
+    <CardLink to={to}>{children}</CardLink>
+  )
+}
 
 interface Props {
   to: string

--- a/src/client/pages/Landing/components/Card.tsx
+++ b/src/client/pages/Landing/components/Card.tsx
@@ -32,14 +32,11 @@ const CardComponent = styled.div<{ disabled?: boolean }>`
     flex-direction: column;
     justify-content: space-between;
     max-width: 28rem;
-    margin: 0 0.5rem 1rem;
     padding: 1.5rem;
   }
 
   @media (min-width: 1020px) {
     justify-content: space-between;
-    margin-right: 0.75rem;
-    margin-left: 0.75rem;
     padding: 2rem;
     border-radius: 0.75rem;
   }


### PR DESCRIPTION
## What?

Group card components in same module.
Update Card stories with proper text components.
Unify breakpoints in card component.
Align arrow icon with paragraph text.
Make headline text slightly smaller on large screens.

## Why?

To fit the card headlines on a single line (for native market languages at least).

I grouped all the components together since they are now so linked in the layout.

<!-- Finally, if that makes sense, add screenshots and/or screen recordings below, preferably with headlines and/or descriptions -->

## Sweden

![Screenshot 2021-05-10 at 12 08 31](https://user-images.githubusercontent.com/1220232/117643875-2c7da600-b189-11eb-98aa-8b977b79ebb2.png)

![Screenshot 2021-05-10 at 12 08 24](https://user-images.githubusercontent.com/1220232/117643872-2be50f80-b189-11eb-9475-b23fa6631686.png)

## Norway

![Screenshot 2021-05-10 at 12 08 42](https://user-images.githubusercontent.com/1220232/117643909-369fa480-b189-11eb-937c-79497959ec8f.png)

![Screenshot 2021-05-10 at 12 08 47](https://user-images.githubusercontent.com/1220232/117643916-37383b00-b189-11eb-9f79-9ea034a211e4.png)

## Denmark

![Screenshot 2021-05-10 at 12 08 53](https://user-images.githubusercontent.com/1220232/117643974-46b78400-b189-11eb-8c47-203dacbe8b13.png)

![Screenshot 2021-05-10 at 12 09 02](https://user-images.githubusercontent.com/1220232/117643980-47501a80-b189-11eb-9b4d-36f9f0a230d8.png)

## Mobile

![Screenshot 2021-05-10 at 12 09 48](https://user-images.githubusercontent.com/1220232/117644006-4dde9200-b189-11eb-9cdb-95b3ad113b69.png)

## Tablet

![Screenshot 2021-05-10 at 12 10 09](https://user-images.githubusercontent.com/1220232/117644028-559e3680-b189-11eb-99b3-3dd23e6e1b04.png)
