### PR TITLE
Track user properties

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -13,12 +13,12 @@ import {
   StorageState,
   WithStorageProps,
 } from './utils/StorageContainer'
-import { usePageview } from './utils/tracking/gtm'
+import { useGTMTracking } from './utils/tracking/gtm'
 
 export const App: React.ComponentType<StorageState> = ({ session }) => {
   const currentLocale = useCurrentLocale()
   const history = useHistory()
-  usePageview()
+  useGTMTracking()
 
   return (
     <>

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -38,9 +38,10 @@ type DataLayerObject = {
 }
 
 /**
+ * Track user properties
  * Track virtual page view when route changes
  */
-export const usePageview = () => {
+export const useGTMTracking = () => {
   const environment = window.hedvigClientConfig.appEnvironment
   const market = useMarket().toLowerCase()
   const location = useLocation()
@@ -52,7 +53,9 @@ export const usePageview = () => {
         market: market,
       },
     })
+  }, [environment, market])
 
+  useEffect(() => {
     pushToGTMDataLayer({
       event: 'virtual_page_view',
       pageData: {
@@ -62,7 +65,7 @@ export const usePageview = () => {
         market: market,
       },
     })
-  }, [environment, location, market])
+  }, [location, market])
 }
 
 const pushToGTMDataLayer = (obj: DataLayerObject) => {

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -49,8 +49,8 @@ export const useGTMTracking = () => {
   useEffect(() => {
     pushToGTMDataLayer({
       userProperties: {
-        environment: environment,
-        market: market,
+        environment,
+        market,
       },
     })
   }, [environment, market])
@@ -62,7 +62,7 @@ export const useGTMTracking = () => {
         page: location.pathname,
         search: location.search,
         title: document.title,
-        market: market,
+        market,
       },
     })
   }, [location, market])

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -4,9 +4,15 @@ import { TypeOfContract } from 'data/graphql'
 import { OfferData } from 'pages/OfferNew/types'
 import { captureSentryError } from 'utils/sentry-client'
 import { useMarket } from 'components/utils/CurrentLocale'
+import { AppEnvironment } from 'shared/clientConfig'
 import { getContractType, DkBundleTypes, NoComboTypes } from './tracking'
 
 type GAContractType = NoComboTypes | DkBundleTypes | TypeOfContract
+
+type GTMUserProperties = {
+  market: string
+  environment: AppEnvironment
+}
 
 type GTMOfferData = {
   insurance_type: GAContractType
@@ -25,7 +31,8 @@ type GTMPageData = {
 }
 
 type DataLayerObject = {
-  event: string
+  event?: string
+  userProperties?: GTMUserProperties
   offerData?: GTMOfferData
   pageData?: GTMPageData
 }
@@ -34,10 +41,18 @@ type DataLayerObject = {
  * Track virtual page view when route changes
  */
 export const usePageview = () => {
-  const location = useLocation()
+  const environment = window.hedvigClientConfig.appEnvironment
   const market = useMarket().toLowerCase()
+  const location = useLocation()
 
   useEffect(() => {
+    pushToGTMDataLayer({
+      userProperties: {
+        environment: environment,
+        market: market,
+      },
+    })
+
     pushToGTMDataLayer({
       event: 'virtual_page_view',
       pageData: {
@@ -47,7 +62,7 @@ export const usePageview = () => {
         market: market,
       },
     })
-  }, [location, market])
+  }, [environment, location, market])
 }
 
 const pushToGTMDataLayer = (obj: DataLayerObject) => {

--- a/src/shared/clientConfig.ts
+++ b/src/shared/clientConfig.ts
@@ -1,10 +1,12 @@
+export type AppEnvironment = 'development' | 'staging' | 'production'
+
 export interface ClientConfig {
   adyenEnvironment: string
   adyenOriginKey: string
   contentServiceEndpoint: string
   giraffeEndpoint: string
   giraffeWsEndpoint: string
-  appEnvironment: 'development' | 'staging' | 'production'
+  appEnvironment: AppEnvironment
 }
 
 declare global {


### PR DESCRIPTION
## What?
Send user properties before we track page views. See documentation:
<img width="1049" alt="Screenshot 2021-08-25 at 16 55 09" src="https://user-images.githubusercontent.com/6661511/130814222-ae44c70d-c434-4c89-959b-1fd8514a1c89.png">

## Why?
Enable easier filtering and attributing of events.
