### PR TITLE
Redirect users that fail to get quote

### DIFF
--- a/src/client/pages/OfferNew/index.tsx
+++ b/src/client/pages/OfferNew/index.tsx
@@ -22,6 +22,7 @@ import { getOfferData } from 'pages/OfferNew/utils'
 import { useVariation, Variation } from 'utils/hooks/useVariation'
 import { trackOfferGTM } from 'utils/tracking/gtm'
 import { getUtmParamsFromCookie, TrackAction } from 'utils/tracking/tracking'
+import { captureSentryError } from 'utils/sentry-client'
 import { useQuoteIds } from '../../utils/hooks/useQuoteIds'
 import { LanguagePicker } from '../Embark/LanguagePicker'
 import { Checkout } from './Checkout'
@@ -72,9 +73,10 @@ export const OfferNew: React.FC = () => {
   }
 
   if (!loadingQuoteBundle && !data?.quoteBundle) {
-    throw new Error(
+    captureSentryError(
       `No quote returned to show offer with (quoteIds=${quoteIds}).`,
     )
+    return <Redirect to={`/${currentLocale}/new-member`} />
   }
 
   const handleCheckoutToggle = (open: boolean) => {

--- a/src/client/pages/OfferNew/index.tsx
+++ b/src/client/pages/OfferNew/index.tsx
@@ -74,7 +74,7 @@ export const OfferNew: React.FC = () => {
 
   if (!loadingQuoteBundle && !data?.quoteBundle) {
     captureSentryError(
-      `No quote returned to show offer with (quoteIds=${quoteIds}).`,
+      `No quote data could be returned for quoteIds: ${quoteIds}.`,
     )
     return <Redirect to={`/${currentLocale}/new-member`} />
   }


### PR DESCRIPTION
<!-- 
If there is a Jira issue and the name of your branch doesn't include the issue key (e.g. GRW-123), please prefix your PR title with it. 
Also, if applicable, include whether this is a Fix, Feature or Chore.
Example: GRW-123 / Feature / Awesome new thing
-->

## What?

Redirect users to start page if create quote returns "UnderwritingLimitsHit".
Capture error to Sentry.

## Why?

Currently, we throw an exception that we never catch so users end up with a blank page.

I didn't find any generic error page/component to show the user. I noticed a similar case where we simply redirect the user so I copied that solution.

This "error" should really be handled in Embark (or better yet, the GraphQL API should return a proper error 😄). I do believe that this is an improvement on the existing solution. If we fix things in Embark/Giraffe - no users need to end up in this if-block.


_Referenced ticket(s): []_
<!-- If there is a Jira issue, add the id between brackets, and a link to that issue will be created. -->


<!-- Finally, if that makes sense, add screenshots and/or screen recordings below, preferably with headlines and/or descriptions -->
