### PR TITLE
Tracking - Add current_offer to GTM tracking

### DIFF
--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -34,6 +34,7 @@ type GTMOfferData = {
   has_accident: boolean
   has_travel: boolean
   initial_offer: string
+  current_offer: string
   member_id?: string
 }
 
@@ -121,9 +122,7 @@ export const trackOfferGTM = (
         has_accident: hasAccidentQuote(offerData),
         has_travel: hasTravelQuote(offerData),
         initial_offer: initialOffer,
-        ...(eventName === EventName.SignedCustomer && {
-          signed_offer: contractCategory,
-        }),
+        current_offer: contractCategory,
         ...(switchedFrom && {
           switched_from: getTrackableContractCategory(
             getContractType(switchedFrom),

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -103,7 +103,7 @@ export const trackOfferGTM = (
 ) => {
   const contractType = getContractType(offerData)
   const contractCategory = getTrackableContractCategory(contractType)
-  const initialOffer = getInitialOfferFromSessionStorage(contractType)
+  const initialOffer = getInitialOfferFromSessionStorage(contractCategory)
   const grossPrice = Math.round(Number(offerData.cost.monthlyGross.amount))
   const netPrice = Math.round(Number(offerData.cost.monthlyNet.amount))
   try {

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -108,10 +108,9 @@ export const trackOfferGTM = (
   const grossPrice = Math.round(Number(offerData.cost.monthlyGross.amount))
   const netPrice = Math.round(Number(offerData.cost.monthlyNet.amount))
 
-  let initialOffer = getInitialOfferFromSessionStorage()
+  const initialOffer = getInitialOfferFromSessionStorage()
   if (!initialOffer) {
     setInitialOfferToSessionStorage(contractCategory)
-    initialOffer = contractCategory
   }
   try {
     pushToGTMDataLayer({
@@ -127,7 +126,7 @@ export const trackOfferGTM = (
         has_home: hasHomeQuote(offerData),
         has_accident: hasAccidentQuote(offerData),
         has_travel: hasTravelQuote(offerData),
-        initial_offer: initialOffer,
+        initial_offer: initialOffer ?? contractCategory,
         current_offer: contractCategory,
         ...(switchedFrom && {
           switched_from: getTrackableContractCategory(

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -102,6 +102,7 @@ export const trackOfferGTM = (
   switchedFrom?: OfferData,
 ) => {
   const contractType = getContractType(offerData)
+  const contractCategory = getTrackableContractCategory(contractType)
   const initialOffer = getInitialOfferFromSessionStorage(contractType)
   const grossPrice = Math.round(Number(offerData.cost.monthlyGross.amount))
   const netPrice = Math.round(Number(offerData.cost.monthlyNet.amount))
@@ -120,13 +121,16 @@ export const trackOfferGTM = (
         has_accident: hasAccidentQuote(offerData),
         has_travel: hasTravelQuote(offerData),
         initial_offer: initialOffer,
-        ...(offerData.memberId && { member_id: offerData.memberId }),
+        ...(eventName === EventName.SignedCustomer && {
+          signed_offer: contractCategory,
+        }),
         ...(switchedFrom && {
           switched_from: getTrackableContractCategory(
             getContractType(switchedFrom),
           ),
-          switched_to: getTrackableContractCategory(contractType),
+          switched_to: contractCategory,
         }),
+        ...(offerData.memberId && { member_id: offerData.memberId }),
       },
     })
   } catch (e) {

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -14,6 +14,7 @@ import {
   getContractType,
   getInitialOfferFromSessionStorage,
   getTrackableContractCategory,
+  setInitialOfferToSessionStorage,
   TrackableContractType,
 } from './tracking'
 
@@ -104,9 +105,14 @@ export const trackOfferGTM = (
 ) => {
   const contractType = getContractType(offerData)
   const contractCategory = getTrackableContractCategory(contractType)
-  const initialOffer = getInitialOfferFromSessionStorage(contractCategory)
   const grossPrice = Math.round(Number(offerData.cost.monthlyGross.amount))
   const netPrice = Math.round(Number(offerData.cost.monthlyNet.amount))
+
+  let initialOffer = getInitialOfferFromSessionStorage()
+  if (!initialOffer) {
+    setInitialOfferToSessionStorage(contractCategory)
+    initialOffer = contractCategory
+  }
   try {
     pushToGTMDataLayer({
       event: eventName,

--- a/src/client/utils/tracking/tracking.ts
+++ b/src/client/utils/tracking/tracking.ts
@@ -151,17 +151,14 @@ export const getTrackableContractCategory = (
   }
 }
 
-export const getInitialOfferFromSessionStorage = (
+export const getInitialOfferFromSessionStorage = () => {
+  return sessionStorage.getItem('initial_offer')
+}
+
+export const setInitialOfferToSessionStorage = (
   contractCategory: TrackableContractCategory,
 ) => {
-  const initialtOffer = sessionStorage.getItem('initial_offer')
-
-  if (initialtOffer) {
-    return initialtOffer
-  }
-
   sessionStorage.setItem('initial_offer', contractCategory)
-  return contractCategory
 }
 
 export enum ApplicationSpecificEvents {

--- a/src/client/utils/tracking/tracking.ts
+++ b/src/client/utils/tracking/tracking.ts
@@ -152,7 +152,7 @@ export const getTrackableContractCategory = (
 }
 
 export const getInitialOfferFromSessionStorage = (
-  contractType: TrackableContractType,
+  contractCategory: TrackableContractCategory,
 ) => {
   const initialtOffer = sessionStorage.getItem('initial_offer')
 
@@ -160,7 +160,6 @@ export const getInitialOfferFromSessionStorage = (
     return initialtOffer
   }
 
-  const contractCategory = getTrackableContractCategory(contractType)
   sessionStorage.setItem('initial_offer', contractCategory)
   return contractCategory
 }


### PR DESCRIPTION
## What?
Update offer events with `current_offer`
Spec here: https://docs.google.com/spreadsheets/d/1IHswc17yIOPkXTGA5aaLsgLRX1lhRvrKaVayzx7RAUo/edit#gid=0

## Why?
Sonny needs to map what offer the user took and then match to what they signed

<img width="557" alt="Screenshot 2021-11-05 at 11 54 53" src="https://user-images.githubusercontent.com/6661511/140499997-d4e49da6-a3f7-4700-8487-3b8353ee9ebf.png">


