### PR TITLE
Conditional rendering for Insurable limits tooltip

### DIFF
--- a/src/client/pages/OfferNew/Perils/InsuranceValues/Limits.tsx
+++ b/src/client/pages/OfferNew/Perils/InsuranceValues/Limits.tsx
@@ -81,10 +81,11 @@ export const Limits: React.FC<Props> = ({ insurableLimits }) => {
                 <Label>{insurableLimit.label}</Label>
                 <Value>{insurableLimit.limit}</Value>
               </TextContainer>
-
-              <TooltipWrapper>
-                <Tooltip size="lg" body={insurableLimit.description} />
-              </TooltipWrapper>
+              {insurableLimit.description && (
+                <TooltipWrapper>
+                  <Tooltip size="lg" body={insurableLimit.description} />
+                </TooltipWrapper>
+              )}
             </Container>
           )
         },


### PR DESCRIPTION
## What?

Don't show empty tooltips

![Screenshot 2021-05-10 at 13 32 32](https://user-images.githubusercontent.com/6661511/117653111-5092b480-b194-11eb-9b2a-4fbc35944625.png)
