### PR TITLE
GRW-563: removed horizontal scroll from modal

### DIFF
--- a/src/client/components/ModalNew.tsx
+++ b/src/client/components/ModalNew.tsx
@@ -15,13 +15,19 @@ export interface ModalProps {
 
 const Wrapper = styled(motion.div)`
   position: fixed;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   z-index: 3000;
 `
 
 const Background = styled(motion.div)`
   position: fixed;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   background-color: rgba(25, 25, 25, 0.4);
 `
 

--- a/src/client/components/ModalNew.tsx
+++ b/src/client/components/ModalNew.tsx
@@ -3,7 +3,7 @@ import { colorsV3 } from '@hedviginsurance/brand'
 import { motion } from 'framer-motion'
 import React from 'react'
 
-import useLockBodyScroll from '../utils/hooks/useLockBodyScroll'
+import { useLockBodyScroll } from '../utils/hooks/useLockBodyScroll'
 
 import { Cross } from './icons/Cross'
 export interface ModalProps {

--- a/src/client/components/ModalNew.tsx
+++ b/src/client/components/ModalNew.tsx
@@ -2,8 +2,10 @@ import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { motion } from 'framer-motion'
 import React from 'react'
-import { Cross } from './icons/Cross'
 
+import useLockBodyScroll from '../utils/hooks/useLockBodyScroll'
+
+import { Cross } from './icons/Cross'
 export interface ModalProps {
   isVisible: boolean
   dynamicHeight?: boolean
@@ -13,23 +15,13 @@ export interface ModalProps {
 
 const Wrapper = styled(motion.div)`
   position: fixed;
-  width: 100%;
-  height: 100%;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  right: 0;
+  inset: 0;
   z-index: 3000;
 `
 
 const Background = styled(motion.div)`
   position: fixed;
-  width: 100%;
-  height: 100%;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  right: 0;
+  inset: 0;
   background-color: rgba(25, 25, 25, 0.4);
 `
 
@@ -39,24 +31,23 @@ interface ModalContainerProps {
 
 const ModalContainer = styled(motion.div)<ModalContainerProps>`
   position: relative;
+  left: 50%;
+  top: 50%;
   width: 100%;
   max-width: 56rem;
   max-height: 100vh;
+
   ${(props) =>
     !props.dynamicHeight &&
     `
-  height: 100%;
   min-height: 25rem;
   max-height: 56rem;`}
   background: ${colorsV3.white};
-  border-radius: 9px;
+  border-radius: 8px;
   position: absolute;
-  left: 50%;
-  top: 50%;
   transform: translateX(-50%) translateY(-50%);
   box-shadow: 0 0 14px rgba(0, 0, 0, 0.06);
-  box-sizing: border-box;
-  overflow-x: scroll;
+  overflow-y: auto;
 
   @media (max-height: 900px) {
     max-height: calc(100vh - 2rem);
@@ -115,14 +106,7 @@ export const Modal: React.FC<ModalProps> = ({
   onClose,
   children,
 }) => {
-  React.useEffect(() => {
-    if (isVisible) {
-      document.body.style.overflow = 'hidden'
-    }
-    return () => {
-      document.body.style.overflow = 'visible'
-    }
-  }, [isVisible])
+  useLockBodyScroll({ lock: isVisible })
 
   return (
     <Wrapper

--- a/src/client/utils/hooks/useLockBodyScroll.ts
+++ b/src/client/utils/hooks/useLockBodyScroll.ts
@@ -2,7 +2,7 @@ import { useLayoutEffect } from 'react'
 
 type UseLockBodyScrollConfig = { lock: boolean }
 
-function useLockBodyScroll({ lock }: UseLockBodyScrollConfig = { lock: true }) {
+export const useLockBodyScroll = ({ lock = true }: UseLockBodyScrollConfig) => {
   useLayoutEffect(() => {
     const previousOverflowStyle = window.getComputedStyle(document.body)
       .overflow
@@ -16,5 +16,3 @@ function useLockBodyScroll({ lock }: UseLockBodyScrollConfig = { lock: true }) {
     }
   }, [lock])
 }
-
-export default useLockBodyScroll

--- a/src/client/utils/hooks/useLockBodyScroll.ts
+++ b/src/client/utils/hooks/useLockBodyScroll.ts
@@ -4,8 +4,7 @@ type UseLockBodyScrollConfig = { lock: boolean }
 
 export const useLockBodyScroll = ({ lock = true }: UseLockBodyScrollConfig) => {
   useLayoutEffect(() => {
-    const previousOverflowStyle = window.getComputedStyle(document.body)
-      .overflow
+    const previousOverflowStyle = document.body.style.overflow
 
     if (lock) {
       document.body.style.overflow = 'hidden'

--- a/src/client/utils/hooks/useLockBodyScroll.ts
+++ b/src/client/utils/hooks/useLockBodyScroll.ts
@@ -1,0 +1,20 @@
+import { useLayoutEffect } from 'react'
+
+type UseLockBodyScrollConfig = { lock: boolean }
+
+function useLockBodyScroll({ lock }: UseLockBodyScrollConfig = { lock: true }) {
+  useLayoutEffect(() => {
+    const previousOverflowStyle = window.getComputedStyle(document.body)
+      .overflow
+
+    if (lock) {
+      document.body.style.overflow = 'hidden'
+    }
+
+    return () => {
+      document.body.style.overflow = previousOverflowStyle
+    }
+  }, [lock])
+}
+
+export default useLockBodyScroll

--- a/src/client/utils/hooks/useLockBodyScroll.ts
+++ b/src/client/utils/hooks/useLockBodyScroll.ts
@@ -4,7 +4,8 @@ type UseLockBodyScrollConfig = { lock: boolean }
 
 export const useLockBodyScroll = ({ lock = true }: UseLockBodyScrollConfig) => {
   useLayoutEffect(() => {
-    const previousOverflowStyle = document.body.style.overflow
+    const previousOverflowStyle = window.getComputedStyle(document.body)
+      .overflow
 
     if (lock) {
       document.body.style.overflow = 'hidden'


### PR DESCRIPTION
## What?

1. Move _lock scroll on body_ logic to a custom hook (`useLockBodyScroll`)
2. Remove weird horizontal scroll from modal:

### Before
![image](https://user-images.githubusercontent.com/19200662/140967582-4d112e27-19ad-429b-95e4-e9f48a311c9d.png)

### After
<img width="1546" alt="Screenshot 2021-11-09 at 17 45 07" src="https://user-images.githubusercontent.com/19200662/140967696-46574c6d-bacb-4055-904e-3d4089264d35.png">

## Why?

1. I intent to use the same hook to solve the same problem on offer page:
<img width="1472" alt="Screenshot 2021-11-09 at 17 44 29" src="https://user-images.githubusercontent.com/19200662/140967486-b2f85b1f-d56a-4b44-8cc4-98649ff85950.png">



_Referenced ticket(s): [GRW-563](https://hedvig.atlassian.net/browse/GRW-563)_
