### PR TITLE
GRW-433 / Hotfix / Fix broken comparison for switcher flow on offer page

### DIFF
--- a/src/client/pages/OfferNew/Introduction/ExternalInsuranceProvider/Compare.tsx
+++ b/src/client/pages/OfferNew/Introduction/ExternalInsuranceProvider/Compare.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { externalInsuranceProviders } from '@hedviginsurance/embark'
 import React from 'react'
-import { HedvigLogo } from 'components/icons/HedvigLogo'
 import { InsuranceCost, InsuranceDataCollection } from 'data/graphql'
 import { Price } from '../../components'
 
@@ -28,11 +27,14 @@ const CompareBox = styled.div<{ isExternalProvider?: boolean }>`
   padding: 1.25rem;
   border-radius: 0.5rem;
   width: 100%;
+  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.05);
+
   ${({ isExternalProvider }) =>
     isExternalProvider &&
     `
-    background-color: rgba(255,255,255,0.25);
-    color: ${colorsV3.white};
+    background-color: ${colorsV3.gray300};
+    color: ${colorsV3.gray700};
+    box-shadow: none;  
   `};
 `
 
@@ -40,6 +42,8 @@ const CompareBoxName = styled.div`
   display: flex;
   align-items: center;
   font-weight: 300;
+  line-height: 2rem;
+  font-size: 1.5rem;
 `
 
 const CompareBoxTitle = styled.div`
@@ -68,9 +72,7 @@ export const Compare: React.FC<Props> = ({ insuranceDataCollection, cost }) => {
     <Wrapper>
       <CompareBox>
         <CompareBoxTitle>
-          <CompareBoxName>
-            <HedvigLogo width={94} />
-          </CompareBoxName>
+          <CompareBoxName>Hedvig</CompareBoxName>
           <Price
             monthlyGross={cost.monthlyGross}
             monthlyNet={cost.monthlyNet}
@@ -82,7 +84,6 @@ export const Compare: React.FC<Props> = ({ insuranceDataCollection, cost }) => {
         <CompareBoxTitle>
           <CompareBoxName>{externalInsuranceProvider?.name}</CompareBoxName>
           <Price
-            lightAppearance
             monthlyGross={
               insuranceDataCollection.monthlyPremium || {
                 amount: '0',

--- a/src/client/pages/OfferNew/Introduction/index.tsx
+++ b/src/client/pages/OfferNew/Introduction/index.tsx
@@ -43,6 +43,10 @@ const HeroContentWrapper = styled.div`
   }
 `
 
+const InsuranceProviderWrapper = styled.div`
+  margin-top: 3rem;
+`
+
 const HeroOfferDetailsContainer = styled.div`
   width: 100%;
 `
@@ -88,10 +92,14 @@ export const Introduction: React.FC<Props> = ({
                 refetchOfferData={refetch}
               />
               {hasDataCollection && (
-                <ExternalInsuranceProvider
-                  dataCollectionId={offerData.quotes[0].dataCollectionId || ''}
-                  offerData={offerData}
-                />
+                <InsuranceProviderWrapper>
+                  <ExternalInsuranceProvider
+                    dataCollectionId={
+                      offerData.quotes[0].dataCollectionId || ''
+                    }
+                    offerData={offerData}
+                  />
+                </InsuranceProviderWrapper>
               )}
             </HeroOfferDetailsContainer>
             <Sidebar


### PR DESCRIPTION
## What?

Broken comparison on the offer page for Switcher flow. Alignment and spacing is off. Wrong background on mobile.

See ticket for bug screenshots

## Why?

The visuals should be good. The comparison was not even visible on mobile.

## Screenshots
_Referenced ticket(s): [GRW-433]_

### Error State
![Screenshot 2021-10-04 at 11 54 49](https://user-images.githubusercontent.com/89857278/135832611-cf071544-bd80-4eae-a21c-7637d550b920.png)
![Screenshot 2021-10-04 at 11 55 01](https://user-images.githubusercontent.com/89857278/135832616-b336d9ed-a8b4-4a2c-8851-b0908c87c0de.png)

### Comparison State
![Screenshot 2021-10-04 at 11 56 23](https://user-images.githubusercontent.com/89857278/135832617-da9b5899-5f20-4f76-a960-fe91408d8555.png)
![Screenshot 2021-10-04 at 11 56 40](https://user-images.githubusercontent.com/89857278/135832618-61df8a4e-7b57-4dfe-928e-1aaf8a5c2f05.png)

[GRW-433]: https://hedvig.atlassian.net/browse/GRW-433