### PR TITLE
Track virtual page views

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -13,10 +13,12 @@ import {
   StorageState,
   WithStorageProps,
 } from './utils/StorageContainer'
+import { usePageview } from './utils/tracking/gtm'
 
 export const App: React.ComponentType<StorageState> = ({ session }) => {
   const currentLocale = useCurrentLocale()
   const history = useHistory()
+  usePageview()
 
   return (
     <>

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -19,6 +19,7 @@ type GTMOfferData = {
 type GTMPageData = {
   page: string
   search?: string
+  title: string
 }
 
 type DataLayerObject = {
@@ -39,6 +40,7 @@ export const usePageview = () => {
       pageData: {
         page: location.pathname,
         search: location.search,
+        title: document.title,
       },
     })
   }, [location])

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router'
 import { TypeOfContract } from 'data/graphql'
 import { OfferData } from 'pages/OfferNew/types'
 import { captureSentryError } from 'utils/sentry-client'
+import { useMarket } from 'components/utils/CurrentLocale'
 import { getContractType, DkBundleTypes, NoComboTypes } from './tracking'
 
 type GAContractType = NoComboTypes | DkBundleTypes | TypeOfContract
@@ -20,6 +21,7 @@ type GTMPageData = {
   page: string
   search?: string
   title: string
+  market: string
 }
 
 type DataLayerObject = {
@@ -33,6 +35,7 @@ type DataLayerObject = {
  */
 export const usePageview = () => {
   const location = useLocation()
+  const market = useMarket().toLowerCase()
 
   useEffect(() => {
     pushToGTMDataLayer({
@@ -41,9 +44,10 @@ export const usePageview = () => {
         page: location.pathname,
         search: location.search,
         title: document.title,
+        market: market,
       },
     })
-  }, [location])
+  }, [location, market])
 }
 
 const pushToGTMDataLayer = (obj: DataLayerObject) => {

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router'
 import { TypeOfContract } from 'data/graphql'
 import { OfferData } from 'pages/OfferNew/types'
 import { captureSentryError } from 'utils/sentry-client'
@@ -5,7 +7,7 @@ import { getContractType, DkBundleTypes, NoComboTypes } from './tracking'
 
 type GAContractType = NoComboTypes | DkBundleTypes | TypeOfContract
 
-interface GTMOfferData {
+type GTMOfferData = {
   insurance_type: GAContractType
   referral_code: 'yes' | 'no'
   number_of_people: number
@@ -14,9 +16,32 @@ interface GTMOfferData {
   member_id?: string
 }
 
-export interface DataLayerObject {
+type GTMPageData = {
+  page: string
+  search?: string
+}
+
+type DataLayerObject = {
   event: string
   offerData?: GTMOfferData
+  pageData?: GTMPageData
+}
+
+/**
+ * Track virtual page view when route changes
+ */
+export const usePageview = () => {
+  const location = useLocation()
+
+  useEffect(() => {
+    pushToGTMDataLayer({
+      event: 'virtual_page_view',
+      pageData: {
+        page: location.pathname,
+        search: location.search,
+      },
+    })
+  }, [location])
 }
 
 const pushToGTMDataLayer = (obj: DataLayerObject) => {


### PR DESCRIPTION
## What?
Send page views to Google Tag Manager with custom dimensions specified by Sonny:
<img width="1125" alt="Screenshot 2021-08-24 at 14 33 50" src="https://user-images.githubusercontent.com/6661511/130617444-4889a9b2-9270-4bb2-a482-a8f3f52d6140.png">

The hook sends paga data to GTM on each route change. Added a new type for `GTMPageData`. It might be a bit overkill to have typed datalayer object since we can send basically anything. But we agreed to have it as this for now, if it will grow we can change it.

## Why?
To be able to remove Segment, who currently picks up the virtual page views, we need to send it ourselves. 

https://user-images.githubusercontent.com/6661511/130618481-e99626d4-9c5a-42ef-894a-1b5e46ec8bb9.mov

