### PR TITLE
GRW-444 / Fix / Fix checkbox sizes

### DIFF
--- a/src/client/components/icons/IconRoot.tsx
+++ b/src/client/components/icons/IconRoot.tsx
@@ -9,5 +9,6 @@ export const IconRoot = styled.svg<IconRootProps>`
   width: 1em;
   height: 1em;
   fill: ${(props) => (props.color ? props.color : 'currentColor')};
+  color: ${(props) => (props.color ? props.color : 'currentColor')};
   font-size: ${(props) => (props.size ? props.size : '1.5rem')};
 `

--- a/src/client/components/icons/SelectedOptionCheckmark.tsx
+++ b/src/client/components/icons/SelectedOptionCheckmark.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { colorsV3 } from '@hedviginsurance/brand'
 import { IconRoot, IconRootProps } from './IconRoot'
 
 export const SelectedOptionCheckmark: React.FC<IconRootProps> = (props) => (
@@ -10,3 +11,7 @@ export const SelectedOptionCheckmark: React.FC<IconRootProps> = (props) => (
     />
   </IconRoot>
 )
+
+SelectedOptionCheckmark.defaultProps = {
+  color: colorsV3.gray900,
+}

--- a/src/client/components/icons/UnselectedOptionCircle.tsx
+++ b/src/client/components/icons/UnselectedOptionCircle.tsx
@@ -1,13 +1,21 @@
 import React from 'react'
+import { colorsV3 } from '@hedviginsurance/brand'
+import { IconRoot, IconRootProps } from './IconRoot'
 
-export const UnselectedOptionCircle = () => (
-  <svg
-    width="22"
-    height="22"
-    viewBox="0 0 22 22"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <rect x="0.5" y="0.5" width="21" height="21" rx="10.5" stroke="#AAAAAA" />
-  </svg>
+export const UnselectedOptionCircle: React.FC<IconRootProps> = (props) => (
+  <IconRoot {...props} viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="0.5"
+      y="0.5"
+      width="21"
+      height="21"
+      rx="10.5"
+      stroke="currentColor"
+      fill="none"
+    />
+  </IconRoot>
 )
+
+UnselectedOptionCircle.defaultProps = {
+  color: colorsV3.gray500,
+}


### PR DESCRIPTION
## What?

Use `IconRoot` for `UnselectedOptionCircle`
Use colors from brand-repo.
Set color CSS value in `IconRoot`.

## Why?

Icon size in checkboxes are different.

## Demo

<img width="365" alt="Screenshot 2021-10-12 at 16 08 21" src="https://user-images.githubusercontent.com/1220232/136975619-e76f2e5e-5149-4e9c-a053-74c6782a0c73.png">

(trust me, they are both 22x22 px 🤞)