### PR TITLE
Disallow indexing of forever pages

### DIFF
--- a/src/client/pages/Forever/index.tsx
+++ b/src/client/pages/Forever/index.tsx
@@ -80,6 +80,7 @@ export const Forever: React.FC<ForeverProps> = ({
       <Helmet>
         <title>{textKeys.FOREVER_LANDINGPAGE_TITLE()}</title>
         <meta property="og:image" content="" />
+        <meta name="robots" content="noindex" />
       </Helmet>
       <SessionContainer>
         {() => (


### PR DESCRIPTION
## What?

Block crawlers by adding noindex meta tag.

## Why?

We don't want people to be able to google for discount codes.
Since this is a single page, it's better use a meta tag instead of including it as part of the robots.txt.

https://developers.google.com/search/docs/advanced/crawling/block-indexing