### PR TITLE
fix(Tooltip): added min width

### DIFF
--- a/src/client/components/Tooltip/Tooltip.tsx
+++ b/src/client/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { motion } from 'framer-motion'
@@ -36,8 +36,7 @@ const TooltipContainer = styled.div<{ visible: boolean }>`
   top: 0;
   right: 100%;
   transform: translateY(calc(-50% + ${ICON_SIZE} / 2))
-    ${(props) =>
-      props.visible ? 'translateX(calc(-0.75rem))' : 'translateX(0)'};
+    ${(props) => (props.visible ? 'translateX(-0.75rem)' : 'translateX(0)')};
 
   &:after {
     content: ' ';
@@ -76,6 +75,7 @@ const TooltipText = styled.p`
   color: ${colorsV3.gray100};
   text-align: center;
   margin: 0;
+  min-width: 12.5rem;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
     width: max-content;
@@ -84,11 +84,11 @@ const TooltipText = styled.p`
 `
 
 export const Tooltip: React.FC<TooltipProps> = ({ body }) => {
-  const ref = React.useRef<HTMLDivElement>(null)
-  const [isVisible, setVisible] = React.useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setVisible] = useState(false)
 
-  React.useEffect(() => {
-    if (isVisible === false) return
+  useEffect(() => {
+    if (!isVisible) return
 
     const handleClickOutside = (event: TouchEvent) => {
       if (ref.current && !ref.current.contains(event.target as Node)) {


### PR DESCRIPTION
## What?

- Added `min-width` to `Tooltip`

## Why?

- So it not looks too narrow on mobile
<img width="408" alt="Screenshot 2021-11-10 at 15 49 38" src="https://user-images.githubusercontent.com/19200662/141135316-f4f7ad3b-376d-4d8d-992d-0f7cc1aee8b1.png">
<img width="1265" alt="Screenshot 2021-11-10 at 15 47 56" src="https://user-images.githubusercontent.com/19200662/141135321-24fd4ddd-24ed-4b9f-8283-065d8a3979af.png">

_Referenced ticket(s): [GRW-565](https://hedvig.atlassian.net/browse/GRW-565)_
