### PR TITLE
Align price and title label in sidebar

### DIFF
--- a/src/client/pages/OfferNew/Checkout/CheckoutContent.tsx
+++ b/src/client/pages/OfferNew/Checkout/CheckoutContent.tsx
@@ -48,12 +48,14 @@ const StartDateLabel = styled.p`
 `
 
 const InsuranceHeading = styled.h3`
-  font-size: 1.375rem;
-  line-height: 1.5;
   margin: 0;
+
+  font-size: 1.375rem;
+  line-height: 1.625rem;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
     font-size: 1.5rem;
+    line-height: 2rem;
   }
 
   span {

--- a/src/client/pages/OfferNew/Checkout/CheckoutContent.tsx
+++ b/src/client/pages/OfferNew/Checkout/CheckoutContent.tsx
@@ -5,6 +5,10 @@ import { useEditQuoteMutation, useRedeemedCampaignsQuery } from 'data/graphql'
 import { Price } from 'pages/OfferNew/components'
 import { useTextKeys } from 'utils/textKeys'
 import { useUnderwritingLimitsHitReporter } from 'utils/sentry-client'
+import {
+  LARGE_SCREEN_MEDIA_QUERY,
+  MEDIUM_SCREEN_MEDIA_QUERY,
+} from 'utils/mediaQueries'
 import { StartDate } from '../Introduction/Sidebar/StartDate'
 import { OfferData } from '../types'
 import {
@@ -23,11 +27,11 @@ const Section = styled.div`
 const Excerpt = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  padding: 1rem 0 1.5rem;
+  align-items: flex-start;
+  padding: 2rem 0 2.5rem;
 
-  @media (min-width: 40rem) {
-    padding-bottom: 2rem;
+  ${MEDIUM_SCREEN_MEDIA_QUERY} {
+    padding-bottom: 3rem;
   }
 `
 
@@ -44,8 +48,13 @@ const StartDateLabel = styled.p`
 `
 
 const InsuranceHeading = styled.h3`
-  font-size: 1.5rem;
-  line-height: 2rem;
+  font-size: 1.375rem;
+  line-height: 1.5;
+  margin: 0;
+
+  ${LARGE_SCREEN_MEDIA_QUERY} {
+    font-size: 1.5rem;
+  }
 
   span {
     display: block;

--- a/src/client/pages/OfferNew/Introduction/Sidebar/index.tsx
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/index.tsx
@@ -18,7 +18,10 @@ import {
 } from 'pages/OfferNew/Introduction/Sidebar/utils'
 import { OfferData } from 'pages/OfferNew/types'
 import { useTextKeys } from 'utils/textKeys'
-import { LARGE_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
+import {
+  LARGE_SCREEN_MEDIA_QUERY,
+  SMALL_SCREEN_MEDIA_QUERY,
+} from 'utils/mediaQueries'
 import { Badge } from 'components/Badge/Badge'
 import { TOP_BAR_Z_INDEX } from 'components/TopBar'
 import { Price } from '../../components'
@@ -83,6 +86,11 @@ const Header = styled.div`
   display: flex;
   align-items: flex-start;
   width: 100%;
+  flex-wrap: wrap;
+
+  ${SMALL_SCREEN_MEDIA_QUERY} {
+    flex-wrap: nowrap;
+  }
 `
 
 const PreTitle = styled.span`

--- a/src/client/pages/OfferNew/Introduction/Sidebar/index.tsx
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/index.tsx
@@ -101,10 +101,11 @@ const Title = styled.h3`
   width: 100%;
   margin: 0 1rem 0 0;
   font-size: 1.375rem;
-  line-height: 1.5;
+  line-height: 1.625rem;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
     font-size: 1.5rem;
+    line-height: 2rem;
   }
 `
 

--- a/src/client/pages/OfferNew/Introduction/Sidebar/index.tsx
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/index.tsx
@@ -81,7 +81,7 @@ const HeaderTop = styled.div`
 const Header = styled.div`
   position: relative;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   width: 100%;
 `
 
@@ -93,7 +93,7 @@ const Title = styled.h3`
   width: 100%;
   margin: 0 1rem 0 0;
   font-size: 1.375rem;
-  line-height: 1.3;
+  line-height: 1.5;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
     font-size: 1.5rem;

--- a/src/client/pages/OfferNew/Introduction/Sidebar/index.tsx
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/index.tsx
@@ -83,9 +83,9 @@ const HeaderTop = styled.div`
 
 const Header = styled.div`
   position: relative;
-  display: flex;
-  align-items: flex-start;
   width: 100%;
+  display: flex;
+  align-items: baseline;
   flex-wrap: wrap;
 
   ${SMALL_SCREEN_MEDIA_QUERY} {

--- a/src/client/pages/OfferNew/common/price.tsx
+++ b/src/client/pages/OfferNew/common/price.tsx
@@ -36,7 +36,9 @@ const PriceNumbers = styled.div<{
 `
 
 const PriceNet = styled.div`
-  font-size: 1.125rem;
+  font-size: 1.375rem;
+  line-height: 1.5;
+
   ${LARGE_SCREEN_MEDIA_QUERY} {
     font-size: 1.5rem;
   }

--- a/src/client/pages/OfferNew/common/price.tsx
+++ b/src/client/pages/OfferNew/common/price.tsx
@@ -4,22 +4,30 @@ import React from 'react'
 import { Spinner } from 'components/utils'
 import { MonetaryAmount } from 'containers/types'
 import { useTextKeys } from 'utils/textKeys'
-import { LARGE_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
+import {
+  LARGE_SCREEN_MEDIA_QUERY,
+  MEDIUM_SMALL_SCREEN_MEDIA_QUERY,
+} from 'utils/mediaQueries'
 
 const PriceWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
   position: relative;
+
+  ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
+    align-items: flex-end;
+  }
 `
 
 const PriceGross = styled.div`
-  height: 0.875rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
-  line-height: 1rem;
   color: ${colorsV3.gray500};
   text-decoration: line-through;
+
+  ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
+    position: absolute;
+    top: -1rem;
+  }
 `
 const OldPriceSuffix = styled.span`
   font-size: 0.875rem;

--- a/src/client/pages/OfferNew/common/price.tsx
+++ b/src/client/pages/OfferNew/common/price.tsx
@@ -6,7 +6,7 @@ import { MonetaryAmount } from 'containers/types'
 import { useTextKeys } from 'utils/textKeys'
 import {
   LARGE_SCREEN_MEDIA_QUERY,
-  MEDIUM_SMALL_SCREEN_MEDIA_QUERY,
+  SMALL_SCREEN_MEDIA_QUERY,
 } from 'utils/mediaQueries'
 
 const PriceWrapper = styled.div`
@@ -14,7 +14,7 @@ const PriceWrapper = styled.div`
   flex-direction: column;
   position: relative;
 
-  ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
+  ${SMALL_SCREEN_MEDIA_QUERY} {
     align-items: flex-end;
   }
 `

--- a/src/client/pages/OfferNew/common/price.tsx
+++ b/src/client/pages/OfferNew/common/price.tsx
@@ -21,14 +21,15 @@ const PriceWrapper = styled.div`
 
 const PriceGross = styled.div`
   font-size: 1rem;
+  line-height: 1.625rem;
   color: ${colorsV3.gray500};
   text-decoration: line-through;
 
-  ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
-    position: absolute;
-    top: -1rem;
+  ${LARGE_SCREEN_MEDIA_QUERY} {
+    line-height: 2rem;
   }
 `
+
 const OldPriceSuffix = styled.span`
   font-size: 0.875rem;
 `
@@ -45,10 +46,11 @@ const PriceNumbers = styled.div<{
 
 const PriceNet = styled.div`
   font-size: 1.375rem;
-  line-height: 1.5;
+  line-height: 1.625rem;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
     font-size: 1.5rem;
+    line-height: 2rem;
   }
 `
 

--- a/src/client/utils/mediaQueries.ts
+++ b/src/client/utils/mediaQueries.ts
@@ -2,8 +2,10 @@ export const BREAKPOINTS = {
   largeScreen: 1000,
   mediumScreen: 800,
   mediumSmallScreen: 450,
+  smallScreen: 375,
 }
 
 export const LARGE_SCREEN_MEDIA_QUERY = `@media screen and (min-width: ${BREAKPOINTS.largeScreen}px)`
 export const MEDIUM_SCREEN_MEDIA_QUERY = `@media screen and (min-width: ${BREAKPOINTS.mediumScreen}px)`
 export const MEDIUM_SMALL_SCREEN_MEDIA_QUERY = `@media screen and (min-width: ${BREAKPOINTS.mediumSmallScreen}px)`
+export const SMALL_SCREEN_MEDIA_QUERY = `@media screen and (min-width: ${BREAKPOINTS.smallScreen}px)`


### PR DESCRIPTION
## What?

Use standard media queries.
Use the same line-height for labels that need to align.
Override global margin (h3).

## Why?

Before the labels were centered which looked strange when the title wraps on two lines.
Changed some line heights to share the same value so they align better.

### Before

![image](https://user-images.githubusercontent.com/1220232/119326182-ebee5400-bc81-11eb-8925-5bcfdb6b15af.png)

### Sidebar mobile + desktop

![Screenshot 2021-05-24 at 11 12 59](https://user-images.githubusercontent.com/1220232/119325846-9ade6000-bc81-11eb-9dd0-645224b7c54e.png)
![Screenshot 2021-05-24 at 11 13 09](https://user-images.githubusercontent.com/1220232/119325853-9e71e700-bc81-11eb-8008-ace5d685697f.png)

### Compare component

![Screenshot 2021-05-24 at 11 11 27](https://user-images.githubusercontent.com/1220232/119325876-a6318b80-bc81-11eb-9cc8-13931079bd01.png)

### Checkout modal mobile + desktop

![Screenshot 2021-05-24 at 11 09 19](https://user-images.githubusercontent.com/1220232/119325960-b9445b80-bc81-11eb-98d8-3e218a65b81e.png)
![Screenshot 2021-05-24 at 11 09 31](https://user-images.githubusercontent.com/1220232/119325974-bba6b580-bc81-11eb-8451-d6f7128ea5bc.png)
