### PR TITLE
GRW-293 - track DK bundles

### DIFF
--- a/src/client/pages/OfferNew/utils.ts
+++ b/src/client/pages/OfferNew/utils.ts
@@ -168,6 +168,9 @@ export const isDanishAccidentBundle = (offerData: OfferData): boolean =>
 export const isDanishTravelBundle = (offerData: OfferData): boolean =>
   isDanish(offerData) && offerData.quotes.length === 3
 
+export const isStudentOffer = (offerData: OfferData): boolean =>
+  offerData.quotes.every((quote) => isStudent(quote.quoteDetails))
+
 export const hasAddress = (offerData: OfferData): boolean =>
   !!offerData.person.address
 

--- a/src/client/pages/OfferNew/utils.ts
+++ b/src/client/pages/OfferNew/utils.ts
@@ -162,6 +162,12 @@ export const isDanishQuote = (quote: OfferQuote): boolean =>
 export const isDanish = (offerData: OfferData): boolean =>
   offerData.quotes.every((quote) => isDanishQuote(quote))
 
+export const isDanishAccidentBundle = (offerData: OfferData): boolean =>
+  isDanish(offerData) && offerData.quotes.length === 2
+
+export const isDanishTravelBundle = (offerData: OfferData): boolean =>
+  isDanish(offerData) && offerData.quotes.length === 3
+
 export const hasAddress = (offerData: OfferData): boolean =>
   !!offerData.person.address
 

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -1,9 +1,9 @@
 import { TypeOfContract } from 'data/graphql'
 import { OfferData } from 'pages/OfferNew/types'
 import { captureSentryError } from 'utils/sentry-client'
-import { getContractType, NoComboTypes } from './tracking'
+import { getContractType, DkBundleTypes, NoComboTypes } from './tracking'
 
-type GAContractType = NoComboTypes | TypeOfContract
+type GAContractType = NoComboTypes | DkBundleTypes | TypeOfContract
 
 interface GTMOfferData {
   insurance_type: GAContractType

--- a/src/client/utils/tracking/tracking.ts
+++ b/src/client/utils/tracking/tracking.ts
@@ -9,7 +9,14 @@ import {
   useRedeemedCampaignsQuery,
 } from 'data/graphql'
 import { OfferData } from 'pages/OfferNew/types'
-import { isBundle, isYouth, isDanish } from 'pages/OfferNew/utils'
+import {
+  isBundle,
+  isYouth,
+  isDanish,
+  isNorwegian,
+  isDanishAccidentBundle,
+  isDanishTravelBundle,
+} from 'pages/OfferNew/utils'
 import { trackOfferGTM } from './gtm'
 
 const cookie = new CookieStorage()
@@ -41,9 +48,26 @@ export enum NoComboTypes {
   NoComboYouth = 'NO_COMBO_YOUTH',
 }
 
+export enum DkBundleTypes {
+  DkAccidentBundle = 'DK_ACCIDENT_BUNDLE',
+  DkTravelBundle = 'DK_TRAVEL_BUNDLE',
+}
+
 export const getContractType = (offerData: OfferData) => {
   if (isBundle(offerData)) {
-    return isYouth(offerData) ? NoComboTypes.NoComboYouth : NoComboTypes.NoCombo
+    if (isNorwegian(offerData)) {
+      return isYouth(offerData)
+        ? NoComboTypes.NoComboYouth
+        : NoComboTypes.NoCombo
+    }
+
+    if (isDanishAccidentBundle(offerData)) {
+      return DkBundleTypes.DkAccidentBundle
+    }
+
+    if (isDanishTravelBundle(offerData)) {
+      return DkBundleTypes.DkTravelBundle
+    }
   }
   return offerData.quotes[0].contractType
 }

--- a/src/client/utils/tracking/tracking.ts
+++ b/src/client/utils/tracking/tracking.ts
@@ -16,6 +16,7 @@ import {
   isNorwegian,
   isDanishAccidentBundle,
   isDanishTravelBundle,
+  isStudentOffer,
 } from 'pages/OfferNew/utils'
 import { trackOfferGTM } from './gtm'
 
@@ -50,7 +51,9 @@ export enum NoComboTypes {
 
 export enum DkBundleTypes {
   DkAccidentBundle = 'DK_ACCIDENT_BUNDLE',
+  DkAccidentBundleStudent = 'DK_ACCIDENT_BUNDLE_STUDENT',
   DkTravelBundle = 'DK_TRAVEL_BUNDLE',
+  DkTravelBundleStudent = 'DK_TRAVEL_BUNDLE_STUDENT',
 }
 
 export const getContractType = (offerData: OfferData) => {
@@ -62,11 +65,15 @@ export const getContractType = (offerData: OfferData) => {
     }
 
     if (isDanishAccidentBundle(offerData)) {
-      return DkBundleTypes.DkAccidentBundle
+      return isStudentOffer(offerData)
+        ? DkBundleTypes.DkAccidentBundleStudent
+        : DkBundleTypes.DkAccidentBundle
     }
 
     if (isDanishTravelBundle(offerData)) {
-      return DkBundleTypes.DkTravelBundle
+      return isStudentOffer(offerData)
+        ? DkBundleTypes.DkTravelBundleStudent
+        : DkBundleTypes.DkTravelBundle
     }
   }
   return offerData.quotes[0].contractType


### PR DESCRIPTION
## What?

Make sure we track DK bundles. A pretty naive solution but checking the actual contents of the danish bundles got a bit messy so checking for the length does the trick IMO :) The naming of the different util functions makes it a bit confusing since some takes `offerData` as an argument and some takes a `quote` or `quoteDetails`


## Why?

Must have for going live 

### Screenshots

#### Accident bundle student
<img width="1792" alt="Screenshot 2021-05-17 at 16 08 18" src="https://user-images.githubusercontent.com/6661511/118503952-5f94dc00-b72b-11eb-9e9b-cc0f81f193d4.png">

#### Accident bundle
<img width="1792" alt="Screenshot 2021-05-17 at 16 08 53" src="https://user-images.githubusercontent.com/6661511/118503957-602d7280-b72b-11eb-9c56-2de85abd996c.png">

#### Home contents
<img width="1792" alt="Screenshot 2021-05-17 at 16 09 34" src="https://user-images.githubusercontent.com/6661511/118503958-60c60900-b72b-11eb-843a-e97aa11a1650.png">
