### PR TITLE
Tracking - Send passage data to Google Tag Manager

### DIFF
--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -223,7 +223,7 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
     },
   ) => {
     const filteredArray = Object.entries(payload).filter(
-      ([key, value]) => value !== undefined,
+      (property) => property[1] !== undefined,
     )
 
     const payloadObject = filteredArray.reduce((prev, item) => {

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -216,6 +216,39 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
 
   const textKeys = useTextKeys()
 
+  const trackPassageData = (
+    eventName: string,
+    payload: {
+      [key: string]: any
+    },
+  ) => {
+    const filteredArray = Object.entries(payload).filter(
+      ([key, value]) => value !== undefined,
+    )
+
+    const payloadObject = filteredArray.reduce((prev, item) => {
+      const [key, value] = item
+      return { ...prev, [key]: value }
+    }, {})
+
+    pushToGTMDataLayer({
+      event: eventName,
+      passageData: {
+        originatedFromEmbarkStory: props.name,
+        ...payloadObject,
+      },
+    })
+
+    // Push data to Segment
+    const castedWindow = window as any
+    if (castedWindow && castedWindow.analytics) {
+      castedWindow.analytics.track(eventName, {
+        originatedFromEmbarkStory: props.name,
+        ...payloadObject,
+      })
+    }
+  }
+
   React.useEffect(() => {
     ;(async () => {
       if (!props.name) {
@@ -342,35 +375,7 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
                     addressAutocompleteQuery: resolveAddressAutocomplete,
                     externalInsuranceProviderProviderStatus: resolveExternalInsuranceProviderProviderStatus,
                     externalInsuranceProviderStartSession: resolveExternalInsuranceProviderStartSession,
-                    track: (eventName, payload) => {
-                      const filteredArray = Object.entries(payload).filter(
-                        ([key, value]) => value !== undefined,
-                      )
-
-                      const payloadObject = filteredArray.reduce(
-                        (prev, item) => {
-                          const [key, value] = item
-                          return { ...prev, [key]: value }
-                        },
-                        {},
-                      )
-
-                      pushToGTMDataLayer({
-                        event: eventName,
-                        passageData: {
-                          originatedFromEmbarkStory: props.name,
-                          ...payloadObject,
-                        },
-                      })
-
-                      const castedWindow = window as any
-                      if (castedWindow && castedWindow.analytics) {
-                        castedWindow.analytics.track(eventName, {
-                          originatedFromEmbarkStory: props.name,
-                          ...payloadObject,
-                        })
-                      }
-                    },
+                    track: trackPassageData,
                   }}
                   initialStore={initialStore}
                   onStoreChange={(store) => {

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -17,6 +17,7 @@ import { apolloClient } from 'apolloClient'
 import { getIsoLocale, useCurrentLocale } from 'components/utils/CurrentLocale'
 import { useVariation, Variation } from 'utils/hooks/useVariation'
 import { useTextKeys } from 'utils/textKeys'
+import { pushToGTMDataLayer } from '../../utils/tracking/gtm'
 import { StorageContainer } from '../../utils/StorageContainer'
 import { createQuote } from './createQuote'
 import {
@@ -342,13 +343,25 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
                     externalInsuranceProviderProviderStatus: resolveExternalInsuranceProviderProviderStatus,
                     externalInsuranceProviderStartSession: resolveExternalInsuranceProviderStartSession,
                     track: (eventName, payload) => {
-                      const castedWindow = window as any
-                      if (castedWindow && castedWindow.analytics) {
-                        castedWindow.analytics.track(eventName, {
-                          ...payload,
+                      const filteredArray = Object.entries(payload).filter(
+                        ([key, value]) => value !== undefined,
+                      )
+
+                      const payloadObject = filteredArray.reduce(
+                        (prev, item) => {
+                          const [key, value] = item
+                          return { ...prev, [key]: value }
+                        },
+                        {},
+                      )
+
+                      pushToGTMDataLayer({
+                        event: eventName,
+                        passageData: {
                           originatedFromEmbarkStory: props.name,
-                        })
-                      }
+                          ...payloadObject,
+                        },
+                      })
                     },
                   }}
                   initialStore={initialStore}

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -362,6 +362,14 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
                           ...payloadObject,
                         },
                       })
+
+                      const castedWindow = window as any
+                      if (castedWindow && castedWindow.analytics) {
+                        castedWindow.analytics.track(eventName, {
+                          originatedFromEmbarkStory: props.name,
+                          ...payloadObject,
+                        })
+                      }
                     },
                   }}
                   initialStore={initialStore}

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -218,9 +218,7 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
 
   const trackPassageData = (
     eventName: string,
-    payload: {
-      [key: string]: any
-    },
+    payload: Record<string, any>,
   ) => {
     const filteredArray = Object.entries(payload).filter(
       (property) => property[1] !== undefined,

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -220,14 +220,10 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
     eventName: string,
     payload: Record<string, any>,
   ) => {
-    const filteredArray = Object.entries(payload).filter(
-      (property) => property[1] !== undefined,
+    const payloadObject = { ...payload }
+    Object.keys(payloadObject).forEach(
+      (key) => payloadObject[key] === undefined && delete payloadObject[key],
     )
-
-    const payloadObject = filteredArray.reduce((prev, item) => {
-      const [key, value] = item
-      return { ...prev, [key]: value }
-    }, {})
 
     pushToGTMDataLayer({
       event: eventName,

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -35,6 +35,7 @@ type DataLayerObject = {
   userProperties?: GTMUserProperties
   offerData?: GTMOfferData
   pageData?: GTMPageData
+  passageData?: Record<string, string | undefined>
 }
 
 /**
@@ -68,7 +69,7 @@ export const useGTMTracking = () => {
   }, [location, market])
 }
 
-const pushToGTMDataLayer = (obj: DataLayerObject) => {
+export const pushToGTMDataLayer = (obj: DataLayerObject) => {
   const castedWindow = window as any
   castedWindow.dataLayer = castedWindow.dataLayer || []
   castedWindow.dataLayer.push(obj)


### PR DESCRIPTION
## What?
- Send Embark passage data to Google Tag Manager datalayer
- Filter out undefined values since payload passes down all properties we want to track, but all are undefined in the start of the flow

## Why?
We want to get rid of Segment and pass data directly to GTM. Sonny told me to still keep Segment data push since Mixpanel is still being used for some dashboards. Aim is to get rid of it later

<img width="646" alt="Screenshot 2021-10-14 at 10 14 41" src="https://user-images.githubusercontent.com/6661511/137290126-dea12a19-00ce-4d54-b123-0640c1977d1e.png">

