### PR TITLE
Override style reset for Embark content

### DIFF
--- a/src/client/pages/Embark/LanguagePicker.tsx
+++ b/src/client/pages/Embark/LanguagePicker.tsx
@@ -28,9 +28,13 @@ const StyledLink = styled(Link)`
   outline: 0;
   color: ${colorsV2.black};
   text-decoration: none;
-  padding: 10px 20px;
   transition: all 250ms;
   font-size: 0.9rem;
+
+  /* Override EmbarkStyling reset */
+  & {
+    padding: 10px 20px;
+  }
 
   :active {
     background-color: ${colorsV2.lightgray};

--- a/src/client/pages/Embark/__snapshots__/LanguagePicker.test.tsx.snap
+++ b/src/client/pages/Embark/__snapshots__/LanguagePicker.test.tsx.snap
@@ -89,16 +89,16 @@ exports[`Danish language picker renders without 💥 matches snaphot 1`] = `
                     to="/dk/new-member"
                   >
                     <Link
-                      className="css-3wdfps-StyledLink e1g7xtvp3"
+                      className="css-oc63j8-StyledLink e1g7xtvp3"
                       to="/dk/new-member"
                     >
                       <LinkAnchor
-                        className="css-3wdfps-StyledLink e1g7xtvp3"
+                        className="css-oc63j8-StyledLink e1g7xtvp3"
                         href="/dk/new-member"
                         navigate={[Function]}
                       >
                         <a
-                          className="css-3wdfps-StyledLink e1g7xtvp3"
+                          className="css-oc63j8-StyledLink e1g7xtvp3"
                           href="/dk/new-member"
                           onClick={[Function]}
                         >
@@ -124,16 +124,16 @@ exports[`Danish language picker renders without 💥 matches snaphot 1`] = `
                     to="/dk-en/new-member"
                   >
                     <Link
-                      className="css-3wdfps-StyledLink e1g7xtvp3"
+                      className="css-oc63j8-StyledLink e1g7xtvp3"
                       to="/dk-en/new-member"
                     >
                       <LinkAnchor
-                        className="css-3wdfps-StyledLink e1g7xtvp3"
+                        className="css-oc63j8-StyledLink e1g7xtvp3"
                         href="/dk-en/new-member"
                         navigate={[Function]}
                       >
                         <a
-                          className="css-3wdfps-StyledLink e1g7xtvp3"
+                          className="css-oc63j8-StyledLink e1g7xtvp3"
                           href="/dk-en/new-member"
                           onClick={[Function]}
                         >
@@ -160,7 +160,7 @@ exports[`Danish language picker renders without 💥 matches snaphot 1`] = `
                     class="css-1xjnew5-Option e1g7xtvp1"
                   >
                     <a
-                      class="css-3wdfps-StyledLink e1g7xtvp3"
+                      class="css-oc63j8-StyledLink e1g7xtvp3"
                       href="/dk/new-member"
                     >
                       Dansk
@@ -173,7 +173,7 @@ exports[`Danish language picker renders without 💥 matches snaphot 1`] = `
                     class="css-1xjnew5-Option e1g7xtvp1"
                   >
                     <a
-                      class="css-3wdfps-StyledLink e1g7xtvp3"
+                      class="css-oc63j8-StyledLink e1g7xtvp3"
                       href="/dk-en/new-member"
                     >
                       English
@@ -549,16 +549,16 @@ exports[`Norwegian language picker renders without 💥 matches snaphot 1`] = `
                     to="/no/new-member"
                   >
                     <Link
-                      className="css-3wdfps-StyledLink e1g7xtvp3"
+                      className="css-oc63j8-StyledLink e1g7xtvp3"
                       to="/no/new-member"
                     >
                       <LinkAnchor
-                        className="css-3wdfps-StyledLink e1g7xtvp3"
+                        className="css-oc63j8-StyledLink e1g7xtvp3"
                         href="/no/new-member"
                         navigate={[Function]}
                       >
                         <a
-                          className="css-3wdfps-StyledLink e1g7xtvp3"
+                          className="css-oc63j8-StyledLink e1g7xtvp3"
                           href="/no/new-member"
                           onClick={[Function]}
                         >
@@ -584,16 +584,16 @@ exports[`Norwegian language picker renders without 💥 matches snaphot 1`] = `
                     to="/no-en/new-member"
                   >
                     <Link
-                      className="css-3wdfps-StyledLink e1g7xtvp3"
+                      className="css-oc63j8-StyledLink e1g7xtvp3"
                       to="/no-en/new-member"
                     >
                       <LinkAnchor
-                        className="css-3wdfps-StyledLink e1g7xtvp3"
+                        className="css-oc63j8-StyledLink e1g7xtvp3"
                         href="/no-en/new-member"
                         navigate={[Function]}
                       >
                         <a
-                          className="css-3wdfps-StyledLink e1g7xtvp3"
+                          className="css-oc63j8-StyledLink e1g7xtvp3"
                           href="/no-en/new-member"
                           onClick={[Function]}
                         >
@@ -620,7 +620,7 @@ exports[`Norwegian language picker renders without 💥 matches snaphot 1`] = `
                     class="css-1xjnew5-Option e1g7xtvp1"
                   >
                     <a
-                      class="css-3wdfps-StyledLink e1g7xtvp3"
+                      class="css-oc63j8-StyledLink e1g7xtvp3"
                       href="/no/new-member"
                     >
                       Norsk
@@ -633,7 +633,7 @@ exports[`Norwegian language picker renders without 💥 matches snaphot 1`] = `
                     class="css-1xjnew5-Option e1g7xtvp1"
                   >
                     <a
-                      class="css-3wdfps-StyledLink e1g7xtvp3"
+                      class="css-oc63j8-StyledLink e1g7xtvp3"
                       href="/no-en/new-member"
                     >
                       English
@@ -1009,16 +1009,16 @@ exports[`Swedish language picker renders without 💥 matches snaphot 1`] = `
                     to="/se/new-member"
                   >
                     <Link
-                      className="css-3wdfps-StyledLink e1g7xtvp3"
+                      className="css-oc63j8-StyledLink e1g7xtvp3"
                       to="/se/new-member"
                     >
                       <LinkAnchor
-                        className="css-3wdfps-StyledLink e1g7xtvp3"
+                        className="css-oc63j8-StyledLink e1g7xtvp3"
                         href="/se/new-member"
                         navigate={[Function]}
                       >
                         <a
-                          className="css-3wdfps-StyledLink e1g7xtvp3"
+                          className="css-oc63j8-StyledLink e1g7xtvp3"
                           href="/se/new-member"
                           onClick={[Function]}
                         >
@@ -1044,16 +1044,16 @@ exports[`Swedish language picker renders without 💥 matches snaphot 1`] = `
                     to="/se-en/new-member"
                   >
                     <Link
-                      className="css-3wdfps-StyledLink e1g7xtvp3"
+                      className="css-oc63j8-StyledLink e1g7xtvp3"
                       to="/se-en/new-member"
                     >
                       <LinkAnchor
-                        className="css-3wdfps-StyledLink e1g7xtvp3"
+                        className="css-oc63j8-StyledLink e1g7xtvp3"
                         href="/se-en/new-member"
                         navigate={[Function]}
                       >
                         <a
-                          className="css-3wdfps-StyledLink e1g7xtvp3"
+                          className="css-oc63j8-StyledLink e1g7xtvp3"
                           href="/se-en/new-member"
                           onClick={[Function]}
                         >
@@ -1080,7 +1080,7 @@ exports[`Swedish language picker renders without 💥 matches snaphot 1`] = `
                     class="css-1xjnew5-Option e1g7xtvp1"
                   >
                     <a
-                      class="css-3wdfps-StyledLink e1g7xtvp3"
+                      class="css-oc63j8-StyledLink e1g7xtvp3"
                       href="/se/new-member"
                     >
                       Svenska
@@ -1093,7 +1093,7 @@ exports[`Swedish language picker renders without 💥 matches snaphot 1`] = `
                     class="css-1xjnew5-Option e1g7xtvp1"
                   >
                     <a
-                      class="css-3wdfps-StyledLink e1g7xtvp3"
+                      class="css-oc63j8-StyledLink e1g7xtvp3"
                       href="/se-en/new-member"
                     >
                       English


### PR DESCRIPTION
## What?

Increase CSS specificity to make sure link padding takes precedence.

## Why?

Fix this issue:

![Screenshot 2021-07-08 at 10 12 06](https://user-images.githubusercontent.com/1220232/124898254-4f88d280-dfdf-11eb-8895-d730d3d160c0.png)

We are applying some general styles to all descendant elements inside Embark that overrides component-specific styling.

```js
// src/client/pages/Embark/index.tsx

const EmbarkStyling = styled.div`
  * {
    padding: 0;
  }
`
```

It seems like this doesn't cause issues consistently but rather based on e.g. order of how styles are injected into the page 🤔 

In either case I think we should refrain from using these semi-global styles in the future. I'm not too happy with the solution since it doesn't address the real problem but it will fix this specific issue at least.

## Demo

![Screenshot 2021-07-08 at 11 03 13](https://user-images.githubusercontent.com/1220232/124897526-ae9a1780-dfde-11eb-9ab1-44344f1d739f.png)

![Screenshot 2021-07-08 at 11 19 01](https://user-images.githubusercontent.com/1220232/124897529-af32ae00-dfde-11eb-8546-9f0fb1df8bb1.png)
