### PR TITLE
GRW-377 Add link component that will determine when to open a link in a new tab

### DIFF
--- a/src/client/components/RawLink.tsx
+++ b/src/client/components/RawLink.tsx
@@ -3,20 +3,20 @@ import { useVariation, Variation } from 'utils/hooks/useVariation'
 
 type RawLinkProps = {
   className?: string
-  external?: boolean
+  openInNewTab?: boolean
   href: string
 }
 
 export const RawLink: React.FC<RawLinkProps> = ({
   className,
   children,
-  external,
+  openInNewTab,
   href,
 }) => {
   const variation = useVariation()
-  const externalCondition =
-    external && ![Variation.IOS, Variation.ANDROID].includes(variation!)
-  const linkAttributes = externalCondition
+  const linkCondition =
+    openInNewTab && ![Variation.IOS, Variation.ANDROID].includes(variation!)
+  const linkAttributes = linkCondition
     ? { target: '_blank', rel: 'noreferrer noopener' }
     : {}
 

--- a/src/client/components/RawLink.tsx
+++ b/src/client/components/RawLink.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { useVariation, Variation } from 'utils/hooks/useVariation'
+
+type RawLinkProps = {
+  className?: string
+  external?: boolean
+  href: string
+}
+
+export const RawLink: React.FC<RawLinkProps> = ({
+  className,
+  children,
+  external,
+  href,
+}) => {
+  const variation = useVariation()
+  const externalCondition =
+    external && ![Variation.IOS, Variation.ANDROID].includes(variation!)
+  const linkAttributes = externalCondition
+    ? { target: '_blank', rel: 'noreferrer noopener' }
+    : {}
+
+  return (
+    <a className={className} href={href} {...linkAttributes}>
+      {children}
+    </a>
+  )
+}

--- a/src/client/components/RawLink.tsx
+++ b/src/client/components/RawLink.tsx
@@ -3,19 +3,20 @@ import { useVariation, Variation } from 'utils/hooks/useVariation'
 
 type RawLinkProps = {
   className?: string
-  openInNewTab?: boolean
+  target?: '_blank'
   href: string
 }
 
 export const RawLink: React.FC<RawLinkProps> = ({
   className,
   children,
-  openInNewTab,
+  target,
   href,
 }) => {
   const variation = useVariation()
   const linkCondition =
-    openInNewTab && ![Variation.IOS, Variation.ANDROID].includes(variation!)
+    target === '_blank' &&
+    ![Variation.IOS, Variation.ANDROID].includes(variation!)
   const linkAttributes = linkCondition
     ? { target: '_blank', rel: 'noreferrer noopener' }
     : {}

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
@@ -107,7 +107,7 @@ export const InsuranceSummaryTermsLinks: React.FC<Props> = ({ offerData }) => {
         return (
           <Row key={termType + index}>
             <LinkWrapper>
-              <Link href={url} openInNewTab={true}>
+              <Link href={url} target="_blank">
                 {displayName}
               </Link>
               {' ↗'}

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummaryTermsLinks.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { InsuranceTerm, InsuranceTermType } from 'data/graphql'
+import { RawLink } from 'components/RawLink'
 import { OfferData, OfferQuote } from '../types'
 import { checkIfMainQuote } from '../utils'
 import { Group, Row } from './InsuranceSummary'
@@ -11,7 +12,7 @@ const linkColor = colorsV3.gray700
 const LinkWrapper = styled.div`
   color: ${colorsV3.gray900};
 `
-const Link = styled.a`
+const Link = styled(RawLink)`
   font-size: 14px;
   color: ${linkColor};
   :hover,
@@ -106,7 +107,7 @@ export const InsuranceSummaryTermsLinks: React.FC<Props> = ({ offerData }) => {
         return (
           <Row key={termType + index}>
             <LinkWrapper>
-              <Link href={url} target="_blank" rel="noreferrer noopener">
+              <Link href={url} openInNewTab={true}>
                 {displayName}
               </Link>
               {' ↗'}

--- a/src/client/pages/OfferNew/Perils/InsuranceValues/index.tsx
+++ b/src/client/pages/OfferNew/Perils/InsuranceValues/index.tsx
@@ -92,7 +92,7 @@ export const InsuranceValues: React.FC<Props> = ({ offerQuote }) => {
               <TermsLink
                 key={insuranceTermType}
                 href={insuranceTerm.url}
-                external
+                openInNewTab={true}
               >
                 {insuranceTerm.displayName}
                 {' ↗'}

--- a/src/client/pages/OfferNew/Perils/InsuranceValues/index.tsx
+++ b/src/client/pages/OfferNew/Perils/InsuranceValues/index.tsx
@@ -5,6 +5,7 @@ import color from 'color'
 import { Limits } from 'pages/OfferNew/Perils/InsuranceValues/Limits'
 import { OfferQuote } from 'pages/OfferNew/types'
 import { useTextKeys } from 'utils/textKeys'
+import { RawLink } from 'components/RawLink'
 import { SubSubHeadingBlack } from '../../components'
 
 const Wrapper = styled.div`
@@ -33,7 +34,7 @@ const Links = styled.div`
   }
 `
 
-const Link = styled.a`
+const TermsLink = styled(RawLink)`
   display: flex;
   align-items: center;
   padding: 0.75rem 1.5rem 0.75rem 1rem;
@@ -88,14 +89,14 @@ export const InsuranceValues: React.FC<Props> = ({ offerQuote }) => {
         {[...offerQuote.insuranceTerms.entries()].map(
           ([insuranceTermType, insuranceTerm]) => {
             return (
-              <Link
+              <TermsLink
                 key={insuranceTermType}
                 href={insuranceTerm.url}
-                target="_blank"
+                external
               >
                 {insuranceTerm.displayName}
                 {' ↗'}
-              </Link>
+              </TermsLink>
             )
           },
         )}

--- a/src/client/pages/OfferNew/Perils/InsuranceValues/index.tsx
+++ b/src/client/pages/OfferNew/Perils/InsuranceValues/index.tsx
@@ -92,7 +92,7 @@ export const InsuranceValues: React.FC<Props> = ({ offerQuote }) => {
               <TermsLink
                 key={insuranceTermType}
                 href={insuranceTerm.url}
-                openInNewTab={true}
+                target="_blank"
               >
                 {insuranceTerm.displayName}
                 {' ↗'}


### PR DESCRIPTION
## What?

Add link component that will determine when to open a link in a new tab


## Why?

When using the web-onboarding in the apps, in a web view, you can't open links with `target=_blank`, in other words, links that would open in a new tab. So when `android` or `ios` variation is active, render a link without `target=_blank`

Things to consider: 

- What should we name the component? 
- Should we rather use the `target=_blank` prop for the component instead of adding a custom one `external`? Might actually prefer that since we would keep the same API as for a regular link.

### Demo
https://user-images.githubusercontent.com/6661511/125460271-f82f60a2-18ea-4479-9669-0f418e7a6223.mov

