### PR TITLE
GRW-468 / Fix / Override iOS 15 button text color in calendar

### DIFF
--- a/src/client/components/DateInput/index.tsx
+++ b/src/client/components/DateInput/index.tsx
@@ -78,6 +78,7 @@ const CalendarDay = styled.button<{ selected: boolean; selectable: boolean }>`
   border-radius: 2px;
   transition: background-color 250ms, color 250ms;
   background: ${colorsV3.white};
+  color: ${colorsV3.gray900};
 
   svg {
     width: 13px;


### PR DESCRIPTION
## What?

☝️ 

## Why?

iOS 15 thinks buttons should be blue.

_Referenced ticket(s): []_

![Screenshot 2021-10-22 at 16 41 20](https://user-images.githubusercontent.com/1220232/138474013-4d6a847f-8904-4110-85cb-2623210efc20.png)