### PR TITLE
Adress autocomplete: Remove possibility to edit address from Danish Details Modal

### DIFF
--- a/src/client/pages/OfferNew/Introduction/Sidebar/DetailsModal/Details/DanishDetails.tsx
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/DetailsModal/Details/DanishDetails.tsx
@@ -36,18 +36,6 @@ export const DanishDetails: React.FC<DetailsProps> = ({
           <ContentColumn>
             <InputGroup>
               <DetailInput
-                field={fieldSchema.danishHomeContents.street}
-                formikProps={formikProps}
-                nameRoot="danishHomeContents"
-                name="street"
-              />
-              <DetailInput
-                field={fieldSchema.danishHomeContents.zipCode}
-                formikProps={formikProps}
-                nameRoot="danishHomeContents"
-                name="zipCode"
-              />
-              <DetailInput
                 field={fieldSchema.danishHomeContents.coInsured}
                 formikProps={formikProps}
                 nameRoot="danishHomeContents"

--- a/src/client/pages/OfferNew/Introduction/Sidebar/DetailsModal/types.ts
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/DetailsModal/types.ts
@@ -44,7 +44,7 @@ export interface NorwegianTravelContentFieldSchema {
 
 export type PartialEditDanishHomeContentsInput = Omit<
   EditDanishHomeContentsInput,
-  'apartment' | 'floor' | 'city' | 'bbrId'
+  'street' | 'zipCode' | 'apartment' | 'floor' | 'city' | 'bbrId'
 >
 
 export interface DanishHomeContentFieldSchema {

--- a/src/client/pages/OfferNew/Introduction/Sidebar/DetailsModal/utils.ts
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/DetailsModal/utils.ts
@@ -299,10 +299,9 @@ const getNorwegianSchema = (
     : { norwegianTravel: { ...commonAttributes } }
 }
 
-const getDanishSchema = (base: BaseFieldSchema): DetailsFieldSchema => {
+const getDanishSchema = (): DetailsFieldSchema => {
   return {
     danishHomeContents: {
-      ...base,
       coInsured: {
         label: 'DETAILS_MODULE_TABLE_COINSURED_CELL_LABEL',
         placeholder: '',
@@ -395,7 +394,7 @@ const getFieldSchemaDetails = (offerQuote: OfferQuote): DetailsFieldSchema => {
     return getNorwegianSchema(base, offerQuote)
   }
   if (isDanishQuote(offerQuote)) {
-    return getDanishSchema(base)
+    return getDanishSchema()
   }
 
   return getSwedishSchema(base, offerQuote)


### PR DESCRIPTION
### Please note that this should be merged and deployed at the same as the address autocomplete feature in Embark
Hence we'll keep it as a draft until then.

## What?

- `'street'` and `'zipCode'` are removed from the `DanishDetails` component (meaning the Danish details modal form)
-  Same properties are also removed from the Danish forms schema in `/DetailsModal/utils.ts`, and omitted from the `PartialEditDanishHomeContentsInput` type.



## Why?

For the first iteration of the Address Autocomplete feature for Denmark we've decided to simply remove the option to edit your address in the Details Modal, since we only want addresses in the correct format and with a `bbrId` attached.

The plan for next iteration(/-s) is to implement autocomplete in the Details Modal as well.


_Referenced ticket(s): [GRW-228]_
<!-- If there is a Jira issue, add the id between brackets, and a link to that issue will be created. -->



[GRW-228]: https://hedvig.atlassian.net/browse/GRW-228