### PR TITLE
GRW-477 / Fix / `isLoading ` check in `useQuoteIds` hook

### DIFF
--- a/src/client/utils/hooks/useQuoteIds.ts
+++ b/src/client/utils/hooks/useQuoteIds.ts
@@ -24,7 +24,7 @@ export const useQuoteIds = () => {
   }, [location, storage, quoteIds, selectedQuoteIds])
 
   return {
-    isLoading: quoteIds === null,
+    isLoading: quoteIds === undefined,
     quoteIds: quoteIds ?? [],
     selectedQuoteIds: selectedQuoteIds ?? [],
     setSelectedQuoteIds,


### PR DESCRIPTION
## What?

Fix the loading quote ids check.

## Why?

The value is never null. Strange that TS didn't complain before.
We are sending an extra query before the ids have loaded.

_Referenced ticket(s): [GRW-477]_

[GRW-477]: https://hedvig.atlassian.net/browse/GRW-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ