### PR TITLE
GRW fix(Checkout): block background scroll when opened

### DIFF
--- a/src/client/pages/OfferNew/Checkout/index.tsx
+++ b/src/client/pages/OfferNew/Checkout/index.tsx
@@ -18,6 +18,7 @@ import { getQuoteIds } from 'pages/OfferNew/utils'
 import { handleSignedEvent } from 'utils/tracking/signing'
 import { useTrack } from 'utils/tracking/tracking'
 import { Variation, useVariation } from 'utils/hooks/useVariation'
+import { useLockBodyScroll } from 'utils/hooks/useLockBodyScroll'
 import { useScrollLock, VisibilityState } from './hooks'
 import { CheckoutContent } from './CheckoutContent'
 import { Sign, SignUiState } from './Sign'
@@ -167,6 +168,8 @@ export const Checkout: React.FC<CheckoutProps> = ({
       setVisibilityState(VisibilityState.CLOSING)
     }
   }, [isOpen])
+
+  useLockBodyScroll({ lock: visibilityState === VisibilityState.OPEN })
 
   const [signUiState, setSignUiState] = useState<SignUiState>('NOT_STARTED')
   const [emailUpdateLoading, setEmailUpdateLoading] = useState(false)


### PR DESCRIPTION
## What?

- Prevent background scrolling when _Checkout_ is opened. To achieve that, I'm using `useLockBodyScroll` hook added on [this PR](https://github.com/HedvigInsurance/web-onboarding/pull/674)

## Why?

- Background content shouldn't be able to be scrolled while _Checkout_ is opened.

### Before
![image](https://user-images.githubusercontent.com/19200662/141452013-5af647ae-edb6-4ea4-b6d1-9fb9a7d246a7.png)

### After
<img width="1295" alt="Screenshot 2021-11-12 at 11 27 30" src="https://user-images.githubusercontent.com/19200662/141452183-8f3bb342-59b2-4b42-bb3b-00f1b619ebd4.png">

_Referenced ticket(s): [GRW-585](https://hedvig.atlassian.net/browse/GRW-585)_