### PR TITLE
Map Extrabuildings and only pass expected values

### DIFF
--- a/src/client/pages/OfferNew/Introduction/Sidebar/DetailsModal/utils.ts
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/DetailsModal/utils.ts
@@ -16,6 +16,7 @@ import {
   EditQuoteMutation,
   EditNorwegianHomeContentsInput,
   EditDanishHomeContentsInput,
+  ExtraBuildingInput,
 } from 'data/graphql'
 import { OfferQuote, OfferData, OfferPersonInfo } from 'pages/OfferNew/types'
 import { birthdateFormats, LocaleData } from 'l10n/locales'
@@ -554,7 +555,13 @@ export const getInitialSwedishHouseValues = (
     numberOfBathrooms: details.numberOfBathrooms,
     yearOfConstruction: details.yearOfConstruction,
     isSubleted: details.isSubleted,
-    extraBuildings: details.extraBuildings,
+    extraBuildings: details.extraBuildings.map<ExtraBuildingInput>(
+      ({ type, area, hasWaterConnected }) => ({
+        type,
+        area,
+        hasWaterConnected,
+      }),
+    ),
   },
 })
 


### PR DESCRIPTION
## What?

Only send expected values for Extrabuiling


## Why?

To be able to edit extra buildings in the details modal
