### PR TITLE
GRW-570 Enable Insurance selector on production in SE

### DIFF
--- a/src/client/utils/hooks/useFeature.ts
+++ b/src/client/utils/hooks/useFeature.ts
@@ -18,7 +18,7 @@ interface FeatureConfig {
 const Config: readonly FeatureConfig[] = [
   {
     name: Features.OFFER_PAGE_INSURANCE_TOGGLE,
-    envs: ['staging'],
+    envs: ['staging', 'production'],
     markets: [Market.Se],
   },
   {


### PR DESCRIPTION
## What?

Enables Insurance Selector on Production by enabling the feature flag for that environment.

_Referenced ticket(s): [GRW-570]_



[GRW-570]: https://hedvig.atlassian.net/browse/GRW-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ