### PR TITLE
Fix / Coverage summary text for Norway and Denmark

### DIFF
--- a/src/translations/da_DK.json
+++ b/src/translations/da_DK.json
@@ -20,7 +20,7 @@
   "ONBOARDING_CONNECT_DD_PAGE_TITLE": "Tilknyt betaling | Hedvig",
   "COVERAGE_LABEL": "Dækning",
   "COVERAGE_HEADLINE": "Omfattende forsikringsdækning",
-  "COVERAGE_BODY": "Al den dækning du har brug for lige ved hånden. Få hjælp med det samme fra rigtige mennesker i appen hverdage fra 9-22, eller weekender 10-22. Hurtig håndtering af forsikringskrav i appen. Lav selvrisiko på 500 kr, ingen selvrisiko for store forsikringskrav. Klik på ikonerne nedenfor for mere information.",
+  "COVERAGE_BODY": "Al den dækning du har brug for lige ved hånden. Få hjælp med det samme fra rigtige mennesker i appen hverdage fra 9-22, eller weekender 10-22. Hurtig håndtering af forsikringskrav i appen. Lav selvrisiko på 500 kr. for almindelige forsikringskrav, ingen selvrisiko for store forsikringskrav. Klik på ikonerne nedenfor for mere information.",
   "COVERAGE_INFO_HEADLINE": "Flere oplysninger",
   "COMPARE_LABEL": "Sammenlign",
   "COMPARE_HEADLINE": "Sammenlign vores dækning med andres",

--- a/src/translations/en_DK.json
+++ b/src/translations/en_DK.json
@@ -20,7 +20,7 @@
   "ONBOARDING_CONNECT_DD_PAGE_TITLE": "Connect payment | Hedvig",
   "COVERAGE_LABEL": "The coverage",
   "COVERAGE_HEADLINE": "Comprehensive insurance coverage",
-  "COVERAGE_BODY": "All the coverage you need at your fingertips. Get instant help from real people in the app weekdays 9-22, or weekends 10-22. Fast claims handling in-app, anywhere. Low deductible 500 DKK, zero deductible for large claims. Click on the icons for more info.",
+  "COVERAGE_BODY": "All the coverage you need at your fingertips. Get instant help from real people in the app weekdays 9-22, or weekends 10-22. Fast claims handling in-app, anywhere. Low deductible of 500 DKK for common claims, zero deductible for large claims. Click on the icons for more info.",
   "COVERAGE_INFO_HEADLINE": "More information",
   "COMPARE_LABEL": "Compare",
   "COMPARE_HEADLINE": "Compare our coverage to theirs ",

--- a/src/translations/en_NO.json
+++ b/src/translations/en_NO.json
@@ -20,7 +20,7 @@
   "ONBOARDING_CONNECT_DD_PAGE_TITLE": "Connect payment | Hedvig",
   "COVERAGE_LABEL": "The coverage",
   "COVERAGE_HEADLINE": "We have you covered",
-  "COVERAGE_BODY": "Extensive coverage for you and your family, your house and your belongings. All risk is always included. Click the icons for more info.",
+  "COVERAGE_BODY": "Extensive coverage for you, your family and your belongings. All risk is always included. Click the icons for more info.",
   "COVERAGE_INFO_HEADLINE": "More information",
   "COMPARE_LABEL": "Compare",
   "COMPARE_HEADLINE": "Compare our coverage to theirs ",

--- a/src/translations/nb_NO.json
+++ b/src/translations/nb_NO.json
@@ -20,7 +20,7 @@
   "ONBOARDING_CONNECT_DD_PAGE_TITLE": "Koble til betaling| Hedvig",
   "COVERAGE_LABEL": "Dekningen",
   "COVERAGE_HEADLINE": "En dekning som strekker seg langt",
-  "COVERAGE_BODY": "Omfattende beskyttelse for deg og familien din, boligen din og tingene dine. Klønetillegg er alltid inkludert. Klikk på ikonene for å få mer informasjon",
+  "COVERAGE_BODY": "Omfattende beskyttelse for deg, familien din og tingene dine. Idiotforsikring er alltid inkludert. Klikk på ikonene for å få mer informasjon",
   "COVERAGE_INFO_HEADLINE": "Mer informasjon",
   "COMPARE_LABEL": "Sammenlign ",
   "COMPARE_HEADLINE": "Sammenlign vår dekning med de andre\\n",


### PR DESCRIPTION
## What?

Updated translations/copy for the `COVERAGE_BODY` text key, for the Danish and Norwegian markets.

**Denmark:**
- Clarification regarding which claims have 500 DKK in deductible - "Lav selvrisiko på 500 kr. **for almindelige forsikringskrav**, ingen selvrisiko for store forsikringskrav." / "Low deductible **of** 500 DKK **for common claims**, zero deductible for large claims."
- The "." after "kr" is on purpose - that's apparently how you write it in Danish 🙃

**Norway:**
- The statement that we insure "your house"/"boligen din" is removed since that's just not true - "Omfattende beskyttelse for deg, ~og~ familien din, ~boligen din~ og tingene dine." / "Extensive coverage for you, ~and~ your family, ~your house~ and your belongings."
- "Klønetillegg" is changed to **Idiotforsikring**

## Why?

- The change for Denmark are based on feedback from Jacob during our last test session
- The changes for Norway is based on feedback from Claire and myself (approved by Catherine)


_Referenced ticket(s): [GRW-346]_



## Screenshots

**/dk:**
<img width="1417" alt="2021-05-31-coverage-text-dk" src="https://user-images.githubusercontent.com/42962286/120215381-f1c1d780-c235-11eb-8efc-035b237bb505.png">


**/dk-en:**
<img width="1420" alt="2021-05-31-coverage-text-dk-en" src="https://user-images.githubusercontent.com/42962286/120215389-f4243180-c235-11eb-8f7b-743e894aa5f4.png">


**/no:**
<img width="1345" alt="2021-05-31-coverage-text-no" src="https://user-images.githubusercontent.com/42962286/120215400-f8e8e580-c235-11eb-8ff3-e04fdc59d14c.png">


**/no-en:**
<img width="1338" alt="2021-05-31-coverage-text-no-en" src="https://user-images.githubusercontent.com/42962286/120215414-fc7c6c80-c235-11eb-87b5-8aba3d3dd4f5.png">



[GRW-346]: https://hedvig.atlassian.net/browse/GRW-346