### PR TITLE
GRW-469 / Fix / Prevent sidebar overlapping FAQs

### DIFF
--- a/src/client/pages/OfferNew/FaqSection.tsx
+++ b/src/client/pages/OfferNew/FaqSection.tsx
@@ -11,7 +11,13 @@ import {
   LARGE_SCREEN_MEDIA_QUERY,
   MEDIUM_SCREEN_MEDIA_QUERY,
 } from 'utils/mediaQueries'
-import { Container, Heading } from './components'
+import {
+  Container,
+  Heading,
+  Column,
+  COLUMN_WIDTH_REM,
+  CONTAINER_MAX_WIDTH_REM,
+} from './components'
 
 const SectionWrapper = styled.div`
   padding-top: 5rem;
@@ -30,6 +36,28 @@ const FAQContainer = styled(Container)`
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
     flex-direction: column;
+  }
+`
+
+const MIN_COLUMN_WIDTH = 32
+const MAX_COLUMN_WIDTH = COLUMN_WIDTH_REM
+const MIN_VIEWPORT_WIDTH = 62.5 // 1000px
+const MAX_VIEWPORT_WIDTH = CONTAINER_MAX_WIDTH_REM
+
+const FAQColumn = styled(Column)`
+  ${LARGE_SCREEN_MEDIA_QUERY} {
+    /* Reference: https://css-tricks.com/snippets/css/fluid-typography/ */
+    max-width: calc(
+      ${MIN_COLUMN_WIDTH}rem + ${MAX_COLUMN_WIDTH - MIN_COLUMN_WIDTH} *
+        (
+          (100vw - ${MIN_VIEWPORT_WIDTH}rem) /
+            (${MAX_VIEWPORT_WIDTH} - ${MIN_VIEWPORT_WIDTH})
+        )
+    );
+  }
+
+  @media screen and (min-width: ${MAX_VIEWPORT_WIDTH}rem) {
+    max-width: ${MAX_COLUMN_WIDTH}rem;
   }
 `
 
@@ -170,17 +198,19 @@ export const FaqSection: React.FC = () => {
     <>
       <SectionWrapper>
         <FAQContainer>
-          <HeadingWhite>{textKeys.OFFER_FAQ_HEADING()}</HeadingWhite>
-          <AccordionsWrapper>
-            {languageData?.faqs?.map((faq) => (
-              <Accordion
-                key={faq?.id}
-                id={faq?.id}
-                headline={faq!.headline!}
-                body={faq!.body!}
-              />
-            ))}
-          </AccordionsWrapper>
+          <FAQColumn>
+            <HeadingWhite>{textKeys.OFFER_FAQ_HEADING()}</HeadingWhite>
+            <AccordionsWrapper>
+              {languageData?.faqs?.map((faq) => (
+                <Accordion
+                  key={faq?.id}
+                  id={faq?.id}
+                  headline={faq!.headline!}
+                  body={faq!.body!}
+                />
+              ))}
+            </AccordionsWrapper>
+          </FAQColumn>
         </FAQContainer>
       </SectionWrapper>
     </>

--- a/src/client/pages/OfferNew/FaqSection.tsx
+++ b/src/client/pages/OfferNew/FaqSection.tsx
@@ -11,13 +11,7 @@ import {
   LARGE_SCREEN_MEDIA_QUERY,
   MEDIUM_SCREEN_MEDIA_QUERY,
 } from 'utils/mediaQueries'
-import {
-  Container,
-  Heading,
-  Column,
-  COLUMN_WIDTH_REM,
-  CONTAINER_MAX_WIDTH_REM,
-} from './components'
+import { Container, Heading, Column, ColumnSpacing } from './components'
 
 const SectionWrapper = styled.div`
   padding-top: 5rem;
@@ -28,36 +22,6 @@ const SectionWrapper = styled.div`
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
     padding-bottom: 5rem;
-  }
-`
-
-const FAQContainer = styled(Container)`
-  flex-direction: column;
-
-  ${LARGE_SCREEN_MEDIA_QUERY} {
-    flex-direction: column;
-  }
-`
-
-const MIN_COLUMN_WIDTH = 32
-const MAX_COLUMN_WIDTH = COLUMN_WIDTH_REM
-const MIN_VIEWPORT_WIDTH = 62.5 // 1000px
-const MAX_VIEWPORT_WIDTH = CONTAINER_MAX_WIDTH_REM
-
-const FAQColumn = styled(Column)`
-  ${LARGE_SCREEN_MEDIA_QUERY} {
-    /* Reference: https://css-tricks.com/snippets/css/fluid-typography/ */
-    max-width: calc(
-      ${MIN_COLUMN_WIDTH}rem + ${MAX_COLUMN_WIDTH - MIN_COLUMN_WIDTH} *
-        (
-          (100vw - ${MIN_VIEWPORT_WIDTH}rem) /
-            (${MAX_VIEWPORT_WIDTH} - ${MIN_VIEWPORT_WIDTH})
-        )
-    );
-  }
-
-  @media screen and (min-width: ${MAX_VIEWPORT_WIDTH}rem) {
-    max-width: ${MAX_COLUMN_WIDTH}rem;
   }
 `
 
@@ -197,8 +161,8 @@ export const FaqSection: React.FC = () => {
   return (
     <>
       <SectionWrapper>
-        <FAQContainer>
-          <FAQColumn>
+        <Container>
+          <Column>
             <HeadingWhite>{textKeys.OFFER_FAQ_HEADING()}</HeadingWhite>
             <AccordionsWrapper>
               {languageData?.faqs?.map((faq) => (
@@ -210,8 +174,9 @@ export const FaqSection: React.FC = () => {
                 />
               ))}
             </AccordionsWrapper>
-          </FAQColumn>
-        </FAQContainer>
+          </Column>
+          <ColumnSpacing />
+        </Container>
       </SectionWrapper>
     </>
   )

--- a/src/client/pages/OfferNew/components.tsx
+++ b/src/client/pages/OfferNew/components.tsx
@@ -93,13 +93,12 @@ export const ContainerWrapper = styled.div`
   }
 `
 
-export const CONTAINER_MAX_WIDTH_REM = 80
 export const Container = styled('div')`
   width: 100%;
   height: 100%;
   padding: 0 1rem;
   margin: 0 auto;
-  max-width: ${CONTAINER_MAX_WIDTH_REM}rem;
+  max-width: 80rem;
   display: flex;
   justify-content: space-between;
   flex-direction: column-reverse;
@@ -111,11 +110,10 @@ export const Container = styled('div')`
   }
 `
 
-export const COLUMN_WIDTH_REM = 47.5
 export const Column = styled('div')`
   display: flex;
   flex-direction: column;
-  max-width: ${COLUMN_WIDTH_REM}rem;
+  max-width: 47.5rem;
   width: 100%;
   flex-grow: 0;
   box-sizing: border-box;

--- a/src/client/pages/OfferNew/components.tsx
+++ b/src/client/pages/OfferNew/components.tsx
@@ -93,12 +93,13 @@ export const ContainerWrapper = styled.div`
   }
 `
 
+export const CONTAINER_MAX_WIDTH_REM = 80
 export const Container = styled('div')`
   width: 100%;
   height: 100%;
   padding: 0 1rem;
   margin: 0 auto;
-  max-width: 80rem;
+  max-width: ${CONTAINER_MAX_WIDTH_REM}rem;
   display: flex;
   justify-content: space-between;
   flex-direction: column-reverse;
@@ -110,10 +111,11 @@ export const Container = styled('div')`
   }
 `
 
+export const COLUMN_WIDTH_REM = 47.5
 export const Column = styled('div')`
   display: flex;
   flex-direction: column;
-  max-width: 47.5rem;
+  max-width: ${COLUMN_WIDTH_REM}rem;
   width: 100%;
   flex-grow: 0;
   box-sizing: border-box;


### PR DESCRIPTION
## What?

Clear text so sidebar doesn't overlap text in FAQ section.
Using a fluid typography technique: https://css-tricks.com/snippets/css/fluid-typography/

## Why?

It's a bit of a complicated solution. However, we don't wrap the FAQ-section in the flexbox container, so it's not that easy to make sure the FAQ text content doesn't flow under the sidebar.

Still I'm kind of happy with how well it actually works ;)

## Demo

https://user-images.githubusercontent.com/1220232/138550380-68bdb1ac-6db3-4513-ac2e-e124ed555c10.mov
