### PR TITLE
Make tabs in perils modal scrollable

### DIFF
--- a/src/client/pages/OfferNew/Perils/PerilModal.tsx
+++ b/src/client/pages/OfferNew/Perils/PerilModal.tsx
@@ -87,6 +87,7 @@ const PickerItemLabel = styled('div')`
 
 const PerilItemsContainer = styled('div')`
   position: relative;
+  width: 100%;
   height: 5.5rem;
   display: flex;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## What?

Remove manual transforms when selecting perils.
Place indicator inside selected peril item.
Make content area scrollable.

## Why?

1. We used to repeat the perils in the tabs section of the modal. This worked when we had lots of perils but when there are only a few, it looks strange when they are visibly repeated.
1. I didn't find a work around that I was happy with and the code to animate and update the repeated perils/tabs was kind of complicated.
1. My solution was therefore to go with a more traditional tabs approach that simplifies the state handling a bit. We miss out of some of the nice animations but I would argue that we gain more from the improved usability (being able to scroll etc.)
1. When we upgrade framer-motion we can use layout animations to animate the "indicator" line moving between the tabs!

## Demo on mobile

https://user-images.githubusercontent.com/1220232/125097396-5f371280-e0d6-11eb-8973-f9842e6354c3.mov

## Screenshots

![Screenshot 2021-07-09 at 16 55 24](https://user-images.githubusercontent.com/1220232/125097896-db315a80-e0d6-11eb-83f3-7b9551ba69dd.png)
![Screenshot 2021-07-09 at 16 55 56](https://user-images.githubusercontent.com/1220232/125097899-dbc9f100-e0d6-11eb-81de-e7931dfdc66d.png)
![Screenshot 2021-07-09 at 16 57 24](https://user-images.githubusercontent.com/1220232/125097904-dc628780-e0d6-11eb-82f6-759d8adf0835.png)
