### PR TITLE
Disable credit checks temporarily

### DIFF
--- a/src/client/utils/featureToggles.ts
+++ b/src/client/utils/featureToggles.ts
@@ -2,6 +2,8 @@ import { Market, useMarket } from '../components/utils/CurrentLocale'
 
 export const useCreditCheckInfo = () => {
   const market = useMarket()
-
-  return [Market.No].includes(market)
+  return (
+    [Market.No].includes(market) &&
+    window.hedvigClientConfig.appEnvironment !== 'production'
+  )
 }


### PR DESCRIPTION
## What?
Disable frontend for credit checks in prod


## Why?
Backend is not ready and we need to deploy to prod
