### PR TITLE
Point VSCode to local TypeScript lib

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
## What?

Tell VSCode to use the local installation of TS.

## Why?

@styrelius and I have run into issues with types etc. since VSCode doesn't reliably use the local TS lib installation but falls back to a more recent version of TS.

This seems pretty safe to include as a default for whoever is developing this project, don't you think?

