### PR TITLE
GRW-448 / Fix / Have separate dates in SE Home + Accident bundle

### DIFF
--- a/src/client/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
@@ -20,12 +20,7 @@ import { LoadingDots } from 'components/LoadingDots/LoadingDots'
 import { useRemoveStartDateMutation, useStartDateMutation } from 'data/graphql'
 import { CancellationOptions } from 'pages/OfferNew/Introduction/Sidebar/CancellationOptions'
 import { OfferData, OfferQuote } from 'pages/OfferNew/types'
-import {
-  hasCurrentInsurer,
-  isBundle,
-  isDanish,
-  isSwedish,
-} from 'pages/OfferNew/utils'
+import { hasCurrentInsurer, isBundle, isDanish } from 'pages/OfferNew/utils'
 import { useTextKeys } from 'utils/textKeys'
 import { Size } from 'components/types'
 import { gqlDateFormat } from './utils'
@@ -350,7 +345,7 @@ export const StartDate: React.FC<Props> = ({
 
   // TODO: Make this flag more generic. This logic should not live here.
   const isSingleStartDateBundle = (offerData: OfferData) =>
-    isBundle(offerData) && (isDanish(offerData) || isSwedish(offerData))
+    isBundle(offerData) && isDanish(offerData)
 
   return (
     <>


### PR DESCRIPTION
## What?

When displaying the Swedish Home + Accident insurance bundle we should allow users to choose between two start dates, one for each insurance.

## Why?

Allows users to get more configurability


_Referenced ticket(s): [GRW-448]_

## Screenshots
<img width="310" alt="Screenshot 2021-10-17 at 20 19 02" src="https://user-images.githubusercontent.com/89857278/137640042-59a6be59-9cd3-4080-9606-76a39e778b9f.png">
<img width="452" alt="Screenshot 2021-10-17 at 20 19 12" src="https://user-images.githubusercontent.com/89857278/137640044-2b8907e2-9a57-407c-86a6-ef2dd9f5b0da.png">


[GRW-448]: https://hedvig.atlassian.net/browse/GRW-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ