### PR TITLE
Fix / broken connect-payment page layout in Safari mobile

### DIFF
--- a/src/client/pages/ConnectPayment/sections/ConnectPayment.tsx
+++ b/src/client/pages/ConnectPayment/sections/ConnectPayment.tsx
@@ -29,7 +29,7 @@ const InnerWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
     flex-direction: row-reverse;
@@ -38,32 +38,41 @@ const InnerWrapper = styled.div`
     padding-left: 2rem;
     padding-right: 2rem;
     padding-top: 8rem;
+    justify-content: space-between;
   }
 `
 const ImageContainer = styled.div`
-  width: 50%;
+  padding-bottom: 3rem;
   display: flex;
   justify-content: center;
-  padding-bottom: 2rem;
+  align-items: flex-start;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
-    justify-content: flex-start;
     width: 45%;
-    padding-top: 2rem;
+    padding-top: 1rem;
     padding-left: 2rem;
+    justify-content: flex-start;
   }
 `
 const ConnectPaymentImage = styled.img`
-  height: auto;
-  width: 100%;
+  max-width: 40vw;
+
+  ${LARGE_SCREEN_MEDIA_QUERY} {
+    width: 100%;
+    max-width: 100%;
+  }
 `
 const TextContainer = styled.div`
   padding-bottom: 2.5rem;
   flex-shrink: 0;
   max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
     width: 60%;
+    align-items: flex-start;
   }
 `
 const Headline = styled.h1`


### PR DESCRIPTION
## What?

- Styling tweaks/fixes in `ConnectPayment.tsx`.

- Lesson learned to always check on at least one _real_ phone before merging, and be more explicit with the CSS since default behaviour apparently can differ _even more_ between browsers than I've realised.

## Why?

Layout turned out to be broken in Safari, especially on mobile 😔 


<hr />

**Review app:** https://web-onboardi-fix-connec-m1umrn.herokuapp.com/dk/new-member/debugger


<!-- Finally, if that makes sense, add screenshots and/or screen recordings below, preferably with headlines and/or descriptions -->

## Screenshots

**/dk on iPhone 11 Safari**

![2021-05-20-connect-payment-dk](https://user-images.githubusercontent.com/42962286/119003757-45a70380-b98e-11eb-84c3-4753bd26272a.PNG)



**/se on iPhone 11 Safari**

![2021-05-20-connect-payment-se](https://user-images.githubusercontent.com/42962286/119003785-4b9ce480-b98e-11eb-86d2-8a62a4b19ce9.PNG)


<hr />

Desktop still looks like in [this PR](https://github.com/HedvigInsurance/web-onboarding/pull/547)
