### PR TITLE
GRW-392 / Feature/ Add insurance selector component

### DIFF
--- a/src/client/components/icons/SelectedOptionCheckmark.tsx
+++ b/src/client/components/icons/SelectedOptionCheckmark.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export const SelectedOptionCheckmark = () => (
+  <svg
+    width="22"
+    height="22"
+    viewBox="0 0 22 22"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M11 22C17.0751 22 22 17.0751 22 11C22 4.92487 17.0751 0 11 0C4.92487 0 0 4.92487 0 11C0 17.0751 4.92487 22 11 22ZM10.2032 15.4305L16.5644 8.16055L15.4356 7.17279L10.1301 13.2361L6.53033 9.63634L5.46967 10.697L10.2032 15.4305Z"
+      fill="#121212"
+    />
+  </svg>
+)

--- a/src/client/components/icons/SelectedOptionCheckmark.tsx
+++ b/src/client/components/icons/SelectedOptionCheckmark.tsx
@@ -10,4 +10,3 @@ export const SelectedOptionCheckmark: React.FC<IconRootProps> = (props) => (
     />
   </IconRoot>
 )
-

--- a/src/client/components/icons/SelectedOptionCheckmark.tsx
+++ b/src/client/components/icons/SelectedOptionCheckmark.tsx
@@ -1,18 +1,13 @@
 import React from 'react'
+import { IconRoot, IconRootProps } from './IconRoot'
 
-export const SelectedOptionCheckmark = () => (
-  <svg
-    width="22"
-    height="22"
-    viewBox="0 0 22 22"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
+export const SelectedOptionCheckmark: React.FC<IconRootProps> = (props) => (
+  <IconRoot {...props} viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
     <path
       fillRule="evenodd"
       clipRule="evenodd"
       d="M11 22C17.0751 22 22 17.0751 22 11C22 4.92487 17.0751 0 11 0C4.92487 0 0 4.92487 0 11C0 17.0751 4.92487 22 11 22ZM10.2032 15.4305L16.5644 8.16055L15.4356 7.17279L10.1301 13.2361L6.53033 9.63634L5.46967 10.697L10.2032 15.4305Z"
-      fill="#121212"
     />
-  </svg>
+  </IconRoot>
 )
+

--- a/src/client/components/icons/UnselectedOptionCircle.tsx
+++ b/src/client/components/icons/UnselectedOptionCircle.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export const UnselectedOptionCircle = () => (
+  <svg
+    width="22"
+    height="22"
+    viewBox="0 0 22 22"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect x="0.5" y="0.5" width="21" height="21" rx="10.5" stroke="#AAAAAA" />
+  </svg>
+)

--- a/src/client/pages/OfferNew/InsuranceSelector/Card.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Card.tsx
@@ -1,0 +1,88 @@
+import styled from '@emotion/styled'
+import { colorsV3 } from '@hedviginsurance/brand'
+import React from 'react'
+import { SelectedOptionCheckmark } from 'components/icons/SelectedOptionCheckmark'
+import { UnselectedOptionCircle } from 'components/icons/UnselectedOptionCircle'
+import { MEDIUM_SMALL_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
+
+const Container = styled.div<{ selected?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-width: 2px;
+  border-style: solid;
+  border-color: ${({ selected }) =>
+    selected ? colorsV3.gray900 : colorsV3.gray500};
+  border-radius: 0.5rem;
+  padding: 1rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  min-height: 6.625rem;
+
+  ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
+    height: 9.25rem;
+  }
+`
+
+const LabelWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`
+
+const Label = styled.span`
+  font-size: 0.75rem;
+  line-height: 1rem;
+  margin-left: 0.5rem;
+  color: ${colorsV3.gray700};
+`
+
+const NameAndPriceWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-top: 1.75rem;
+`
+
+const Name = styled.div`
+  font-size: 1rem;
+  line-height: 1.5rem;
+`
+
+const Price = styled.div`
+  color: ${colorsV3.gray700};
+`
+
+interface Props {
+  name: string
+  price: number
+  label?: string
+  selected?: boolean
+  currency: string
+  onClick: () => void
+}
+
+export const Card: React.FC<Props> = ({
+  name,
+  price,
+  currency,
+  label,
+  selected,
+  onClick,
+}) => {
+  return (
+    <Container selected={selected} onClick={onClick}>
+      <LabelWrapper>
+        {selected ? <SelectedOptionCheckmark /> : <UnselectedOptionCircle />}
+        {label && <Label>{label}</Label>}
+      </LabelWrapper>
+      <NameAndPriceWrapper>
+        <Name>{name}</Name>
+        <Price>
+          {price}
+          {currency}
+        </Price>
+      </NameAndPriceWrapper>
+    </Container>
+  )
+}

--- a/src/client/pages/OfferNew/InsuranceSelector/Card.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Card.tsx
@@ -49,6 +49,7 @@ const NameAndPriceWrapper = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: flex-end;
+  gap: 1rem;
   margin-top: 1.75rem;
 `
 
@@ -57,24 +58,35 @@ const Name = styled.div`
   line-height: 1.5rem;
 `
 
+const PriceWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+`
+
 const Price = styled.div`
   color: ${colorsV3.gray700};
 `
 
+const FullPrice = styled(Price)`
+  font-size: 0.875rem;
+  text-decoration: line-through;
+`
+
 interface Props {
   name: string
-  price: number
+  price: string
+  fullPrice?: string
   label?: string
   selected?: boolean
   focused?: boolean
-  currency: string
   onClick: () => void
 }
 
 export const Card: React.FC<Props> = ({
   name,
   price,
-  currency,
+  fullPrice,
   label,
   selected,
   onClick,
@@ -88,10 +100,10 @@ export const Card: React.FC<Props> = ({
       </LabelWrapper>
       <NameAndPriceWrapper>
         <Name>{name}</Name>
-        <Price>
-          {price}
-          {currency}
-        </Price>
+        <PriceWrapper>
+          {fullPrice ? <FullPrice>{fullPrice}</FullPrice> : null}
+          <Price>{price}</Price>
+        </PriceWrapper>
       </NameAndPriceWrapper>
     </Container>
   )

--- a/src/client/pages/OfferNew/InsuranceSelector/Card.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Card.tsx
@@ -101,7 +101,7 @@ export const Card: React.FC<Props> = ({
       <NameAndPriceWrapper>
         <Name>{name}</Name>
         <PriceWrapper>
-          {grossPrice ? <GrossPrice>{grossPrice}</GrossPrice> : null}
+          {grossPrice && <GrossPrice>{grossPrice}</GrossPrice>}
           <Price>{price}</Price>
         </PriceWrapper>
       </NameAndPriceWrapper>

--- a/src/client/pages/OfferNew/InsuranceSelector/Card.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Card.tsx
@@ -5,14 +5,18 @@ import { SelectedOptionCheckmark } from 'components/icons/SelectedOptionCheckmar
 import { UnselectedOptionCircle } from 'components/icons/UnselectedOptionCircle'
 import { MEDIUM_SMALL_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
 
-const Container = styled.div<{ selected?: boolean }>`
+const Container = styled.div<{ selected?: boolean; focused?: boolean }>`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   border-width: 2px;
   border-style: solid;
-  border-color: ${({ selected }) =>
-    selected ? colorsV3.gray900 : colorsV3.gray500};
+  border-color: ${({ selected, focused }) =>
+    selected
+      ? colorsV3.gray900
+      : focused
+      ? colorsV3.gray700
+      : colorsV3.gray500};
   border-radius: 0.5rem;
   padding: 1rem;
   font-size: 1rem;
@@ -21,6 +25,10 @@ const Container = styled.div<{ selected?: boolean }>`
 
   ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
     height: 9.25rem;
+  }
+
+  &:hover {
+    border-color: ${colorsV3.gray700};
   }
 `
 
@@ -58,6 +66,7 @@ interface Props {
   price: number
   label?: string
   selected?: boolean
+  focused?: boolean
   currency: string
   onClick: () => void
 }
@@ -69,9 +78,10 @@ export const Card: React.FC<Props> = ({
   label,
   selected,
   onClick,
+  focused,
 }) => {
   return (
-    <Container selected={selected} onClick={onClick}>
+    <Container selected={selected} focused={focused} onClick={onClick}>
       <LabelWrapper>
         {selected ? <SelectedOptionCheckmark /> : <UnselectedOptionCircle />}
         {label && <Label>{label}</Label>}

--- a/src/client/pages/OfferNew/InsuranceSelector/Card.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Card.tsx
@@ -68,7 +68,7 @@ const Price = styled.div`
   color: ${colorsV3.gray700};
 `
 
-const FullPrice = styled(Price)`
+const GrossPrice = styled(Price)`
   font-size: 0.875rem;
   text-decoration: line-through;
 `
@@ -76,7 +76,7 @@ const FullPrice = styled(Price)`
 interface Props {
   name: string
   price: string
-  fullPrice?: string
+  grossPrice?: string
   label?: string
   selected?: boolean
   focused?: boolean
@@ -86,7 +86,7 @@ interface Props {
 export const Card: React.FC<Props> = ({
   name,
   price,
-  fullPrice,
+  grossPrice,
   label,
   selected,
   onClick,
@@ -101,7 +101,7 @@ export const Card: React.FC<Props> = ({
       <NameAndPriceWrapper>
         <Name>{name}</Name>
         <PriceWrapper>
-          {fullPrice ? <FullPrice>{fullPrice}</FullPrice> : null}
+          {grossPrice ? <GrossPrice>{grossPrice}</GrossPrice> : null}
           <Price>{price}</Price>
         </PriceWrapper>
       </NameAndPriceWrapper>

--- a/src/client/pages/OfferNew/InsuranceSelector/Selector.stories.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Selector.stories.tsx
@@ -36,5 +36,15 @@ export default {
 }
 
 export const Default = () => {
-  return <Selector insurances={mockInsurances} onChange={(id) => alert(id)} />
+  const [insurances, setInsurances] = React.useState(mockInsurances)
+  return (
+    <Selector
+      insurances={insurances}
+      onChange={(id) =>
+        setInsurances((prev) =>
+          prev.map((item) => ({ ...item, selected: item.id === id })),
+        )
+      }
+    />
+  )
 }

--- a/src/client/pages/OfferNew/InsuranceSelector/Selector.stories.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Selector.stories.tsx
@@ -6,7 +6,7 @@ const mockInsurances = [
     id: '1',
     name: 'Inbo, Ulykke & Rejse',
     price: '329 kr/md',
-    fullPrice: '369 kr',
+    grossPrice: '369 kr',
     label: '3-in-1',
     selected: true,
   },

--- a/src/client/pages/OfferNew/InsuranceSelector/Selector.stories.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Selector.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { Selector } from './Selector'
+
+const mockInsurances = [
+  {
+    id: '1',
+    name: 'Inbo, Ulykke & Rejse',
+    price: 329,
+    currency: 'kr/md',
+    label: '3-in-1',
+    selected: true,
+  },
+  {
+    id: '2',
+    name: 'Inbo &  Ulykke',
+    price: 279,
+    currency: 'kr/md',
+    label: '2-in-1',
+    selected: false,
+  },
+  {
+    id: '3',
+    name: 'Inbo',
+    price: 189,
+    currency: 'kr/md',
+    selected: false,
+  },
+]
+
+export default {
+  title: 'Offer/InsuranceSelector',
+  component: Selector,
+  parameters: {
+    backgrounds: { default: 'gray100' },
+  },
+}
+
+export const Default = () => {
+  return <Selector insurances={mockInsurances} onChange={(id) => alert(id)} />
+}

--- a/src/client/pages/OfferNew/InsuranceSelector/Selector.stories.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Selector.stories.tsx
@@ -35,14 +35,11 @@ export default {
 
 export const Default = () => {
   const [insurances, setInsurances] = React.useState(mockInsurances)
-  return (
-    <Selector
-      insurances={insurances}
-      onChange={(id) =>
-        setInsurances((prev) =>
-          prev.map((item) => ({ ...item, selected: item.id === id })),
-        )
-      }
-    />
-  )
+
+  const handleOnChange = (id: string) =>
+    setInsurances((prev) =>
+      prev.map((item) => ({ ...item, selected: item.id === id })),
+    )
+
+  return <Selector insurances={insurances} onChange={handleOnChange} />
 }

--- a/src/client/pages/OfferNew/InsuranceSelector/Selector.stories.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Selector.stories.tsx
@@ -5,24 +5,22 @@ const mockInsurances = [
   {
     id: '1',
     name: 'Inbo, Ulykke & Rejse',
-    price: 329,
-    currency: 'kr/md',
+    price: '329 kr/md',
+    fullPrice: '369 kr',
     label: '3-in-1',
     selected: true,
   },
   {
     id: '2',
     name: 'Inbo &  Ulykke',
-    price: 279,
-    currency: 'kr/md',
+    price: '279 kr/md',
     label: '2-in-1',
     selected: false,
   },
   {
     id: '3',
     name: 'Inbo',
-    price: 189,
-    currency: 'kr/md',
+    price: '189 kr/md',
     selected: false,
   },
 ]

--- a/src/client/pages/OfferNew/InsuranceSelector/Selector.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Selector.tsx
@@ -27,7 +27,7 @@ interface Props {
     id: string
     name: string
     price: string
-    fullPrice?: string
+    grossPrice?: string
     label?: string
     selected?: boolean
   }[]
@@ -81,7 +81,7 @@ export const Selector: React.FC<Props> = ({ insurances, onChange }) => {
       aria-activedescendant={focusId ?? undefined}
       onKeyDown={handleContainerKeyPress}
     >
-      {insurances.map(({ id, name, price, fullPrice, label, selected }) => (
+      {insurances.map(({ id, name, price, grossPrice, label, selected }) => (
         <CardWrapper
           id={id}
           key={id}
@@ -95,7 +95,7 @@ export const Selector: React.FC<Props> = ({ insurances, onChange }) => {
             focused={focusId === id}
             name={name}
             price={price}
-            fullPrice={fullPrice}
+            grossPrice={grossPrice}
             label={label}
           />
         </CardWrapper>

--- a/src/client/pages/OfferNew/InsuranceSelector/Selector.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Selector.tsx
@@ -22,7 +22,7 @@ const CardWrapper = styled.div`
   cursor: pointer;
 `
 
-interface Props {
+type Props = {
   insurances: {
     id: string
     name: string

--- a/src/client/pages/OfferNew/InsuranceSelector/Selector.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Selector.tsx
@@ -1,5 +1,5 @@
+import React, { useState, KeyboardEvent } from 'react'
 import styled from '@emotion/styled'
-import React from 'react'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { MEDIUM_SMALL_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
 import { Card } from './Card'
@@ -10,6 +10,13 @@ const CardListContainer = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   background-color: ${colorsV3.gray100};
+
+  &:focus {
+    div#${(props) => CSS.escape(props['aria-activedescendant'] || 'test')} {
+      background-color: red;
+      box-shaddow: 0 0 0 8px #f1f2f6;
+    }
+  }
 `
 
 const CardWrapper = styled.div`
@@ -21,6 +28,14 @@ const CardWrapper = styled.div`
     margin-right: 1rem;
   }
 `
+
+const KeyCodes = {
+  arrowLeft: 37,
+  arrowUp: 38,
+  arrowRight: 39,
+  arrowDown: 40,
+  space: 32,
+}
 
 interface Props {
   insurances: {
@@ -35,12 +50,72 @@ interface Props {
 }
 
 export const Selector: React.FC<Props> = ({ insurances, onChange }) => {
+  const [focusId, setFocusId] = useState('')
+
+  const handleInitialFocus = () => {
+    if (!focusId) setFocusId(`${insurances[0].id}`)
+  }
+
+  const handleCardClick = (id: string) => {
+    setFocusId(id)
+    onChange(id)
+  }
+
+  const handleContainerKeyPress = (event: KeyboardEvent) => {
+    switch (event.keyCode) {
+      case KeyCodes.arrowLeft:
+      case KeyCodes.arrowUp:
+        event.preventDefault()
+        const previousInsuranceIndex =
+          insurances.findIndex((x) => x.id === focusId) - 1
+        if (previousInsuranceIndex >= 0) {
+          const previousInsuranceId = insurances[previousInsuranceIndex].id
+          setFocusId(previousInsuranceId)
+          onChange(previousInsuranceId)
+        } else {
+          const lastInsuranceId = insurances[insurances.length - 1].id
+          setFocusId(lastInsuranceId)
+          onChange(lastInsuranceId)
+        }
+        break
+      case KeyCodes.arrowRight:
+      case KeyCodes.arrowDown:
+        event.preventDefault()
+        const nextInsuranceIndex =
+          insurances.findIndex((x) => x.id === focusId) + 1
+        if (nextInsuranceIndex < insurances.length) {
+          const nextInsuranceId = insurances[nextInsuranceIndex].id
+          setFocusId(nextInsuranceId)
+          onChange(nextInsuranceId)
+        } else {
+          const firstInsuranceId = insurances[0].id
+          setFocusId(firstInsuranceId)
+          onChange(firstInsuranceId)
+        }
+        break
+      default:
+        break
+    }
+  }
+
   return (
-    <CardListContainer>
+    <CardListContainer
+      tabIndex={0}
+      role="radio-group"
+      aria-activedescendant={focusId}
+      onFocus={handleInitialFocus}
+      onKeyDown={handleContainerKeyPress}
+    >
       {insurances.map(({ id, name, price, label, selected, currency }) => (
-        <CardWrapper key={id}>
+        <CardWrapper
+          id={`${id}`}
+          key={id}
+          tabIndex={0}
+          role="radio"
+          aria-checked={selected}
+        >
           <Card
-            onClick={() => onChange(id)}
+            onClick={() => handleCardClick(id)}
             selected={selected}
             name={name}
             price={price}

--- a/src/client/pages/OfferNew/InsuranceSelector/Selector.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Selector.tsx
@@ -65,9 +65,9 @@ export const Selector: React.FC<Props> = ({ insurances, onChange }) => {
       case 'ArrowDown':
         event.preventDefault()
         onChange(
-          currentFocusIndex <= insurances.length - 1 - 1
-            ? insurances[currentFocusIndex + 1].id
-            : insurances[0].id,
+          currentFocusIndex === insurances.length - 1
+            ? insurances[0].id
+            : insurances[currentFocusIndex + 1].id,
         )
         break
       default:

--- a/src/client/pages/OfferNew/InsuranceSelector/Selector.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Selector.tsx
@@ -1,15 +1,20 @@
 import React, { useState, KeyboardEvent, useEffect } from 'react'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
+import { MEDIUM_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
 import { Card } from './Card'
 
 const CardListContainer = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   grid-auto-rows: auto;
   gap: 1rem;
   background-color: ${colorsV3.gray100};
   outline: none;
+
+  ${MEDIUM_SCREEN_MEDIA_QUERY} {
+    grid-template-columns: 1fr 1fr;
+  }
 `
 
 const CardWrapper = styled.div`
@@ -21,10 +26,10 @@ interface Props {
   insurances: {
     id: string
     name: string
-    price: number
+    price: string
+    fullPrice?: string
     label?: string
     selected?: boolean
-    currency: string
   }[]
   onChange: (id: string) => void
 }
@@ -76,7 +81,7 @@ export const Selector: React.FC<Props> = ({ insurances, onChange }) => {
       aria-activedescendant={focusId ?? undefined}
       onKeyDown={handleContainerKeyPress}
     >
-      {insurances.map(({ id, name, price, label, selected, currency }) => (
+      {insurances.map(({ id, name, price, fullPrice, label, selected }) => (
         <CardWrapper
           id={id}
           key={id}
@@ -90,8 +95,8 @@ export const Selector: React.FC<Props> = ({ insurances, onChange }) => {
             focused={focusId === id}
             name={name}
             price={price}
+            fullPrice={fullPrice}
             label={label}
-            currency={currency}
           />
         </CardWrapper>
       ))}

--- a/src/client/pages/OfferNew/InsuranceSelector/Selector.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/Selector.tsx
@@ -1,0 +1,54 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import { colorsV3 } from '@hedviginsurance/brand'
+import { MEDIUM_SMALL_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
+import { Card } from './Card'
+
+const CardListContainer = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: row;
+  flex-wrap: wrap;
+  background-color: ${colorsV3.gray100};
+`
+
+const CardWrapper = styled.div`
+  width: 100%;
+  margin-bottom: 1rem;
+
+  ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
+    width: calc(50% - 1rem);
+    margin-right: 1rem;
+  }
+`
+
+interface Props {
+  insurances: {
+    id: string
+    name: string
+    price: number
+    label?: string
+    selected?: boolean
+    currency: string
+  }[]
+  onChange: (id: string) => void
+}
+
+export const Selector: React.FC<Props> = ({ insurances, onChange }) => {
+  return (
+    <CardListContainer>
+      {insurances.map(({ id, name, price, label, selected, currency }) => (
+        <CardWrapper key={id}>
+          <Card
+            onClick={() => onChange(id)}
+            selected={selected}
+            name={name}
+            price={price}
+            label={label}
+            currency={currency}
+          />
+        </CardWrapper>
+      ))}
+    </CardListContainer>
+  )
+}

--- a/src/client/pages/OfferNew/InsuranceSelector/index.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/index.tsx
@@ -18,18 +18,14 @@ export const InsuranceSelector: React.FC<Props> = ({
   selectedQuoteBundle,
   onChange,
 }) => {
-  const memoizedQuoteMap = useMemo(() => {
-    const quoteMap: Record<string, QuoteBundleVariant> = variations.reduce(
-      (acc, { bundle }) => {
-        return {
-          ...acc,
-          [bundle.id]: bundle,
-        }
-      },
-      {},
-    )
-    return quoteMap
-  }, [variations])
+  const quoteMap = useMemo(
+    () =>
+      variations.reduce<Record<string, QuoteBundleVariant>>(
+        (acc, { bundle }) => ({ ...acc, [bundle.id]: bundle }),
+        {},
+      ),
+    [variations],
+  )
 
   const insurances = variations.map(({ label, bundle }) => {
     const {
@@ -59,7 +55,7 @@ export const InsuranceSelector: React.FC<Props> = ({
   return (
     <Selector
       insurances={insurances}
-      onChange={(id: string) => onChange(memoizedQuoteMap[id])}
+      onChange={(id: string) => onChange(quoteMap[id])}
     />
   )
 }

--- a/src/client/pages/OfferNew/InsuranceSelector/index.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/index.tsx
@@ -1,18 +1,16 @@
 import React, { useMemo } from 'react'
-import { QuoteBundle } from 'src/client/data/graphql'
-import { getBundleId } from 'pages/OfferNew/utils'
+import { QuoteBundleVariant } from 'src/client/data/graphql'
 import { Selector } from './Selector'
 
-// TODO: To be replaced once the new type for variations is in place
 interface Variation {
   label?: string
-  bundle: QuoteBundle
+  bundle: QuoteBundleVariant
 }
 
 interface Props {
   variations: Variation[]
-  selectedQuoteBundle?: QuoteBundle
-  onChange: (bundle?: QuoteBundle) => void
+  selectedQuoteBundle?: QuoteBundleVariant
+  onChange: (bundle?: QuoteBundleVariant) => void
 }
 
 export const InsuranceSelector: React.FC<Props> = ({
@@ -21,11 +19,11 @@ export const InsuranceSelector: React.FC<Props> = ({
   onChange,
 }) => {
   const memoizedQuoteMap = useMemo(() => {
-    const quoteMap: Record<string, QuoteBundle> = variations.reduce(
+    const quoteMap: Record<string, QuoteBundleVariant> = variations.reduce(
       (acc, { bundle }) => {
         return {
           ...acc,
-          [getBundleId(bundle)]: bundle,
+          [bundle.id]: bundle,
         }
       },
       {},
@@ -35,20 +33,26 @@ export const InsuranceSelector: React.FC<Props> = ({
 
   const insurances = variations.map(({ label, bundle }) => {
     const {
-      displayName,
-      bundleCost: {
-        monthlyNet: { amount, currency },
+      id: bundleId,
+      bundle: {
+        displayName,
+        bundleCost: {
+          monthlyNet: { amount, currency },
+          monthlyGross: { amount: grossAmount, currency: grossCurrency },
+        },
       },
     } = bundle
-    const bundleId = getBundleId(bundle)
+
     return {
       id: bundleId,
       label,
       name: displayName,
-      price: Math.round(Number(amount)),
-      currency,
-      selected:
-        selectedQuoteBundle && bundleId === getBundleId(selectedQuoteBundle),
+      price: `${Math.round(Number(amount))} ${currency}`,
+      fullPrice:
+        amount !== grossAmount
+          ? `${Math.round(Number(grossAmount))} ${grossCurrency}`
+          : undefined,
+      selected: selectedQuoteBundle && bundleId === selectedQuoteBundle.id,
     }
   })
 

--- a/src/client/pages/OfferNew/InsuranceSelector/index.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/index.tsx
@@ -1,0 +1,61 @@
+import React, { useMemo } from 'react'
+import { QuoteBundle } from 'src/client/data/graphql'
+import { getBundleId } from 'pages/OfferNew/utils'
+import { Selector } from './Selector'
+
+// TODO: To be replaced once the new type for variations is in place
+interface Variation {
+  label?: string
+  bundle: QuoteBundle
+}
+
+interface Props {
+  variations: Variation[]
+  selectedQuoteBundle?: QuoteBundle
+  onChange: (bundle?: QuoteBundle) => void
+}
+
+export const InsuranceSelector: React.FC<Props> = ({
+  variations,
+  selectedQuoteBundle,
+  onChange,
+}) => {
+  const memoizedQuoteMap = useMemo(() => {
+    const quoteMap: Record<string, QuoteBundle> = variations.reduce(
+      (acc, { bundle }) => {
+        return {
+          ...acc,
+          [getBundleId(bundle)]: bundle,
+        }
+      },
+      {},
+    )
+    return quoteMap
+  }, [variations])
+
+  const insurances = variations.map(({ label, bundle }) => {
+    const {
+      displayName,
+      bundleCost: {
+        monthlyNet: { amount, currency },
+      },
+    } = bundle
+    const bundleId = getBundleId(bundle)
+    return {
+      id: bundleId,
+      label,
+      name: displayName,
+      price: Math.round(Number(amount)),
+      currency,
+      selected:
+        selectedQuoteBundle && bundleId === getBundleId(selectedQuoteBundle),
+    }
+  })
+
+  return (
+    <Selector
+      insurances={insurances}
+      onChange={(id: string) => onChange(memoizedQuoteMap[id])}
+    />
+  )
+}

--- a/src/client/pages/OfferNew/InsuranceSelector/index.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/index.tsx
@@ -48,7 +48,7 @@ export const InsuranceSelector: React.FC<Props> = ({
       label,
       name: displayName,
       price: `${Math.round(Number(amount))} ${currency}`,
-      fullPrice:
+      grossPrice:
         amount !== grossAmount
           ? `${Math.round(Number(grossAmount))} ${grossCurrency}`
           : undefined,

--- a/src/client/pages/OfferNew/InsuranceSelector/index.tsx
+++ b/src/client/pages/OfferNew/InsuranceSelector/index.tsx
@@ -2,60 +2,52 @@ import React, { useMemo } from 'react'
 import { QuoteBundleVariant } from 'src/client/data/graphql'
 import { Selector } from './Selector'
 
-interface Variation {
-  label?: string
-  bundle: QuoteBundleVariant
-}
-
 interface Props {
-  variations: Variation[]
+  variants: QuoteBundleVariant[]
   selectedQuoteBundle?: QuoteBundleVariant
   onChange: (bundle?: QuoteBundleVariant) => void
 }
 
 export const InsuranceSelector: React.FC<Props> = ({
-  variations,
+  variants,
   selectedQuoteBundle,
   onChange,
 }) => {
-  const quoteMap = useMemo(
+  const variantMap = useMemo(
     () =>
-      variations.reduce<Record<string, QuoteBundleVariant>>(
-        (acc, { bundle }) => ({ ...acc, [bundle.id]: bundle }),
+      variants.reduce<Record<string, QuoteBundleVariant>>(
+        (acc, variant) => ({ ...acc, [variant.id]: variant }),
         {},
       ),
-    [variations],
+    [variants],
   )
 
-  const insurances = variations.map(({ label, bundle }) => {
+  const insurances = variants.map(({ id, tag, bundle }) => {
     const {
-      id: bundleId,
-      bundle: {
-        displayName,
-        bundleCost: {
-          monthlyNet: { amount, currency },
-          monthlyGross: { amount: grossAmount, currency: grossCurrency },
-        },
+      displayName,
+      bundleCost: {
+        monthlyNet: { amount, currency },
+        monthlyGross: { amount: grossAmount, currency: grossCurrency },
       },
     } = bundle
 
     return {
-      id: bundleId,
-      label,
+      id,
+      label: tag ?? undefined,
       name: displayName,
       price: `${Math.round(Number(amount))} ${currency}`,
       grossPrice:
         amount !== grossAmount
           ? `${Math.round(Number(grossAmount))} ${grossCurrency}`
           : undefined,
-      selected: selectedQuoteBundle && bundleId === selectedQuoteBundle.id,
+      selected: selectedQuoteBundle && id === selectedQuoteBundle.id,
     }
   })
 
   return (
     <Selector
       insurances={insurances}
-      onChange={(id: string) => onChange(quoteMap[id])}
+      onChange={(id: string) => onChange(variantMap[id])}
     />
   )
 }

--- a/src/client/pages/OfferNew/utils.ts
+++ b/src/client/pages/OfferNew/utils.ts
@@ -22,6 +22,9 @@ import { birthDateFormats } from 'l10n/birthDateAndSsnFormats'
 import { Address, OfferData, OfferQuote } from 'pages/OfferNew/types'
 import { TextKeyMap } from 'utils/textKeys'
 
+export const getBundleId = (bundle: QuoteBundle) =>
+  bundle.quotes.map(({ id }) => id).join('+')
+
 export const getOfferData = (quoteBundle: QuoteBundle): OfferData => {
   const firstQuote = quoteBundle.quotes[0]
   return {

--- a/src/client/pages/OfferNew/utils.ts
+++ b/src/client/pages/OfferNew/utils.ts
@@ -22,9 +22,6 @@ import { birthDateFormats } from 'l10n/birthDateAndSsnFormats'
 import { Address, OfferData, OfferQuote } from 'pages/OfferNew/types'
 import { TextKeyMap } from 'utils/textKeys'
 
-export const getBundleId = (bundle: QuoteBundle) =>
-  bundle.quotes.map(({ id }) => id).join('+')
-
 export const getOfferData = (quoteBundle: QuoteBundle): OfferData => {
   const firstQuote = quoteBundle.quotes[0]
   return {


### PR DESCRIPTION
## What?

Add a new `<InsuranceSelector>` component to be able to toggle different bundles directly on the offer page.

Here is an example of how to use this component

```React
<InsuranceSelector
  variants={quoteBundle.possibleVariations}
  selectedQuoteBundle={selectedQuoteBundle}
  onChange={(bundle) => setSelectedQuoteBundle(bundle)}
/>
```

* This will consume the `possibleVariations` that part of `QuoteBundle` query.
* PR for update the the `QuoteBundle` in giraffe is [here](https://github.com/HedvigInsurance/giraffe/pull/1333)
* Integrating this component into the offer page will be done as part of [GRW-391]

## Why?

This is to allow members to get a smaller or larger bundle depending on their needs without going through the whole onboarding again.

_Referenced ticket(s): [GRW-392]_

## Demo
![Screenshot 2021-09-23 at 13 24 36](https://user-images.githubusercontent.com/89857278/134498933-c0a07953-92a2-43ca-ae46-5937dbd36724.png)
![Screenshot 2021-09-23 at 13 24 55](https://user-images.githubusercontent.com/89857278/134498936-14328c3f-0e28-40bf-964e-5854adc19aac.png)


[GRW-391]: https://hedvig.atlassian.net/browse/GRW-391
[GRW-392]: https://hedvig.atlassian.net/browse/GRW-392