### PR TITLE
GRW-465 / Fix / Fix layout issues with peril texts

### DIFF
--- a/src/client/pages/OfferNew/Perils/PerilCollection/PerilCollection.stories.tsx
+++ b/src/client/pages/OfferNew/Perils/PerilCollection/PerilCollection.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import { MemoryRouter } from 'react-router-dom'
+import { MockedProvider } from '@apollo/react-testing'
+import { perilsMock } from 'utils/testData/offerDataMock'
+import { TextKeyProvider } from 'utils/textKeys'
+import { PerilCollection } from '.'
+
+export default {
+  title: 'Offer/Perils/PerilCollection',
+  component: PerilCollection,
+  parameters: {
+    paddings: [{ name: 'Medium', value: '16px', default: true }],
+  },
+}
+
+export const Default = () => {
+  return (
+    <PerilCollection
+      perils={perilsMock}
+      setCurrentPeril={(args) => action('setCurrentPeril')(args)}
+      setIsShowingPeril={(args) => action('setIsShowingPeril')(args)}
+    />
+  )
+}

--- a/src/client/pages/OfferNew/Perils/PerilCollection/PerilCollection.stories.tsx
+++ b/src/client/pages/OfferNew/Perils/PerilCollection/PerilCollection.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Offer/Perils/PerilCollection',
   component: PerilCollection,
   parameters: {
-    paddings: [{ name: 'Medium', value: '16px', default: true }],
+    layout: 'padded',
   },
 }
 

--- a/src/client/pages/OfferNew/Perils/PerilCollection/PerilCollection.stories.tsx
+++ b/src/client/pages/OfferNew/Perils/PerilCollection/PerilCollection.stories.tsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
-import { MemoryRouter } from 'react-router-dom'
-import { MockedProvider } from '@apollo/react-testing'
 import { perilsMock } from 'utils/testData/offerDataMock'
-import { TextKeyProvider } from 'utils/textKeys'
 import { PerilCollection } from '.'
 
 export default {

--- a/src/client/pages/OfferNew/Perils/PerilCollection/PerilItem.tsx
+++ b/src/client/pages/OfferNew/Perils/PerilCollection/PerilItem.tsx
@@ -85,6 +85,7 @@ const PerilIcon = styled.img`
   svg {
     width: 100%;
     height: 100%;
+
     ${MEDIUM_SCREEN_MEDIA_QUERY} {
       transform: translateX(-0.625rem);
     }
@@ -100,13 +101,15 @@ const Title = styled('h4')`
   font-size: 0.875rem;
   overflow: hidden;
   text-overflow: ellipsis;
+  /* allow ellipsis to overlap right padding */
+  width: calc(100% + 0.25rem);
 
   ${MEDIUM_SCREEN_MEDIA_QUERY} {
     font-size: 1rem;
   }
 `
 
-const LongTitle = styled(Title)`
+const MultiLineTitle = styled(Title)`
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -118,13 +121,17 @@ export const PerilItem: React.FC<PerilItemProps> = ({
   onClick,
 }) => {
   const iconUrl = icon.variants.light.svgUrl
-  const isLongTitle = title.length > 25
+  const isMultiWordTitle = title.includes(' ')
 
   return (
     <OuterContainer>
       <Container onClick={onClick}>
         {iconUrl && <PerilIcon src={iconUrl} alt="" width={24} height={24} />}
-        {isLongTitle ? <LongTitle>{title}</LongTitle> : <Title>{title}</Title>}
+        {isMultiWordTitle ? (
+          <MultiLineTitle>{title}</MultiLineTitle>
+        ) : (
+          <Title>{title}</Title>
+        )}
       </Container>
     </OuterContainer>
   )

--- a/src/client/pages/OfferNew/Perils/PerilCollection/PerilItem.tsx
+++ b/src/client/pages/OfferNew/Perils/PerilCollection/PerilItem.tsx
@@ -5,7 +5,7 @@ import { Icon } from 'data/graphql'
 import { MEDIUM_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
 
 interface PerilItemProps {
-  title: React.ReactNode
+  title: string
   icon: Icon
   onClick: () => void
 }
@@ -36,7 +36,7 @@ const Container = styled.button`
   justify-content: flex-start;
   text-align: left;
   min-height: 3.75rem;
-  padding: 0.5rem 1rem 0.5rem 0.375rem;
+  padding: 0.5rem 0.5rem 0.5rem 0.375rem;
   color: inherit;
   font-family: inherit;
   border-radius: 0.375rem;
@@ -98,10 +98,18 @@ const PerilIcon = styled.img`
 const Title = styled('h4')`
   margin: 0;
   font-size: 0.875rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   ${MEDIUM_SCREEN_MEDIA_QUERY} {
     font-size: 1rem;
   }
+`
+
+const LongTitle = styled(Title)`
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 `
 
 export const PerilItem: React.FC<PerilItemProps> = ({
@@ -110,12 +118,13 @@ export const PerilItem: React.FC<PerilItemProps> = ({
   onClick,
 }) => {
   const iconUrl = icon.variants.light.svgUrl
+  const isLongTitle = title.length > 25
 
   return (
     <OuterContainer>
       <Container onClick={onClick}>
         {iconUrl && <PerilIcon src={iconUrl} alt="" width={24} height={24} />}
-        <Title>{title}</Title>
+        {isLongTitle ? <LongTitle>{title}</LongTitle> : <Title>{title}</Title>}
       </Container>
     </OuterContainer>
   )

--- a/src/client/utils/testData/offerDataMock.ts
+++ b/src/client/utils/testData/offerDataMock.ts
@@ -117,43 +117,114 @@ export const insuranceTermsNoTravelMock = new Map([
 
 export const perilsMock: PerilV2[] = [
   {
-    title: 'Forsinkelser',
+    title: 'Fire',
+    shortDescription: '',
     description:
-      'Hvis det blir forsinkelser når du er ute og reiser erstatter vi ekstrautgiftene dette medfører, for eksempel hvis bagasjen ikke dukker opp eller flyet er forsinket og du må overnatte en ekstra natt på et hotell.',
+      'We will cover fire damage, e.g. an over-heated mobile charger or a failed attempt to fry fries. In case of an apartment fire, we can reimburse you for fire and smoke damages.',
     covered: [
-      'Bagasje (minst 4 timer): utgifter for toalettsaker mens bagasjen er borte, inntil 5000 kroner per person og 8000 kroner for familie',
-      'Avreise grunnet værforhold, teknisk feil eller trafikkuhell: utgifter for nødvendig overnatting inntil 1500 kroner per person og 3000 kroner for familie, når reisen har begynt og transportmiddel allerede er betalt',
-      'Ankomst grunnet værforhold, teknisk feil eller trafikuhell: ekstra utgifter (opptil 20 000 kroner per person og 50 000 kroner for familie) for å endre billetter eller kjøpe nye. ',
+      'Fire due to open flames (not just glow)',
+      'Explosion',
+      'Lightning',
+      'Corrosive gas created by unintentional burning of plastics',
+      'Cleaning of soot caused by open fire',
+      'Sudden damage caused by soot',
     ],
-    exceptions: [
-      'Bagasje på hjemreisen',
-      'Flyforsinkelse, kansellering eller overbooking som omfattes av EU-direktiv 261/2004 og som flyselskapene selv har erstatningsansvaret',
-      'Økonomisk tap eller skade som direkte/indirekte skyldes streik, arbeidskonflikt, lockout eller konkurs',
-    ],
-    info: '',
+    exceptions: ['Explosive work', 'Soot from lit candles'],
+    info: 'Be careful with candles and fires.',
     icon: {
+      svgUrl: 'https://promise.hedvig.com/media/fire_97796e0790.svg',
+      pdfUrl: 'https://promise.hedvig.com/media/fire_2b4db0c75f.pdf',
+      vectorDrawableUrl: '',
       variants: {
         light: {
-          svgUrl: '/app-content-service/delayed_luggage.svg',
-          pdfUrl: '',
+          svgUrl: 'https://promise.hedvig.com/media/fire_97796e0790.svg',
+          pdfUrl: 'https://promise.hedvig.com/media/fire_2b4db0c75f.pdf',
           vectorDrawableUrl: '',
-          __typename: 'IconVariant',
         },
         dark: {
-          svgUrl: '/app-content-service/delayed_luggage.svg',
-          pdfUrl: '',
+          svgUrl: 'https://promise.hedvig.com/media/fire_dark_942da46f6f.svg',
+          pdfUrl: 'https://promise.hedvig.com/media/fire_dark_b25d17c420.pdf',
           vectorDrawableUrl: '',
-          __typename: 'IconVariant',
         },
-        __typename: 'IconVariants',
       },
-      svgUrl: '/app-content-service/delayed_luggage.svg',
-      pdfUrl: '',
-      vectorDrawableUrl: '',
-      __typename: 'Icon',
     },
+  },
+  {
+    title: 'Behandlingskostnader',
     shortDescription: '',
-    __typename: 'PerilV2',
+    description:
+      'We cover different types of water damages, for example if a washing machine leaks uncontrollably or if a bathroom is flooded. We can reimburse you for damages to the apartment and for other costs incurred during the reparations.',
+    covered: [
+      'Unexpected escape of liquid/steam from the pipework system, connected appliances or kitchen, laundry room and bathroom.',
+      'Leaking fridge/freezer',
+      'Leaking fire extinguisher',
+      'Leaking sink',
+      'Leaking aquarium',
+    ],
+    exceptions: [
+      'Surface and water barrier installed by uncertified plumber',
+      'Damage to the leaking unit itself',
+      'Damage caused by roof gutters or external downspouts',
+    ],
+    info:
+      'Make sure that faucets are sealed and turned off when not in use. Place drip trays that collect water below the fridge/freezer/washing machine. Make sure that the piping system and devices connected to it do not freeze. If you leave your apartment for more than seven days, shut the main water valve.',
+    icon: {
+      svgUrl: 'https://promise.hedvig.com/media/water_damage_e25b83cd0b.svg',
+      pdfUrl: 'https://promise.hedvig.com/media/water_damage_40c8d05caa.pdf',
+      vectorDrawableUrl: '',
+      variants: {
+        light: {
+          svgUrl:
+            'https://promise.hedvig.com/media/water_damage_e25b83cd0b.svg',
+          pdfUrl:
+            'https://promise.hedvig.com/media/water_damage_40c8d05caa.pdf',
+          vectorDrawableUrl: '',
+        },
+        dark: {
+          svgUrl:
+            'https://promise.hedvig.com/media/water_damage_dark_227105c1de.svg',
+          pdfUrl:
+            'https://promise.hedvig.com/media/water_damage_dark_747fb516a1.pdf',
+          vectorDrawableUrl: '',
+        },
+      },
+    },
+  },
+  {
+    title: 'Stöld och skadegörelse',
+    shortDescription: '',
+    description:
+      'Vid stöld och skadegörelse av dina saker så täcks dem och ersätts av oss. Oavsett om du är hemma eller på resande fot kan du alltid känna dig trygg med oss.',
+    covered: [
+      'Stöld och skadegörelse i ditt hem',
+      'Stöld ur gemensamhetsutrymme, t.ex. cykel- eller barnvagnsförråd',
+      'Stöld och skadegörelse av saker du tar med dig till ditt arbete eller hotellrum',
+      'Stöld och skadegörelse vid förvaring hos t.ex. Shurgard',
+      'Stöld utanför bostaden',
+      'Stöld ur bil när du är på resa',
+    ],
+    exceptions: [
+      'För vissa typer av saker, t.ex. pengar, hemelektronik, mobiltelefoner, datorer, kameror, sprit och smycken gäller speciella regler beroende på var stölden inträffat.',
+    ],
+    info:
+      'Ha alltid uppsikt över dina saker. Lämna inte värdesaker på t.ex. ett bord på ett café. Lås alltid bilen om du förvarar saker där och stöldbegärlig egendom (smycke, dator) ska alltid döljas. Och lås alltid din cykel.',
+    icon: {
+      svgUrl: 'https://promise.hedvig.com/media/theft_701fa78317.svg',
+      pdfUrl: 'https://promise.hedvig.com/media/theft_a3509c7f24.pdf',
+      vectorDrawableUrl: '',
+      variants: {
+        light: {
+          svgUrl: 'https://promise.hedvig.com/media/theft_701fa78317.svg',
+          pdfUrl: 'https://promise.hedvig.com/media/theft_a3509c7f24.pdf',
+          vectorDrawableUrl: '',
+        },
+        dark: {
+          svgUrl: 'https://promise.hedvig.com/media/theft_dark_71deb24845.svg',
+          pdfUrl: 'https://promise.hedvig.com/media/theft_dark_8b98af07d7.pdf',
+          vectorDrawableUrl: '',
+        },
+      },
+    },
   },
 ]
 


### PR DESCRIPTION
## What?

Add story for peril collection.
Show ellipsis for long titles.
Limit titles to two lines.
Update offer data mocks for perils.

## Why?

On certain screen sizes the the peril text overflows the container.
We also have issues when the label text take up more than two lines.
See demos.

_Referenced ticket(s): [GRW-465]_

## Desktop (no changes)
![Screenshot 2021-10-22 at 13 46 15](https://user-images.githubusercontent.com/1220232/138449321-ed00d1bd-f05e-4473-9a97-862eeee579e6.png)

## Tablet

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img src="https://user-images.githubusercontent.com/1220232/138449520-2a7faff3-e076-4550-b9d2-1800d06fa6eb.png" />
	<td><img src="https://user-images.githubusercontent.com/1220232/138449566-7a77f4c6-a931-4f24-ba05-1aa39343dc29.png" />
</table>

# Mobile

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img src="https://user-images.githubusercontent.com/1220232/138449668-4ceaf22d-4435-4828-bcd6-a3b9f9b32d70.png" />
	<td><img src="https://user-images.githubusercontent.com/1220232/138449707-97614471-393e-41b4-957f-5822e60ce5db.png" />
</table>



[GRW-465]: https://hedvig.atlassian.net/browse/GRW-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ