### PR TITLE
Fix hidden Hedvig logo on Safari

### DIFF
--- a/src/client/components/TopBar.tsx
+++ b/src/client/components/TopBar.tsx
@@ -60,8 +60,10 @@ const CenteredContainer = styled(Container)`
 `
 
 const LogoLink = styled.a`
+  display: block;
   color: inherit;
-  display: flex;
+  /* remove extra space under child SVG: https://stackoverflow.com/a/51161925 */
+  font-size: 0;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
## What?
The problem is that with `display: flex` on the parent of a responsive SVG, the SVG does not take up any height. Resorting to good ol' `display: block` does the trick. The `font-size: 0` hack as made popular by @robinandeer takes care of unwanted white-space below the SVG 🙌


## Why?
Logo was not visible in Safari

### Before
<img width="1780" alt="Screenshot 2021-11-09 at 17 23 20" src="https://user-images.githubusercontent.com/6661511/140963509-126cf16e-3041-44f7-8b6d-3329944fa480.png">

### After
<img width="1779" alt="Screenshot 2021-11-09 at 17 24 39" src="https://user-images.githubusercontent.com/6661511/140963754-fa46114a-8a2e-4ed0-a8bd-d3be0aae67b0.png">


