### PR TITLE
GRW-371 - Add nonce to CSP

### DIFF
--- a/src/server/middleware/helmet.ts
+++ b/src/server/middleware/helmet.ts
@@ -1,4 +1,5 @@
 import koaHelmet from 'koa-helmet'
+import { v4 as uuidV4 } from 'uuid'
 import { CONTENT_SERVICE_ENDPOINT, GIRAFFE_WS_ENDPOINT } from '../config'
 
 const defaultSrc = [
@@ -21,6 +22,7 @@ const defaultSrc = [
   'www.google-analytics.com',
   'www.googletagmanager.com',
   'https://tagmanager.google.com',
+  'https://www.googletagmanager.com',
   'www.googleadservices.com',
   'www.gstatic.com',
   'https://fonts.gstatic.com',
@@ -77,15 +79,18 @@ export const helmet = koaHelmet({
       defaultSrc,
       scriptSrc: [
         "'unsafe-eval'",
-        "'unsafe-inline'",
         'https://browser.sentry-cdn.com',
         ...defaultSrc,
+        (_request: any, response: any) => {
+          response.cspNonce = uuidV4()
+          return `'nonce-${response.cspNonce}'`
+        },
       ],
       styleSrc: [
         "'unsafe-inline'",
         "'self'",
         'checkoutshopper-live.adyen.com',
-        'https://tagmanager.google.com',
+        'https://www.googletagmanager.com',
         'https://fonts.googleapis.com',
         'https://optimize.google.com',
       ],

--- a/src/server/middleware/helmet.ts
+++ b/src/server/middleware/helmet.ts
@@ -90,6 +90,7 @@ export const helmet = koaHelmet({
         "'unsafe-inline'",
         "'self'",
         'checkoutshopper-live.adyen.com',
+        'https://tagmanager.google.com',
         'https://www.googletagmanager.com',
         'https://fonts.googleapis.com',
         'https://optimize.google.com',

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -74,7 +74,7 @@ const template = (
     </script>
 
     <!-- Google Tag Manager -->
-    <script nonce="${cspNonce}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    <script id="gtmScript" nonce="${cspNonce}" data-nonce="${cspNonce}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;j.setAttribute('nonce','${cspNonce}');f.parentNode.insertBefore(j,f);

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -40,6 +40,7 @@ const clientConfig: ClientConfig = {
 const template = (
   route: ServerSideRoute,
   locale: string,
+  cspNonce: string,
   adtractionTag: string | null,
   code: string | null,
 ) => {
@@ -68,20 +69,24 @@ const template = (
      />
      <meta name="google-site-verification" content="AZ5rW7lm8fgkGEsSI8BbV4i45ylXAnGEicXf6HPQE-Q" />
 
-    <script>
+    <script nonce="${cspNonce}">
       dataLayer = [];
     </script>
 
     <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    <script nonce="${cspNonce}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;j.setAttribute('nonce','${cspNonce}');f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-WWMKHK5');</script>
     <!-- End Google Tag Manager -->
 
-    <script key="segment-snippet">${segmentSnippet}</script>
-    ${adtractionTag ? `<script defer src="${adtractionTag}"></script>` : ''}
+    <script key="segment-snippet" nonce="${cspNonce}">${segmentSnippet}</script>
+    ${
+      adtractionTag
+        ? `<script nonce="${cspNonce}" defer src="${adtractionTag}"></script>`
+        : ''
+    }
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->
@@ -91,14 +96,14 @@ const template = (
 
     <div id="react-root"></div>
 
-    <script>
+    <script nonce="${cspNonce}">
       Object.defineProperty(window, 'hedvigClientConfig', {
         value: Object.freeze(${JSON.stringify(clientConfig)}),
         writable: false,
       })
     </script>
     ${getClientScripts()
-      .map((script) => `<script src="${script}"></script>`)
+      .map((script) => `<script nonce="${cspNonce}" src="${script}"></script>`)
       .join('')}
   </body>
   </html>
@@ -148,6 +153,7 @@ export const getPage = (
   ctx.body = template(
     route,
     ctx.params.locale,
+    (ctx.res as any).cspNonce,
     adtractionScript,
     ctx.params.code ?? null,
   )


### PR DESCRIPTION
## What

Remove `unsafe-inline` rule from script-src in our CSP (content security policy). In order to do that we have to add a nonce (number only used once) to all inline scripts. Not a problem for the ones we control, but for GTM we had to pick up the nonce and pass it to the scripts added in GTM. Google themself don't address this issue in their docs, but you basically need to pickup the nonce value in GTM and pass it to the inline script. See attached screen recording how it's done in GTM:


https://user-images.githubusercontent.com/6661511/129705482-b5840a00-1ad5-47d6-b793-bd04a2838b22.mov


So before deploying this to prod we have to update the scripts in GTM, have synced this with Sonny.


## Why
We temporarily added `unsafe-inline` to be able to run Custom HTML tags containing inline scripts. This is not advisable since it's lessens the security of our site. 

## What can be improved:

- We still have `unsafe-inline` on styles. This is due to emotion inlining styles, seems to be a way around it but haven't had time to investigate yet. 
- We have `unasfe-eval` on script-src, and from what I can see we had that from the start, not sure why. This isn't great 😄 Disabling it caused a bunch of errors in our app.js file where webpack seems to output `eval` on a bunch of stuff. So would be good to investigate how to get around that.

### Resources:

- https://www.dumky.net/posts/using-gtm-with-a-content-security-policy-csp-and-impress-your-devops-team-in-the-process/
- https://dev.to/matijamrkaic/using-google-tag-manager-with-a-content-security-policy-9ai
- https://developers.google.com/web/fundamentals/security/csp
- https://developers.google.com/tag-manager/web/csp