### PR TITLE
Remove description field from edit quote mutation

### DIFF
--- a/src/client/graphql/EditQuote.graphql
+++ b/src/client/graphql/EditQuote.graphql
@@ -5,7 +5,6 @@ mutation EditQuote($input: EditQuoteInput!) {
     }
     ... on UnderwritingLimitsHit {
       limits {
-        description
         code
       }
     }


### PR DESCRIPTION
## What?

Remove description field from mutation.

## Why?

Remove field not part of schema anymore.
Broken in production.

_Referenced ticket(s): [GRW-458]_
<!-- If there is a Jira issue, add the id between brackets, and a link to that issue will be created. -->

<!-- Finally, if that makes sense, add screenshots and/or screen recordings below, preferably with headlines and/or descriptions -->

Co-Authored-By: Mehdi <89857278+mehdielket@users.noreply.github.com>

[GRW-458]: https://hedvig.atlassian.net/browse/GRW-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ