### PR TITLE
GRW-567 Fix misaligned start date pickers on narrow screens

### DIFF
--- a/src/client/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/StartDate.tsx
@@ -39,8 +39,10 @@ const DateFormsWrapper = styled.div`
   margin-bottom: 1.5rem;
 `
 
-const RowButtonWrapper = styled.div`
-  width: 100%;
+const RowButtonWrapper = styled.div<{
+  isSplit: boolean
+}>`
+  width: ${({ isSplit }) => (isSplit ? `50%` : `100%`)};
   flex: 1;
 `
 
@@ -91,6 +93,9 @@ const StartDateRowLabel = styled.div`
   color: ${colorsV3.gray500};
   font-size: 0.75rem;
   padding-bottom: 0.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `
 
 const Value = styled.div`
@@ -296,7 +301,7 @@ const DateForm: React.FC<{
   const hasStartDate = Boolean(getDefaultDateValue(quote))
 
   return (
-    <RowButtonWrapper>
+    <RowButtonWrapper isSplit={isSplit}>
       {isSplit && <StartDateRowLabel>{quote.displayName}</StartDateRowLabel>}
       <RowButton
         datePickerOpen={datePickerOpen}


### PR DESCRIPTION
## What?

Fixes bug with mis-aligned start date fields when there are too dates and the screen is very narrow.

_Referenced ticket(s): [GRW-567]_

<img width="319" alt="Screenshot 2021-11-10 at 14 15 57" src="https://user-images.githubusercontent.com/89857278/141120601-a5b9b841-ff75-4c20-83aa-8233dfefa7ed.png">

[GRW-567]: https://hedvig.atlassian.net/browse/GRW-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ