### PR TITLE
Fix / Offer page hero address

### DIFF
--- a/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
+++ b/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
@@ -42,7 +42,7 @@ const OfferInfo = styled.div`
 
 export const HeroOfferDetails: React.FC<Props> = ({ offerData }) => {
   const [numberCoInsured, setNumberCoInsured] = useState<number | null>(null)
-  const [street, setStreet] = useState<Address['street'] | null>(null)
+  const [address, setAddress] = useState<Address['street'] | null>(null)
 
   const { person, quotes } = offerData
 
@@ -55,7 +55,7 @@ export const HeroOfferDetails: React.FC<Props> = ({ offerData }) => {
     })
     if (quoteWithAddress) {
       const address = getAddress(quoteWithAddress.quoteDetails)
-      setStreet(address)
+      setAddress(address)
     }
   }, [quotes])
 
@@ -67,7 +67,7 @@ export const HeroOfferDetails: React.FC<Props> = ({ offerData }) => {
         {person.firstName}
         {Boolean(numberCoInsured) && ` +${numberCoInsured}`}
       </OfferInfo>
-      {street && <OfferInfo>{street}</OfferInfo>}
+      {address && <OfferInfo>{address}</OfferInfo>}
     </Container>
   )
 }

--- a/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
+++ b/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
@@ -67,7 +67,7 @@ export const HeroOfferDetails: React.FC<Props> = ({ offerData }) => {
       <Heading>{textKeys.HERO_OFFER_DETAILS_HEADER()}</Heading>
       <OfferInfo>
         {person.firstName}
-        {!!numberCoInsured && ` +${numberCoInsured}`}
+        {Boolean(numberCoInsured) && ` +${numberCoInsured}`}
       </OfferInfo>
       {street && <OfferInfo>{street}</OfferInfo>}
     </Container>

--- a/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
+++ b/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
@@ -3,7 +3,10 @@ import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { OfferData } from 'pages/OfferNew/types'
 import { useTextKeys } from 'utils/textKeys'
-import { LARGE_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
+import {
+  LARGE_SCREEN_MEDIA_QUERY,
+  MEDIUM_SCREEN_MEDIA_QUERY,
+} from 'utils/mediaQueries'
 import { getHouseholdSize, quoteDetailsHasAddress } from '../utils'
 import { getAddress } from '../Checkout/InsuranceSummaryDetails'
 
@@ -11,31 +14,38 @@ type Props = {
   offerData: OfferData
 }
 
-const Container = styled.div`
-  padding: 2rem 0 1rem;
+const Wrapper = styled.div`
+  padding: 2.5rem 0 1rem;
   color: ${colorsV3.white};
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
     padding-top: 0;
   }
 `
-
-const Heading = styled.h1`
+const Headline = styled.h1`
   margin: 0;
   text-transform: uppercase;
-  font-size: 0.75rem;
+  font-size: 1rem;
+`
+const OfferInfoWrapper = styled.div`
+  padding: 1rem 0;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
-    font-size: 1rem;
+    padding-top: 0;
   }
 `
-
-const OfferInfo = styled.div`
+const NameAndCoInsured = styled.div`
   font-size: 2rem;
-  word-break: break-all;
 
-  ${LARGE_SCREEN_MEDIA_QUERY} {
+  ${MEDIUM_SCREEN_MEDIA_QUERY} {
     font-size: 3rem;
+  }
+`
+const Address = styled.div`
+  font-size: 1.375rem;
+
+  ${MEDIUM_SCREEN_MEDIA_QUERY} {
+    font-size: 2.5rem;
   }
 `
 
@@ -60,13 +70,15 @@ export const HeroOfferDetails: React.FC<Props> = ({ offerData }) => {
 
   const textKeys = useTextKeys()
   return (
-    <Container>
-      <Heading>{textKeys.HERO_OFFER_DETAILS_HEADER()}</Heading>
-      <OfferInfo>
-        {person.firstName}
-        {Boolean(numberCoInsured) && ` +${numberCoInsured}`}
-      </OfferInfo>
-      {address && <OfferInfo>{address}</OfferInfo>}
-    </Container>
+    <Wrapper>
+      <Headline>{textKeys.HERO_OFFER_DETAILS_HEADER()}</Headline>
+      <OfferInfoWrapper>
+        <NameAndCoInsured>
+          {person.firstName}
+          {Boolean(numberCoInsured) && ` +${numberCoInsured}`}
+        </NameAndCoInsured>
+        {address && <Address>{address}</Address>}
+      </OfferInfoWrapper>
+    </Wrapper>
   )
 }

--- a/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
+++ b/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
-import { Address } from 'data/graphql'
 import { OfferData } from 'pages/OfferNew/types'
 import { useTextKeys } from 'utils/textKeys'
 import { LARGE_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
@@ -42,7 +41,7 @@ const OfferInfo = styled.div`
 
 export const HeroOfferDetails: React.FC<Props> = ({ offerData }) => {
   const [numberCoInsured, setNumberCoInsured] = useState<number | null>(null)
-  const [address, setAddress] = useState<Address['street'] | null>(null)
+  const [address, setAddress] = useState<string | null>(null)
 
   const { person, quotes } = offerData
 

--- a/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
+++ b/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
@@ -5,14 +5,11 @@ import { Address } from 'data/graphql'
 import { OfferData } from 'pages/OfferNew/types'
 import { useTextKeys } from 'utils/textKeys'
 import { LARGE_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
-import { getHouseholdSize } from '../utils'
+import { getHouseholdSize, quoteDetailsHasAddress } from '../utils'
+import { getAddress } from '../Checkout/InsuranceSummaryDetails'
 
 type Props = {
   offerData: OfferData
-}
-
-type QuoteWithStreet = {
-  quoteDetails: { street: Address['street'] }
 }
 
 const Container = styled.div`
@@ -53,11 +50,12 @@ export const HeroOfferDetails: React.FC<Props> = ({ offerData }) => {
     const householdSize = getHouseholdSize(quotes[0].quoteDetails)
     setNumberCoInsured(householdSize - 1)
 
-    const quoteWithStreet = quotes.find((quote) => {
-      return 'street' in quote.quoteDetails
+    const quoteWithAddress = quotes.find((quote) => {
+      return quoteDetailsHasAddress(quote.quoteDetails)
     })
-    if (quoteWithStreet) {
-      setStreet((quoteWithStreet as QuoteWithStreet).quoteDetails.street)
+    if (quoteWithAddress) {
+      const address = getAddress(quoteWithAddress.quoteDetails)
+      setStreet(address)
     }
   }, [quotes])
 


### PR DESCRIPTION
## What?

- Display floor and apartment as well as street name + number in hero section of */offer* page (reuse logic from `InsuranceSummaryDetails` component)
- Tweak styling slightly, most importantly change font size of address text to be smaller in order for it to look better on more screen sizes


## Why?

Danish people (of course) want to see their entire address 🙃 


_Referenced ticket(s): [GRW-370]_
<!-- If there is a Jira issue, add the id between brackets, and a link to that issue will be created. -->


<!-- Finally, if that makes sense, add screenshots and/or screen recordings below, preferably with headlines and/or descriptions -->

## Screenshots

_Will add shortly_
