### PR TITLE
Tracking - add initial offer and discounted premium to GTM event

### DIFF
--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -25,6 +25,7 @@ type GTMOfferData = {
   referral_code: 'yes' | 'no'
   number_of_people: number
   insurance_price: number
+  discounted_premium?: number
   currency: string
   is_student: boolean
   has_home: boolean
@@ -90,6 +91,8 @@ export const trackOfferGTM = (
   offerData: OfferData,
   referralCodeUsed: boolean,
 ) => {
+  const grossPrice = Math.round(Number(offerData.cost.monthlyGross.amount))
+  const netPrice = Math.round(Number(offerData.cost.monthlyNet.amount))
   try {
     pushToGTMDataLayer({
       event: eventName,
@@ -97,7 +100,8 @@ export const trackOfferGTM = (
         insurance_type: getContractType(offerData),
         referral_code: referralCodeUsed ? 'yes' : 'no',
         number_of_people: offerData.person.householdSize,
-        insurance_price: parseFloat(offerData.cost.monthlyNet.amount),
+        insurance_price: grossPrice,
+        ...(grossPrice !== netPrice && { discounted_premium: netPrice }),
         currency: offerData.cost.monthlyNet.currency,
         is_student: isStudentOffer(offerData),
         has_home: hasHomeQuote(offerData),

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -12,7 +12,7 @@ import {
 } from 'pages/OfferNew/utils'
 import {
   getContractType,
-  getInitialOfferFromCookie,
+  getInitialOfferFromSessionStorage,
   TrackableContractType,
 } from './tracking'
 
@@ -94,7 +94,7 @@ export const trackOfferGTM = (
   referralCodeUsed: boolean,
 ) => {
   const contractType = getContractType(offerData)
-  const initialOffer = getInitialOfferFromCookie(contractType)
+  const initialOffer = getInitialOfferFromSessionStorage(contractType)
   const grossPrice = Math.round(Number(offerData.cost.monthlyGross.amount))
   const netPrice = Math.round(Number(offerData.cost.monthlyNet.amount))
   try {

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -11,9 +11,18 @@ import {
   hasAccidentQuote,
   hasTravelQuote,
 } from 'pages/OfferNew/utils'
-import { getContractType, DkBundleTypes, NoComboTypes } from './tracking'
+import {
+  getContractType,
+  DkBundleTypes,
+  NoComboTypes,
+  SeBundleTypes,
+} from './tracking'
 
-type GAContractType = NoComboTypes | DkBundleTypes | TypeOfContract
+type GAContractType =
+  | SeBundleTypes
+  | NoComboTypes
+  | DkBundleTypes
+  | TypeOfContract
 
 type GTMUserProperties = {
   market: string

--- a/src/client/utils/tracking/tracking.test.ts
+++ b/src/client/utils/tracking/tracking.test.ts
@@ -1,4 +1,12 @@
-import { getUtmParamsFromCookie } from './tracking'
+import { TypeOfContract } from 'data/graphql'
+import {
+  DkBundleTypes,
+  getTrackableContractCategory,
+  getUtmParamsFromCookie,
+  NoComboTypes,
+  SeBundleTypes,
+  TrackableContractCategory,
+} from './tracking'
 let mockGetItem: jest.Mock
 jest.mock('cookie-storage', () => ({
   CookieStorage() {
@@ -27,5 +35,66 @@ describe('getUtmParamsFromCookie()', () => {
 
     expect(res).toBeUndefined()
     mockGetItem.mockClear()
+  })
+})
+
+describe('getTrackableContractCategory', () => {
+  it('returns correct contract category for swedish quotes', () => {
+    expect(getTrackableContractCategory(TypeOfContract.SeApartmentRent)).toBe(
+      TrackableContractCategory.Home,
+    )
+    expect(
+      getTrackableContractCategory(TypeOfContract.SeApartmentStudentBrf),
+    ).toBe(TrackableContractCategory.Home)
+    expect(
+      getTrackableContractCategory(SeBundleTypes.SeHomeAccidentBundleHouse),
+    ).toBe(TrackableContractCategory.HomeAccident)
+    expect(
+      getTrackableContractCategory(SeBundleTypes.SeHomeAccidentBundleBrf),
+    ).toBe(TrackableContractCategory.HomeAccident)
+  })
+
+  it('returns correct contract category for norwegian quotes', () => {
+    expect(getTrackableContractCategory(TypeOfContract.NoHomeContentOwn)).toBe(
+      TrackableContractCategory.Home,
+    )
+
+    expect(getTrackableContractCategory(TypeOfContract.NoTravel)).toBe(
+      TrackableContractCategory.Travel,
+    )
+
+    expect(getTrackableContractCategory(NoComboTypes.NoCombo)).toBe(
+      TrackableContractCategory.HomeTravel,
+    )
+
+    expect(getTrackableContractCategory(NoComboTypes.NoComboYouth)).toBe(
+      TrackableContractCategory.HomeTravel,
+    )
+  })
+
+  it('returns correct contract category for danish quotes', () => {
+    expect(getTrackableContractCategory(TypeOfContract.DkHomeContentRent)).toBe(
+      TrackableContractCategory.Home,
+    )
+
+    expect(
+      getTrackableContractCategory(TypeOfContract.DkHomeContentStudentOwn),
+    ).toBe(TrackableContractCategory.Home)
+
+    expect(
+      getTrackableContractCategory(DkBundleTypes.DkAccidentBundleStudent),
+    ).toBe(TrackableContractCategory.HomeAccident)
+
+    expect(getTrackableContractCategory(DkBundleTypes.DkAccidentBundle)).toBe(
+      TrackableContractCategory.HomeAccident,
+    )
+
+    expect(getTrackableContractCategory(DkBundleTypes.DkTravelBundle)).toBe(
+      TrackableContractCategory.HomeAccidentTravel,
+    )
+
+    expect(
+      getTrackableContractCategory(DkBundleTypes.DkTravelBundleStudent),
+    ).toBe(TrackableContractCategory.HomeAccidentTravel)
   })
 })

--- a/src/client/utils/tracking/tracking.ts
+++ b/src/client/utils/tracking/tracking.ts
@@ -15,6 +15,7 @@ import {
   isDanishTravelBundle,
   isStudentOffer,
   getMainQuote,
+  isSwedish,
 } from 'pages/OfferNew/utils'
 import { trackOfferGTM } from './gtm'
 import { adtraction } from './adtraction'
@@ -66,6 +67,11 @@ export enum DkBundleTypes {
 
 export const getContractType = (offerData: OfferData) => {
   if (isBundle(offerData)) {
+    if (isSwedish(offerData)) {
+      return isStudentOffer(offerData)
+        ? SeBundleTypes.SeHomeAccidentBundleStudentBrf
+        : SeBundleTypes.SeHomeAccidentBundleBrf
+    }
     if (isNorwegian(offerData)) {
       return isYouth(offerData)
         ? NoComboTypes.NoComboYouth

--- a/src/client/utils/tracking/tracking.ts
+++ b/src/client/utils/tracking/tracking.ts
@@ -1,7 +1,6 @@
 import { CookieStorage } from 'cookie-storage'
 import { SegmentAnalyticsJs, setupTrackers } from 'quepasa'
 import React from 'react'
-import { match } from 'matchly'
 import {
   SignState,
   TypeOfContract,
@@ -122,27 +121,35 @@ export enum TrackableContractCategory {
   HomeAccident = 'home_accident',
   HomeAccidentTravel = 'home_accident_travel',
 }
-export const getTrackableContractCategory = match([
-  [
-    SeBundleTypes ||
-      DkBundleTypes.DkAccidentBundle ||
-      DkBundleTypes.DkAccidentBundleStudent,
-    TrackableContractCategory.HomeAccident,
-  ],
-  [
-    NoComboTypes.NoCombo || NoComboTypes.NoComboYouth,
-    TrackableContractCategory.HomeTravel,
-  ],
-  [
-    DkBundleTypes.DkTravelBundle || DkBundleTypes.DkTravelBundleStudent,
-    TrackableContractCategory.HomeAccidentTravel,
-  ],
-  [
-    TypeOfContract.NoTravel || TypeOfContract.NoTravelYouth,
-    TrackableContractCategory.Travel,
-  ],
-  [match.any(), TrackableContractCategory.Home],
-])
+
+export const getTrackableContractCategory = (
+  contractType: TrackableContractType,
+) => {
+  switch (contractType) {
+    case SeBundleTypes.SeHomeAccidentBundleBrf:
+    case SeBundleTypes.SeHomeAccidentBundleRent:
+    case SeBundleTypes.SeHomeAccidentBundleHouse:
+    case SeBundleTypes.SeHomeAccidentBundleStudentBrf:
+    case SeBundleTypes.SeHomeAccidentBundleStudentRent:
+    case DkBundleTypes.DkAccidentBundle:
+    case DkBundleTypes.DkAccidentBundleStudent:
+      return TrackableContractCategory.HomeAccident
+
+    case NoComboTypes.NoCombo:
+    case NoComboTypes.NoComboYouth:
+      return TrackableContractCategory.HomeTravel
+
+    case DkBundleTypes.DkTravelBundle:
+    case DkBundleTypes.DkTravelBundleStudent:
+      return TrackableContractCategory.HomeAccidentTravel
+
+    case TypeOfContract.NoTravel:
+    case TypeOfContract.NoTravelYouth:
+      return TrackableContractCategory.Travel
+    default:
+      return TrackableContractCategory.Home
+  }
+}
 
 export const getInitialOfferFromSessionStorage = (
   contractType: TrackableContractType,
@@ -153,7 +160,7 @@ export const getInitialOfferFromSessionStorage = (
     return initialtOffer
   }
 
-  const contractCategory = getTrackableContractCategory(contractType)!
+  const contractCategory = getTrackableContractCategory(contractType)
   sessionStorage.setItem('initial_offer', contractCategory)
   return contractCategory
 }

--- a/src/client/utils/tracking/tracking.ts
+++ b/src/client/utils/tracking/tracking.ts
@@ -131,17 +131,17 @@ export const getTrackableContractCategory = match([
   [match.any(), TrackableContractCategory.Home],
 ])
 
-export const getInitialOfferFromCookie = (
+export const getInitialOfferFromSessionStorage = (
   contractType: TrackableContractType,
 ) => {
-  const initialtOffer = cookie.getItem('initial_offer')
+  const initialtOffer = sessionStorage.getItem('initial_offer')
 
   if (initialtOffer) {
     return initialtOffer
   }
 
   const contractCategory = getTrackableContractCategory(contractType)!
-  cookie.setItem('initial_offer', contractCategory, { path: '/' })
+  sessionStorage.setItem('initial_offer', contractCategory)
   return contractCategory
 }
 

--- a/src/client/utils/tracking/tracking.ts
+++ b/src/client/utils/tracking/tracking.ts
@@ -17,7 +17,9 @@ import {
   isDanishTravelBundle,
   isStudentOffer,
   getMainQuote,
-  isSwedish,
+  isSwedishHouse,
+  isSwedishApartment,
+  isSwedishBRF,
 } from 'pages/OfferNew/utils'
 import { trackOfferGTM } from './gtm'
 import { adtraction } from './adtraction'
@@ -75,10 +77,22 @@ export type TrackableContractType =
 
 export const getContractType = (offerData: OfferData) => {
   if (isBundle(offerData)) {
-    if (isSwedish(offerData)) {
-      return isStudentOffer(offerData)
-        ? SeBundleTypes.SeHomeAccidentBundleStudentBrf
-        : SeBundleTypes.SeHomeAccidentBundleBrf
+    const { quoteDetails: homeQuoteDetails } = getMainQuote(offerData)
+
+    if (isSwedishHouse(homeQuoteDetails)) {
+      return SeBundleTypes.SeHomeAccidentBundleHouse
+    }
+
+    if (isSwedishApartment(homeQuoteDetails)) {
+      if (isSwedishBRF(homeQuoteDetails)) {
+        return isStudentOffer(offerData)
+          ? SeBundleTypes.SeHomeAccidentBundleStudentBrf
+          : SeBundleTypes.SeHomeAccidentBundleBrf
+      } else {
+        return isStudentOffer(offerData)
+          ? SeBundleTypes.SeHomeAccidentBundleStudentRent
+          : SeBundleTypes.SeHomeAccidentBundleRent
+      }
     }
     if (isNorwegian(offerData)) {
       return isYouth(offerData)
@@ -110,8 +124,7 @@ export enum TrackableContractCategory {
 }
 export const getTrackableContractCategory = match([
   [
-    SeBundleTypes.SeAccidentBundle ||
-      SeBundleTypes.SeAccidentBundle ||
+    SeBundleTypes ||
       DkBundleTypes.DkAccidentBundle ||
       DkBundleTypes.DkAccidentBundleStudent,
     TrackableContractCategory.HomeAccident,


### PR DESCRIPTION
## What?
Add `initial_offer` and `discounted_premium` to GTM event


## Why?
Update based on this tracking document from Sonny https://docs.google.com/spreadsheets/d/1IHswc17yIOPkXTGA5aaLsgLRX1lhRvrKaVayzx7RAUo/edit#gid=0


<img width="1916" alt="Screenshot 2021-11-02 at 17 11 38" src="https://user-images.githubusercontent.com/6661511/140023870-09798c3f-f98d-4b2b-be75-e73cea79fa74.png">

