### PR TITLE
Tracking/update offer tracking

### DIFF
--- a/src/client/pages/OfferNew/utils.ts
+++ b/src/client/pages/OfferNew/utils.ts
@@ -196,6 +196,9 @@ export const isDanishTravelBundle = (offerData: OfferData): boolean =>
 export const isStudentOffer = (offerData: OfferData): boolean =>
   offerData.quotes.every((quote) => isStudent(quote.quoteDetails))
 
+export const hasHomeQuote = (offerData: OfferData) =>
+  offerData.quotes.some(({ quoteDetails }) => isHomeQuote(quoteDetails))
+
 export const hasAddress = (offerData: OfferData): boolean =>
   !!offerData.person.address
 

--- a/src/client/pages/OfferNew/utils.ts
+++ b/src/client/pages/OfferNew/utils.ts
@@ -17,6 +17,7 @@ import {
   DanishTravelDetails,
   ApartmentType,
   QuoteBundleVariant,
+  SwedishAccidentDetails,
 } from 'data/graphql'
 import { LocaleLabel, locales } from 'l10n/locales'
 import { birthDateFormats } from 'l10n/birthDateAndSsnFormats'
@@ -123,6 +124,16 @@ const isHomeQuote = (
   isSwedishHouse(quoteDetails) ||
   isSwedishApartment(quoteDetails)
 
+const isAccidentQuote = (
+  quoteDetails: QuoteDetails,
+): quoteDetails is SwedishAccidentDetails | DanishAccidentDetails =>
+  isDanishAccident(quoteDetails) || isSwedishAccident(quoteDetails)
+
+const isTravelQuote = (
+  quoteDetails: QuoteDetails,
+): quoteDetails is NorwegianTravelDetails | DanishTravelDetails =>
+  isDanishTravel(quoteDetails) || isNorwegianTravel(quoteDetails)
+
 export const quoteDetailsHasAddress = isHomeQuote
 
 export const getMainQuote = (offerData: OfferData) => {
@@ -198,6 +209,12 @@ export const isStudentOffer = (offerData: OfferData): boolean =>
 
 export const hasHomeQuote = (offerData: OfferData) =>
   offerData.quotes.some(({ quoteDetails }) => isHomeQuote(quoteDetails))
+
+export const hasAccidentQuote = (offerData: OfferData) =>
+  offerData.quotes.some(({ quoteDetails }) => isAccidentQuote(quoteDetails))
+
+export const hasTravelQuote = (offerData: OfferData) =>
+  offerData.quotes.some(({ quoteDetails }) => isTravelQuote(quoteDetails))
 
 export const hasAddress = (offerData: OfferData): boolean =>
   !!offerData.person.address

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -5,6 +5,7 @@ import { OfferData } from 'pages/OfferNew/types'
 import { captureSentryError } from 'utils/sentry-client'
 import { useMarket } from 'components/utils/CurrentLocale'
 import { AppEnvironment } from 'shared/clientConfig'
+import { isStudentOffer } from 'pages/OfferNew/utils'
 import { getContractType, DkBundleTypes, NoComboTypes } from './tracking'
 
 type GAContractType = NoComboTypes | DkBundleTypes | TypeOfContract
@@ -20,6 +21,7 @@ type GTMOfferData = {
   number_of_people: number
   insurance_price: number
   currency: string
+  is_student: boolean
   member_id?: string
 }
 
@@ -89,6 +91,7 @@ export const trackOfferGTM = (
         number_of_people: offerData.person.householdSize,
         insurance_price: parseFloat(offerData.cost.monthlyNet.amount),
         currency: offerData.cost.monthlyNet.currency,
+        is_student: isStudentOffer(offerData),
         ...(offerData.memberId && { member_id: offerData.memberId }),
       },
     })

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -5,7 +5,12 @@ import { OfferData } from 'pages/OfferNew/types'
 import { captureSentryError } from 'utils/sentry-client'
 import { useMarket } from 'components/utils/CurrentLocale'
 import { AppEnvironment } from 'shared/clientConfig'
-import { isStudentOffer, hasHomeQuote } from 'pages/OfferNew/utils'
+import {
+  isStudentOffer,
+  hasHomeQuote,
+  hasAccidentQuote,
+  hasTravelQuote,
+} from 'pages/OfferNew/utils'
 import { getContractType, DkBundleTypes, NoComboTypes } from './tracking'
 
 type GAContractType = NoComboTypes | DkBundleTypes | TypeOfContract
@@ -22,7 +27,9 @@ type GTMOfferData = {
   insurance_price: number
   currency: string
   is_student: boolean
-  has_home?: boolean
+  has_home: boolean
+  has_accident: boolean
+  has_travel: boolean
   member_id?: string
 }
 
@@ -94,6 +101,8 @@ export const trackOfferGTM = (
         currency: offerData.cost.monthlyNet.currency,
         is_student: isStudentOffer(offerData),
         has_home: hasHomeQuote(offerData),
+        has_accident: hasAccidentQuote(offerData),
+        has_travel: hasTravelQuote(offerData),
         ...(offerData.memberId && { member_id: offerData.memberId }),
       },
     })

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -5,7 +5,7 @@ import { OfferData } from 'pages/OfferNew/types'
 import { captureSentryError } from 'utils/sentry-client'
 import { useMarket } from 'components/utils/CurrentLocale'
 import { AppEnvironment } from 'shared/clientConfig'
-import { isStudentOffer } from 'pages/OfferNew/utils'
+import { isStudentOffer, hasHomeQuote } from 'pages/OfferNew/utils'
 import { getContractType, DkBundleTypes, NoComboTypes } from './tracking'
 
 type GAContractType = NoComboTypes | DkBundleTypes | TypeOfContract
@@ -22,6 +22,7 @@ type GTMOfferData = {
   insurance_price: number
   currency: string
   is_student: boolean
+  has_home?: boolean
   member_id?: string
 }
 
@@ -92,6 +93,7 @@ export const trackOfferGTM = (
         insurance_price: parseFloat(offerData.cost.monthlyNet.amount),
         currency: offerData.cost.monthlyNet.currency,
         is_student: isStudentOffer(offerData),
+        has_home: hasHomeQuote(offerData),
         ...(offerData.memberId && { member_id: offerData.memberId }),
       },
     })


### PR DESCRIPTION
## What?
First PR in a series of tracking updates. Validated from Sonny.
Update GTM tracking events with `is_student`, `has_home`, `has_accident` & `has_travel` parameters

## Why?
Better granularity for offer tracking

https://user-images.githubusercontent.com/6661511/139296316-f2ff5311-1cf7-4ea5-b082-d749999d8384.mov


