### PR TITLE
Fix/Tabs overflow + some other small design tweaks

### DIFF
--- a/src/client/pages/OfferNew/Tabs/Tab.tsx
+++ b/src/client/pages/OfferNew/Tabs/Tab.tsx
@@ -15,6 +15,7 @@ const TabContainer = styled.button<{ selected?: boolean }>`
   padding: 0 1rem 0.25rem 0;
   position: relative;
   flex-shrink: 0;
+  overflow-wrap: anywhere;
 
   &:hover {
     color: ${colorsV3.gray900};

--- a/src/client/pages/OfferNew/Tabs/Tab.tsx
+++ b/src/client/pages/OfferNew/Tabs/Tab.tsx
@@ -16,6 +16,7 @@ const TabContainer = styled.button<{ selected?: boolean }>`
   position: relative;
   flex-shrink: 0;
   overflow-wrap: anywhere;
+  margin: 0;
 
   &:hover {
     color: ${colorsV3.gray900};

--- a/src/client/pages/OfferNew/Tabs/Tab.tsx
+++ b/src/client/pages/OfferNew/Tabs/Tab.tsx
@@ -12,7 +12,7 @@ const TabContainer = styled.button<{ selected?: boolean }>`
   display: flex;
   font-size: 1.25rem;
   line-height: 1.4;
-  padding: 0 1rem 0.25rem 0;
+  padding: 0 1rem calc(0.25rem + 2px) 0;
   position: relative;
   flex-shrink: 0;
   overflow-wrap: anywhere;

--- a/src/client/pages/OfferNew/Tabs/Tab.tsx
+++ b/src/client/pages/OfferNew/Tabs/Tab.tsx
@@ -2,7 +2,7 @@ import React, { createRef } from 'react'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { MEDIUM_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
-import { UnderlineComponent } from './Underline'
+import { UnderlineComponent, UNDERLINE_HEIGHT } from './Underline'
 
 const TabContainer = styled.button<{ selected?: boolean }>`
   background-color: transparent;
@@ -12,7 +12,7 @@ const TabContainer = styled.button<{ selected?: boolean }>`
   display: flex;
   font-size: 1.25rem;
   line-height: 1.4;
-  padding: 0 1rem calc(0.25rem + 2px) 0;
+  padding: 0 1rem calc(0.25rem + ${UNDERLINE_HEIGHT}) 0;
   position: relative;
   flex-shrink: 0;
   overflow-wrap: anywhere;

--- a/src/client/pages/OfferNew/Tabs/Underline.tsx
+++ b/src/client/pages/OfferNew/Tabs/Underline.tsx
@@ -14,7 +14,7 @@ export const UnderlineComponent: React.FC = () => {
         height: '2px',
         backgroundColor: colorsV3.gray900,
         position: 'absolute',
-        bottom: '0px',
+        bottom: 0,
         width: isDesktop ? 'calc(100% - 2.5rem)' : 'calc(100% - 1rem)',
         zIndex: 1,
       }}

--- a/src/client/pages/OfferNew/Tabs/Underline.tsx
+++ b/src/client/pages/OfferNew/Tabs/Underline.tsx
@@ -4,6 +4,8 @@ import { colorsV3 } from '@hedviginsurance/brand'
 import { useMediaQuery } from 'react-responsive'
 import { BREAKPOINTS } from 'utils/mediaQueries'
 
+export const UNDERLINE_HEIGHT = '2px'
+
 export const UnderlineComponent: React.FC = () => {
   const isDesktop = useMediaQuery({ minWidth: BREAKPOINTS.mediumScreen })
 
@@ -11,7 +13,7 @@ export const UnderlineComponent: React.FC = () => {
     <motion.div
       layoutId="underline"
       style={{
-        height: '2px',
+        height: UNDERLINE_HEIGHT,
         backgroundColor: colorsV3.gray900,
         position: 'absolute',
         bottom: 0,


### PR DESCRIPTION
## What?

- Fix tabs overflow by using "overflow-wrap"
    I can't claim to understanding how/why this works. However, according to [this article](https://css-tricks.com/almanac/properties/o/overflow-wrap/) that property is often used to solve text-related layout issues.
- Safari: fix underline floating on top of background
    I believe Safari was adding a default 2px margin to buttons 🙃🔫
- Correct padding between text and underline (4px)

## Why?

We want thing to look crisp 💎 
...and the layout was broken before.

## Demo

https://user-images.githubusercontent.com/1220232/141194813-98047944-b29b-46e0-a9cf-fa8bc45563b9.mov