### PR TITLE
GRW-58 / Feature / Offer Page Debugger for new Onboarding API

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "react": "^16.13.0",
     "react-animate-height": "^2.0.6",
     "react-dom": "^16.13.0",
+    "react-error-boundary": "^3.1.4",
     "react-helmet": "5.2.0",
     "react-helmet-async": "0.2.0",
     "react-hot-loader": "^4.3.11",

--- a/src/client/data/graphql.tsx
+++ b/src/client/data/graphql.tsx
@@ -11420,6 +11420,38 @@ export type CreateDanishHomeAccidentTravelQuoteMutation = {
     | { __typename: 'UnderwritingLimitsHit' }
 }
 
+export type CreateOnboardingQuoteCartMutationVariables = Exact<{
+  market: Market
+  locale: Scalars['String']
+}>
+
+export type CreateOnboardingQuoteCartMutation = {
+  __typename?: 'Mutation'
+} & Pick<Mutation, 'onboardingQuoteCart_create'>
+
+export type CreateQuoteBundleMutationVariables = Exact<{
+  id: Scalars['ID']
+  quotes: Array<QuoteData> | QuoteData
+}>
+
+export type CreateQuoteBundleMutation = { __typename?: 'Mutation' } & {
+  quoteCart_createQuoteBundle:
+    | ({ __typename?: 'QuoteCart' } & Pick<QuoteCart, 'id'> & {
+          bundle?: Maybe<
+            { __typename?: 'QuoteBundle' } & {
+              quotes: Array<
+                { __typename?: 'BundledQuote' } & Pick<BundledQuote, 'id'>
+              >
+            }
+          >
+        })
+    | ({ __typename?: 'CreateQuoteBundleError' } & {
+        limits: Array<
+          { __typename?: 'UnderwritingLimit' } & Pick<UnderwritingLimit, 'code'>
+        >
+      })
+}
+
 export type CreateSwedishHomeAccidentQuoteMutationVariables = Exact<{
   homeInput: CreateQuoteInput
   accidentInput: CreateQuoteInput
@@ -11825,6 +11857,132 @@ export type QuoteBundleVariantsQuery = { __typename?: 'Query' } & {
         }
     >
   }
+}
+
+export type QuoteCartQueryVariables = Exact<{
+  id: Scalars['ID']
+}>
+
+export type QuoteCartQuery = { __typename?: 'Query' } & {
+  quoteCart: { __typename?: 'QuoteCart' } & Pick<
+    QuoteCart,
+    'id' | 'checkoutMethods'
+  > & {
+      bundle?: Maybe<
+        { __typename?: 'QuoteBundle' } & {
+          possibleVariations: Array<
+            { __typename?: 'QuoteBundleVariant' } & Pick<
+              QuoteBundleVariant,
+              'id' | 'tag'
+            > & {
+                bundle: { __typename?: 'QuoteBundle' } & {
+                  bundleCost: { __typename?: 'InsuranceCost' } & {
+                    monthlyGross: { __typename?: 'MonetaryAmountV2' } & Pick<
+                      MonetaryAmountV2,
+                      'amount' | 'currency'
+                    >
+                  }
+                }
+              }
+          >
+          bundleCost: { __typename?: 'InsuranceCost' } & Pick<
+            InsuranceCost,
+            'freeUntil'
+          > & {
+              monthlyGross: { __typename?: 'MonetaryAmountV2' } & Pick<
+                MonetaryAmountV2,
+                'amount' | 'currency'
+              >
+              monthlyNet: { __typename?: 'MonetaryAmountV2' } & Pick<
+                MonetaryAmountV2,
+                'amount' | 'currency'
+              >
+              monthlyDiscount: { __typename?: 'MonetaryAmountV2' } & Pick<
+                MonetaryAmountV2,
+                'amount' | 'currency'
+              >
+            }
+          quotes: Array<
+            { __typename?: 'BundledQuote' } & Pick<
+              BundledQuote,
+              | 'id'
+              | 'firstName'
+              | 'lastName'
+              | 'ssn'
+              | 'birthDate'
+              | 'startDate'
+              | 'expiresAt'
+              | 'email'
+              | 'dataCollectionId'
+              | 'typeOfContract'
+              | 'initiatedFrom'
+            > & {
+                currentInsurer?: Maybe<
+                  { __typename?: 'CurrentInsurer' } & Pick<
+                    CurrentInsurer,
+                    'id' | 'displayName' | 'switchable'
+                  >
+                >
+                price: { __typename?: 'MonetaryAmountV2' } & Pick<
+                  MonetaryAmountV2,
+                  'amount' | 'currency'
+                >
+                quoteDetails:
+                  | ({ __typename: 'SwedishApartmentQuoteDetails' } & Pick<
+                      SwedishApartmentQuoteDetails,
+                      | 'street'
+                      | 'zipCode'
+                      | 'householdSize'
+                      | 'livingSpace'
+                      | 'type'
+                    >)
+                  | ({ __typename: 'SwedishHouseQuoteDetails' } & Pick<
+                      SwedishHouseQuoteDetails,
+                      'street'
+                    >)
+                  | ({ __typename: 'SwedishAccidentDetails' } & Pick<
+                      SwedishAccidentDetails,
+                      'street'
+                    >)
+                  | { __typename: 'NorwegianHomeContentsDetails' }
+                  | { __typename: 'NorwegianTravelDetails' }
+                  | { __typename: 'DanishHomeContentsDetails' }
+                  | { __typename: 'DanishAccidentDetails' }
+                  | { __typename: 'DanishTravelDetails' }
+              }
+          >
+        }
+      >
+      campaign?: Maybe<
+        { __typename?: 'Campaign' } & Pick<Campaign, 'code' | 'expiresAt'> & {
+            incentive?: Maybe<
+              | ({ __typename?: 'MonthlyCostDeduction' } & {
+                  amount?: Maybe<
+                    { __typename?: 'MonetaryAmountV2' } & Pick<
+                      MonetaryAmountV2,
+                      'amount' | 'currency'
+                    >
+                  >
+                })
+              | { __typename?: 'FreeMonths' }
+              | { __typename?: 'NoDiscount' }
+              | { __typename?: 'VisibleNoDiscount' }
+              | ({ __typename?: 'PercentageDiscountMonths' } & Pick<
+                  PercentageDiscountMonths,
+                  'percentageDiscount' | 'quantity'
+                >)
+              | { __typename?: 'IndefinitePercentageDiscount' }
+            >
+            owner?: Maybe<
+              { __typename?: 'CampaignOwner' } & Pick<
+                CampaignOwner,
+                'displayName' | 'id'
+              >
+            >
+          }
+      >
+      checkout?: Maybe<{ __typename?: 'Checkout' } & Pick<Checkout, 'status'>>
+    }
 }
 
 export type RedeemCodeMutationVariables = Exact<{
@@ -12503,6 +12661,120 @@ export type CreateDanishHomeAccidentTravelQuoteMutationResult = ApolloReactCommo
 export type CreateDanishHomeAccidentTravelQuoteMutationOptions = ApolloReactCommon.BaseMutationOptions<
   CreateDanishHomeAccidentTravelQuoteMutation,
   CreateDanishHomeAccidentTravelQuoteMutationVariables
+>
+export const CreateOnboardingQuoteCartDocument = gql`
+  mutation CreateOnboardingQuoteCart($market: Market!, $locale: String!) {
+    onboardingQuoteCart_create(input: { market: $market, locale: $locale })
+  }
+`
+export type CreateOnboardingQuoteCartMutationFn = ApolloReactCommon.MutationFunction<
+  CreateOnboardingQuoteCartMutation,
+  CreateOnboardingQuoteCartMutationVariables
+>
+
+/**
+ * __useCreateOnboardingQuoteCartMutation__
+ *
+ * To run a mutation, you first call `useCreateOnboardingQuoteCartMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateOnboardingQuoteCartMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createOnboardingQuoteCartMutation, { data, loading, error }] = useCreateOnboardingQuoteCartMutation({
+ *   variables: {
+ *      market: // value for 'market'
+ *      locale: // value for 'locale'
+ *   },
+ * });
+ */
+export function useCreateOnboardingQuoteCartMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateOnboardingQuoteCartMutation,
+    CreateOnboardingQuoteCartMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
+    CreateOnboardingQuoteCartMutation,
+    CreateOnboardingQuoteCartMutationVariables
+  >(CreateOnboardingQuoteCartDocument, options)
+}
+export type CreateOnboardingQuoteCartMutationHookResult = ReturnType<
+  typeof useCreateOnboardingQuoteCartMutation
+>
+export type CreateOnboardingQuoteCartMutationResult = ApolloReactCommon.MutationResult<
+  CreateOnboardingQuoteCartMutation
+>
+export type CreateOnboardingQuoteCartMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  CreateOnboardingQuoteCartMutation,
+  CreateOnboardingQuoteCartMutationVariables
+>
+export const CreateQuoteBundleDocument = gql`
+  mutation CreateQuoteBundle($id: ID!, $quotes: [QuoteData!]!) {
+    quoteCart_createQuoteBundle(id: $id, input: { quoteData: $quotes }) {
+      ... on QuoteCart {
+        id
+        bundle {
+          quotes {
+            id
+          }
+        }
+      }
+      ... on CreateQuoteBundleError {
+        limits {
+          code
+        }
+      }
+    }
+  }
+`
+export type CreateQuoteBundleMutationFn = ApolloReactCommon.MutationFunction<
+  CreateQuoteBundleMutation,
+  CreateQuoteBundleMutationVariables
+>
+
+/**
+ * __useCreateQuoteBundleMutation__
+ *
+ * To run a mutation, you first call `useCreateQuoteBundleMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateQuoteBundleMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createQuoteBundleMutation, { data, loading, error }] = useCreateQuoteBundleMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      quotes: // value for 'quotes'
+ *   },
+ * });
+ */
+export function useCreateQuoteBundleMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateQuoteBundleMutation,
+    CreateQuoteBundleMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
+    CreateQuoteBundleMutation,
+    CreateQuoteBundleMutationVariables
+  >(CreateQuoteBundleDocument, options)
+}
+export type CreateQuoteBundleMutationHookResult = ReturnType<
+  typeof useCreateQuoteBundleMutation
+>
+export type CreateQuoteBundleMutationResult = ApolloReactCommon.MutationResult<
+  CreateQuoteBundleMutation
+>
+export type CreateQuoteBundleMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  CreateQuoteBundleMutation,
+  CreateQuoteBundleMutationVariables
 >
 export const CreateSwedishHomeAccidentQuoteDocument = gql`
   mutation CreateSwedishHomeAccidentQuote(
@@ -13233,6 +13505,150 @@ export type QuoteBundleVariantsLazyQueryHookResult = ReturnType<
 export type QuoteBundleVariantsQueryResult = ApolloReactCommon.QueryResult<
   QuoteBundleVariantsQuery,
   QuoteBundleVariantsQueryVariables
+>
+export const QuoteCartDocument = gql`
+  query QuoteCart($id: ID!) {
+    quoteCart(id: $id) {
+      id
+      bundle {
+        possibleVariations {
+          id
+          tag(locale: sv_SE)
+          bundle {
+            bundleCost {
+              monthlyGross {
+                amount
+                currency
+              }
+            }
+          }
+        }
+        bundleCost {
+          monthlyGross {
+            amount
+            currency
+          }
+          monthlyNet {
+            amount
+            currency
+          }
+          monthlyDiscount {
+            amount
+            currency
+          }
+          freeUntil
+        }
+        quotes {
+          id
+          currentInsurer {
+            id
+            displayName
+            switchable
+          }
+          price {
+            amount
+            currency
+          }
+          firstName
+          lastName
+          ssn
+          birthDate
+          quoteDetails {
+            __typename
+            ... on SwedishApartmentQuoteDetails {
+              street
+              zipCode
+              householdSize
+              livingSpace
+              type
+            }
+            ... on SwedishHouseQuoteDetails {
+              street
+            }
+            ... on SwedishAccidentDetails {
+              street
+            }
+          }
+          startDate
+          expiresAt
+          email
+          dataCollectionId
+          typeOfContract
+          initiatedFrom
+        }
+      }
+      campaign {
+        incentive {
+          ... on MonthlyCostDeduction {
+            amount {
+              amount
+              currency
+            }
+          }
+          ... on PercentageDiscountMonths {
+            percentageDiscount
+            quantity
+          }
+        }
+        code
+        owner {
+          displayName
+          id
+        }
+        expiresAt
+      }
+      checkoutMethods
+      checkout {
+        status
+      }
+    }
+  }
+`
+
+/**
+ * __useQuoteCartQuery__
+ *
+ * To run a query within a React component, call `useQuoteCartQuery` and pass it any options that fit your needs.
+ * When your component renders, `useQuoteCartQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useQuoteCartQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useQuoteCartQuery(
+  baseOptions: Apollo.QueryHookOptions<QuoteCartQuery, QuoteCartQueryVariables>,
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<QuoteCartQuery, QuoteCartQueryVariables>(
+    QuoteCartDocument,
+    options,
+  )
+}
+export function useQuoteCartLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    QuoteCartQuery,
+    QuoteCartQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<QuoteCartQuery, QuoteCartQueryVariables>(
+    QuoteCartDocument,
+    options,
+  )
+}
+export type QuoteCartQueryHookResult = ReturnType<typeof useQuoteCartQuery>
+export type QuoteCartLazyQueryHookResult = ReturnType<
+  typeof useQuoteCartLazyQuery
+>
+export type QuoteCartQueryResult = ApolloReactCommon.QueryResult<
+  QuoteCartQuery,
+  QuoteCartQueryVariables
 >
 export const RedeemCodeDocument = gql`
   mutation RedeemCode($code: String!) {

--- a/src/client/data/graphql.tsx
+++ b/src/client/data/graphql.tsx
@@ -36,7 +36,7 @@ export type Scalars = {
   CheckoutPaymentsAction: any
   /** A String-representation of Adyen's payments details request */
   PaymentsDetailsRequest: any
-  QuoteData: any
+  JSON: any
   /** The `Upload` scalar type represents a file upload. */
   Upload: any
   UUID: any
@@ -171,10 +171,7 @@ export type ActiveStatus = {
   upcomingAgreementChange?: Maybe<UpcomingAgreementChange>
 }
 
-export type AddCampaignError = {
-  __typename?: 'AddCampaignError'
-  errorCode: Scalars['String']
-}
+export type AddCampaignResult = QuoteCart | BasicError
 
 export type AdditionalPaymentsDetailsRequest = {
   paymentsDetailsRequest: Scalars['PaymentsDetailsRequest']
@@ -1536,6 +1533,11 @@ export enum BankIdStatus {
   Complete = 'complete',
 }
 
+export type BasicError = Error & {
+  __typename?: 'BasicError'
+  message: Scalars['String']
+}
+
 export type BatchPayload = {
   __typename?: 'BatchPayload'
   /** The number of nodes that have been affected by the Batch operation. */
@@ -1773,6 +1775,38 @@ export type ChatState = {
   onboardingDone: Scalars['Boolean']
 }
 
+/** The signing of an onboarding session, that contains information about the current signing status. */
+export type Checkout = {
+  __typename?: 'Checkout'
+  /**  Current signing status of the session  */
+  status: CheckoutStatus
+  /**  A user-visible text that explains the current status. Useful for async signing like SE BankID.  */
+  statusText?: Maybe<Scalars['String']>
+}
+
+export enum CheckoutMethod {
+  SwedishBankId = 'SWEDISH_BANK_ID',
+  NorwegianBankId = 'NORWEGIAN_BANK_ID',
+  DanishBankId = 'DANISH_BANK_ID',
+  SimpleSign = 'SIMPLE_SIGN',
+  ApproveOnly = 'APPROVE_ONLY',
+}
+
+export enum CheckoutStatus {
+  /**  This signing session is ongoing. Only for async signing like SE BankID.  */
+  Pending = 'PENDING',
+  /**
+   * This signing session is signed, and can be completed (producing an access token).
+   *
+   * Synchronous signing methods, like simple sign, immediately produce this state.
+   */
+  Signed = 'SIGNED',
+  /** This signing is completed, which means the onboarding session has reached its terminal state. */
+  Completed = 'COMPLETED',
+  /** The signing has failed - which means it also can be retried. */
+  Failed = 'FAILED',
+}
+
 export type Claim = {
   __typename?: 'Claim'
   id: Scalars['String']
@@ -1803,6 +1837,42 @@ export enum ClaimStatus {
   Submitted = 'SUBMITTED',
   BeingHandled = 'BEING_HANDLED',
   Closed = 'CLOSED',
+  Reopened = 'REOPENED',
+}
+
+export type ClaimStatusCard = {
+  __typename?: 'ClaimStatusCard'
+  id: Scalars['ID']
+  pills: Array<ClaimStatusCardPill>
+  title: Scalars['String']
+  subtitle: Scalars['String']
+  progressSegments: Array<ClaimStatusProgressSegment>
+}
+
+export type ClaimStatusCardPill = {
+  __typename?: 'ClaimStatusCardPill'
+  text: Scalars['String']
+  type: ClaimStatusCardPillType
+}
+
+export enum ClaimStatusCardPillType {
+  Open = 'OPEN',
+  Closed = 'CLOSED',
+  Reopened = 'REOPENED',
+  Payment = 'PAYMENT',
+}
+
+export type ClaimStatusProgressSegment = {
+  __typename?: 'ClaimStatusProgressSegment'
+  text: Scalars['String']
+  type: ClaimStatusProgressType
+}
+
+export enum ClaimStatusProgressType {
+  PastInactive = 'PAST_INACTIVE',
+  CurrentlyActive = 'CURRENTLY_ACTIVE',
+  FutureInactive = 'FUTURE_INACTIVE',
+  Paid = 'PAID',
   Reopened = 'REOPENED',
 }
 
@@ -1843,6 +1913,7 @@ export type ColorInput = {
 
 export type CommonClaim = {
   __typename?: 'CommonClaim'
+  id: Scalars['String']
   icon: Icon
   title: Scalars['String']
   layout: CommonClaimLayouts
@@ -2528,44 +2599,31 @@ export type CreateNorwegianTravelInput = {
   isYouth: Scalars['Boolean']
 }
 
-export type CreateOnboardingQuoteError = {
-  __typename?: 'CreateOnboardingQuoteError'
+export type CreateOnboardingQuoteCartInput = {
+  market: Market
+  locale: Scalars['String']
+}
+
+export type CreateQuoteBundleError = Error & {
+  __typename?: 'CreateQuoteBundleError'
+  message: Scalars['String']
   limits: Array<UnderwritingLimit>
 }
 
-export type CreateOnboardingQuoteInput = {
-  id?: Maybe<Scalars['ID']>
-  firstName: Scalars['String']
-  lastName: Scalars['String']
-  email?: Maybe<Scalars['String']>
-  dataCollectionId?: Maybe<Scalars['ID']>
-  phoneNumber?: Maybe<Scalars['String']>
-  currentInsurer?: Maybe<Scalars['String']>
-  ssn?: Maybe<Scalars['String']>
-  birthDate?: Maybe<Scalars['LocalDate']>
-  startDate?: Maybe<Scalars['LocalDate']>
-  swedishApartmentData?: Maybe<Scalars['QuoteData']>
-  swedishHouseData?: Maybe<Scalars['QuoteData']>
-  swedishAccidentData?: Maybe<Scalars['QuoteData']>
-  norwegianHomeContentsData?: Maybe<Scalars['QuoteData']>
-  norwegianTravelData?: Maybe<Scalars['QuoteData']>
-  danishHomeContentsData?: Maybe<Scalars['QuoteData']>
-  danishAccidentData?: Maybe<Scalars['QuoteData']>
-  danishTravelData?: Maybe<Scalars['QuoteData']>
+export type CreateQuoteBundleInput = {
+  quoteData: Array<QuoteData>
 }
 
-export type CreateOnboardingQuoteResult =
-  | CreateOnboardingQuoteSuccess
-  | CreateOnboardingQuoteError
+export type CreateQuoteBundleResult = QuoteCart | CreateQuoteBundleError
 
-export type CreateOnboardingQuoteSuccess = {
-  __typename?: 'CreateOnboardingQuoteSuccess'
+export type CreateQuoteBundleSuccess = {
+  __typename?: 'CreateQuoteBundleSuccess'
   id: Scalars['ID']
 }
 
-export type CreateOnboardingSessionInput = {
-  country: Scalars['String']
-  locale: Scalars['String']
+export type CreateQuoteCartAccessTokenResult = {
+  __typename?: 'CreateQuoteCartAccessTokenResult'
+  accessToken: Scalars['String']
 }
 
 export type CreateQuoteInput = {
@@ -3743,13 +3801,18 @@ export type Emergency = {
   __typename?: 'Emergency'
   color: HedvigColor
   title: Scalars['String']
-  /**  Phone Number on E.164-format  */
+  /** Phone Number on E.164-format */
   emergencyNumber: Scalars['String']
 }
 
 export enum Environment {
   Production = 'Production',
   Staging = 'Staging',
+}
+
+/**  Base Error interface that contains displayable error message.  */
+export type Error = {
+  message: Scalars['String']
 }
 
 export type ExceededMaximumUpdates = {
@@ -6740,6 +6803,12 @@ export enum LoggingSource {
   Android = 'ANDROID',
 }
 
+export enum Market {
+  Sweden = 'SWEDEN',
+  Norway = 'NORWAY',
+  Denmark = 'DENMARK',
+}
+
 export type MarketingStory = Node & {
   __typename?: 'MarketingStory'
   /** System stage field */
@@ -7481,25 +7550,25 @@ export type Mutation = {
    * Create a new onboarding session. This is not an authentication session, but rather an object that
    * ties the onboarding journey together.
    */
-  onboardingSession_create: Scalars['ID']
+  onboardingQuoteCart_create: Scalars['ID']
   /** Create a quote as part of this onboarding session. */
-  onboardingSession_createQuote: CreateOnboardingQuoteResult
+  quoteCart_createQuoteBundle: CreateQuoteBundleResult
   /**
    * Add a campaign by its code to this onboarding session. This campaign won't be "redeemed", but rather
    * left in a pending state on the onboarding until signing occurs and a member is created.
    *
    * Returns an error if there was a problem with redeeming it, or null upon success.
    */
-  onboardingSession_addCampaign?: Maybe<AddCampaignError>
+  quoteCart_addCampaign: AddCampaignResult
   /** Remove the existing campaign. */
-  onboardingSession_removeCampaign: Scalars['Boolean']
+  quoteCart_removeCampaign: RemoveCampaignResult
   /**
    * Initiate signing of this onboarding, optionally tagging a subset of the quotes if not all of them are wanted.
    *
    * Note, the session should only be moved into its signing state once the prior things, such as campaign, are
    * considered done.
    */
-  onboardingSession_startSigning: OnboardingStartSignResponse
+  quoteCart_startCheckout: StartCheckoutResult
   /**
    * Once an onboarding session is "signed", it can be finalized/consumed by this method, which will produce
    * an access token. This access token will serve as the means of authorization towards the member that was
@@ -7507,7 +7576,7 @@ export type Mutation = {
    *
    * This is needed at this stage because the "connecting payments" stage will happen with an actual signed member.
    */
-  onboardingSession_createAccessToken: OnboardingSessionAccessTokenResult
+  quoteCart_createAccessToken: CreateQuoteCartAccessTokenResult
   logout: Scalars['Boolean']
   createClaim: Scalars['ID']
   createSession: Scalars['String']
@@ -7674,30 +7743,30 @@ export type MutationLogin_ResendOtpArgs = {
   id: Scalars['ID']
 }
 
-export type MutationOnboardingSession_CreateArgs = {
-  input: CreateOnboardingSessionInput
+export type MutationOnboardingQuoteCart_CreateArgs = {
+  input: CreateOnboardingQuoteCartInput
 }
 
-export type MutationOnboardingSession_CreateQuoteArgs = {
+export type MutationQuoteCart_CreateQuoteBundleArgs = {
   id: Scalars['ID']
-  input: CreateOnboardingQuoteInput
+  input: CreateQuoteBundleInput
 }
 
-export type MutationOnboardingSession_AddCampaignArgs = {
+export type MutationQuoteCart_AddCampaignArgs = {
   id: Scalars['ID']
-  campaignCode: Scalars['String']
+  code: Scalars['String']
 }
 
-export type MutationOnboardingSession_RemoveCampaignArgs = {
+export type MutationQuoteCart_RemoveCampaignArgs = {
   id: Scalars['ID']
 }
 
-export type MutationOnboardingSession_StartSigningArgs = {
+export type MutationQuoteCart_StartCheckoutArgs = {
   id: Scalars['ID']
   quoteIds?: Maybe<Array<Scalars['ID']>>
 }
 
-export type MutationOnboardingSession_CreateAccessTokenArgs = {
+export type MutationQuoteCart_CreateAccessTokenArgs = {
   id: Scalars['ID']
 }
 
@@ -7882,72 +7951,10 @@ export enum NorwegianTravelLineOfBusiness {
   Youth = 'YOUTH',
 }
 
-/**
- * An onboarding session is a type that exists to guide the client through an onboarding journey,
- * as a means of storing intermediate state up until the point where it is "signed" and then flushed
- * into a proper "member".
- */
-export type OnboardingSession = {
-  __typename?: 'OnboardingSession'
-  id: Scalars['ID']
-  /**  Campaign, if one has been attached by a code  */
-  campaign?: Maybe<Campaign>
-  /**  The quote bundle "view" of the quotes created as part of this onboarding  */
-  bundle?: Maybe<QuoteBundle>
-  /**  The ongoing signing state, if it has been initiated - or null if it has not.  */
-  signing?: Maybe<OnboardingSessionSigning>
-}
-
-export type OnboardingSessionAccessTokenResult = {
-  __typename?: 'OnboardingSessionAccessTokenResult'
-  accessToken: Scalars['String']
-}
-
-/** The signing of an onboarding session, that contains information about the current signing status. */
-export type OnboardingSessionSigning = {
-  __typename?: 'OnboardingSessionSigning'
-  /**  Current signing status of the session  */
-  status: OnboardingSessionSignStatus
-  /**  A user-visible text that explains the current status. Useful for async signing like SE BankID.  */
-  statusText?: Maybe<Scalars['String']>
-}
-
-export enum OnboardingSessionSignStatus {
-  /**  This signing session is ongoing. Only for async signing like SE BankID.  */
-  Pending = 'PENDING',
-  /**
-   * This signing session is signed, and can be completed (producing an access token).
-   *
-   * Synchronous signing methods, like simple sign, immediately produce this state.
-   */
-  Signed = 'SIGNED',
-  /** This signing is completed, which means the onboarding session has reached its terminal state. */
-  Completed = 'COMPLETED',
-  /** The signing has failed - which means it also can be retried. */
-  Failed = 'FAILED',
-}
-
-export type OnboardingSigningFailure = {
-  __typename?: 'OnboardingSigningFailure'
-  errorMessage: Scalars['String']
-  errorCode: Scalars['String']
-}
-
 export type OnboardingSigningSuccess = {
   __typename?: 'OnboardingSigningSuccess'
-  status?: Maybe<OnboardingSessionSignStatus>
+  status?: Maybe<CheckoutStatus>
 }
-
-export type OnboardingSigningSwedishBankId = {
-  __typename?: 'OnboardingSigningSwedishBankId'
-  status?: Maybe<OnboardingSessionSignStatus>
-  autoStartToken?: Maybe<Scalars['String']>
-}
-
-export type OnboardingStartSignResponse =
-  | OnboardingSigningSwedishBankId
-  | OnboardingSigningSuccess
-  | OnboardingSigningFailure
 
 export type OtpLoginAttemptInput = {
   otpType: OtpType
@@ -8170,15 +8177,17 @@ export type Query = {
   externalInsuranceProvider?: Maybe<ExternalInsuranceProvider>
   autoCompleteAddress: Array<AutoCompleteResponse>
   _?: Maybe<Scalars['Boolean']>
+  /** Returns all claims the member has */
+  claims: Array<Claim>
   /** Returns all the currently active contracts, combined into bundles. */
   activeContractBundles: Array<ContractBundle>
   /** Returns all contracts the member currently holds, regardless of activation/termination status */
   contracts: Array<Contract>
   /** Returns whether a member has at least one contract */
   hasContract: Scalars['Boolean']
-  /** Fetch onboarding session by its ID. */
-  onboardingSession: OnboardingSession
   quoteBundle: QuoteBundle
+  /** Fetch onboarding session by its ID. */
+  quoteCart: QuoteCart
   /** @deprecated Use `contracts` instead */
   insurance: Insurance
   cashback?: Maybe<Cashback>
@@ -8201,14 +8210,13 @@ export type Query = {
   selfChangeEligibility: SelfChangeEligibility
   /** All locales that are available and activated */
   availableLocales: Array<Locale>
-  /** Returns all claims the member has */
-  claims: Array<Claim>
   /** Returns perils from promise-cms */
   contractPerils: Array<PerilV2>
   embarkStory?: Maybe<EmbarkStory>
   /** returns names of all available embark stories */
   embarkStoryNames: Array<Scalars['String']>
   embarkStories: Array<EmbarkStoryMetadata>
+  claims_statusCards: Array<ClaimStatusCard>
 }
 
 export type QueryFaqsArgs = {
@@ -8377,12 +8385,12 @@ export type QueryAutoCompleteAddressArgs = {
   options?: Maybe<AddressAutocompleteOptions>
 }
 
-export type QueryOnboardingSessionArgs = {
-  id: Scalars['ID']
-}
-
 export type QueryQuoteBundleArgs = {
   input: QuoteBundleInput
+}
+
+export type QueryQuoteCartArgs = {
+  id: Scalars['ID']
 }
 
 export type QueryCashbackArgs = {
@@ -8418,6 +8426,10 @@ export type QueryEmbarkStoryArgs = {
 
 export type QueryEmbarkStoriesArgs = {
   locale: Scalars['String']
+}
+
+export type QueryClaims_StatusCardsArgs = {
+  locale: Locale
 }
 
 export type Quote = CompleteQuote | IncompleteQuote
@@ -8496,6 +8508,29 @@ export type QuoteBundleVariantTagArgs = {
   locale: Locale
 }
 
+/**
+ * An onboarding session is a type that exists to guide the client through an onboarding journey,
+ * as a means of storing intermediate state up until the point where it is "signed" and then flushed
+ * into a proper "member".
+ */
+export type QuoteCart = {
+  __typename?: 'QuoteCart'
+  id: Scalars['ID']
+  /**  Campaign, if one has been attached by a code  */
+  campaign?: Maybe<Campaign>
+  /**  The quote bundle "view" of the quotes created as part of this onboarding  */
+  bundle?: Maybe<QuoteBundle>
+  /**  The ongoing signing state, if it has been initiated - or null if it has not.  */
+  checkout?: Maybe<Checkout>
+  /**  The accepted checkout methods.  */
+  checkoutMethods: Array<CheckoutMethod>
+}
+
+export type QuoteData = {
+  type: Scalars['String']
+  payload: Scalars['JSON']
+}
+
 export type QuoteDetails =
   | SwedishApartmentQuoteDetails
   | SwedishHouseQuoteDetails
@@ -8550,6 +8585,8 @@ export type RegisterDirectDebitClientContext = {
 export type RemoveCampaignCodeResult =
   | SuccessfullyRemovedCampaignsResult
   | CannotRemoveActiveCampaignCode
+
+export type RemoveCampaignResult = QuoteCart | BasicError
 
 export type RemoveCurrentInsurerInput = {
   id: Scalars['ID']
@@ -9683,6 +9720,8 @@ export enum Stage {
   Published = 'PUBLISHED',
 }
 
+export type StartCheckoutResult = QuoteCart | BasicError
+
 export type StartSignResponse =
   | SwedishBankIdSession
   | NorwegianBankIdSession
@@ -9738,6 +9777,12 @@ export type SubscriptionCurrentChatResponseArgs = {
 
 export type SubscriptionChatStateArgs = {
   mostRecentTimestamp: Scalars['String']
+}
+
+/**  Generic success type for mutation success cases when there is nothing to return.  */
+export type Success = {
+  __typename?: 'Success'
+  _?: Maybe<Scalars['Boolean']>
 }
 
 export type SuccessfullyRemovedCampaignsResult = {
@@ -9942,12 +9987,11 @@ export enum TextContentType {
 export type TitleAndBulletPoints = {
   __typename?: 'TitleAndBulletPoints'
   color: HedvigColor
-  icon: Icon
   title: Scalars['String']
   buttonTitle: Scalars['String']
+  bulletPoints: Array<BulletPoints>
   /** @deprecated not used */
   claimFirstMessage: Scalars['String']
-  bulletPoints: Array<BulletPoints>
 }
 
 export enum TokenizationChannel {

--- a/src/client/data/graphql.tsx
+++ b/src/client/data/graphql.tsx
@@ -11430,7 +11430,7 @@ export type CreateOnboardingQuoteCartMutation = {
 } & Pick<Mutation, 'onboardingQuoteCart_create'>
 
 export type CreateQuoteBundleMutationVariables = Exact<{
-  id: Scalars['ID']
+  quoteCartId: Scalars['ID']
   quotes: Array<QuoteData> | QuoteData
 }>
 
@@ -11861,6 +11861,7 @@ export type QuoteBundleVariantsQuery = { __typename?: 'Query' } & {
 
 export type QuoteCartQueryVariables = Exact<{
   id: Scalars['ID']
+  locale: Locale
 }>
 
 export type QuoteCartQuery = { __typename?: 'Query' } & {
@@ -12713,8 +12714,11 @@ export type CreateOnboardingQuoteCartMutationOptions = ApolloReactCommon.BaseMut
   CreateOnboardingQuoteCartMutationVariables
 >
 export const CreateQuoteBundleDocument = gql`
-  mutation CreateQuoteBundle($id: ID!, $quotes: [QuoteData!]!) {
-    quoteCart_createQuoteBundle(id: $id, input: { quoteData: $quotes }) {
+  mutation CreateQuoteBundle($quoteCartId: ID!, $quotes: [QuoteData!]!) {
+    quoteCart_createQuoteBundle(
+      id: $quoteCartId
+      input: { quoteData: $quotes }
+    ) {
       ... on QuoteCart {
         id
         bundle {
@@ -12749,7 +12753,7 @@ export type CreateQuoteBundleMutationFn = ApolloReactCommon.MutationFunction<
  * @example
  * const [createQuoteBundleMutation, { data, loading, error }] = useCreateQuoteBundleMutation({
  *   variables: {
- *      id: // value for 'id'
+ *      quoteCartId: // value for 'quoteCartId'
  *      quotes: // value for 'quotes'
  *   },
  * });
@@ -13507,13 +13511,13 @@ export type QuoteBundleVariantsQueryResult = ApolloReactCommon.QueryResult<
   QuoteBundleVariantsQueryVariables
 >
 export const QuoteCartDocument = gql`
-  query QuoteCart($id: ID!) {
+  query QuoteCart($id: ID!, $locale: Locale!) {
     quoteCart(id: $id) {
       id
       bundle {
         possibleVariations {
           id
-          tag(locale: sv_SE)
+          tag(locale: $locale)
           bundle {
             bundleCost {
               monthlyGross {
@@ -13618,6 +13622,7 @@ export const QuoteCartDocument = gql`
  * const { data, loading, error } = useQuoteCartQuery({
  *   variables: {
  *      id: // value for 'id'
+ *      locale: // value for 'locale'
  *   },
  * });
  */

--- a/src/client/graphql/CreateOnboardingQuoteCart.graphql
+++ b/src/client/graphql/CreateOnboardingQuoteCart.graphql
@@ -1,0 +1,3 @@
+mutation CreateOnboardingQuoteCart($market: Market!, $locale: String!) {
+  onboardingQuoteCart_create(input: { market: $market, locale: $locale })
+}

--- a/src/client/graphql/CreateQuoteBundle.graphql
+++ b/src/client/graphql/CreateQuoteBundle.graphql
@@ -1,5 +1,5 @@
-mutation CreateQuoteBundle($id: ID!, $quotes: [QuoteData!]!) {
-  quoteCart_createQuoteBundle(id: $id, input: { quoteData: $quotes }) {
+mutation CreateQuoteBundle($quoteCartId: ID!, $quotes: [QuoteData!]!) {
+  quoteCart_createQuoteBundle(id: $quoteCartId, input: { quoteData: $quotes }) {
     ... on QuoteCart {
       id
       bundle {

--- a/src/client/graphql/CreateQuoteBundle.graphql
+++ b/src/client/graphql/CreateQuoteBundle.graphql
@@ -1,0 +1,17 @@
+mutation CreateQuoteBundle($id: ID!, $quotes: [QuoteData!]!) {
+  quoteCart_createQuoteBundle(id: $id, input: { quoteData: $quotes }) {
+    ... on QuoteCart {
+      id
+      bundle {
+        quotes {
+          id
+        }
+      }
+    }
+    ... on CreateQuoteBundleError {
+      limits {
+        code
+      }
+    }
+  }
+}

--- a/src/client/graphql/QuoteCart.graphql
+++ b/src/client/graphql/QuoteCart.graphql
@@ -1,10 +1,10 @@
-query QuoteCart($id: ID!) {
+query QuoteCart($id: ID!, $locale: Locale!) {
   quoteCart(id: $id) {
     id
     bundle {
       possibleVariations {
         id
-        tag(locale: sv_SE)
+        tag(locale: $locale)
         bundle {
           bundleCost {
             monthlyGross {

--- a/src/client/graphql/QuoteCart.graphql
+++ b/src/client/graphql/QuoteCart.graphql
@@ -1,0 +1,96 @@
+query QuoteCart($id: ID!) {
+  quoteCart(id: $id) {
+    id
+    bundle {
+      possibleVariations {
+        id
+        tag(locale: sv_SE)
+        bundle {
+          bundleCost {
+            monthlyGross {
+              amount
+              currency
+            }
+          }
+        }
+      }
+      bundleCost {
+        monthlyGross {
+          amount
+          currency
+        }
+        monthlyNet {
+          amount
+          currency
+        }
+        monthlyDiscount {
+          amount
+          currency
+        }
+        freeUntil
+      }
+      quotes {
+        id
+        currentInsurer {
+          id
+          displayName
+          switchable
+        }
+        price {
+          amount
+          currency
+        }
+        firstName
+        lastName
+        ssn
+        birthDate
+        quoteDetails {
+          __typename
+          ... on SwedishApartmentQuoteDetails {
+            street
+            zipCode
+            householdSize
+            livingSpace
+            type
+          }
+          ... on SwedishHouseQuoteDetails {
+            street
+          }
+          ... on SwedishAccidentDetails {
+            street
+          }
+        }
+        startDate
+        expiresAt
+        email
+        dataCollectionId
+        typeOfContract
+        initiatedFrom
+      }
+    }
+    campaign {
+      incentive {
+        ... on MonthlyCostDeduction {
+          amount {
+            amount
+            currency
+          }
+        }
+        ... on PercentageDiscountMonths {
+          percentageDiscount
+          quantity
+        }
+      }
+      code
+      owner {
+        displayName
+        id
+      }
+      expiresAt
+    }
+    checkoutMethods
+    checkout {
+      status
+    }
+  }
+}

--- a/src/client/l10n/locales.ts
+++ b/src/client/l10n/locales.ts
@@ -1,4 +1,4 @@
-import { Locale as IsoLocale } from 'data/graphql'
+import { Locale as IsoLocale, Market as ApiMarket } from 'data/graphql'
 import {
   ssnLengths,
   ssnFormats,
@@ -20,6 +20,7 @@ export type LocaleData = {
   path: LocaleLabel
   isoLocale: IsoLocale
   marketLabel: MarketLabel
+  apiMarket: ApiMarket
   htmlLang: 'en' | 'sv' | 'no' | 'da'
   adtractionScriptSrc?: string
   ssn: {
@@ -41,6 +42,7 @@ export const locales: Record<LocaleLabel, LocaleData> = {
     path: 'se',
     isoLocale: IsoLocale.SvSe,
     marketLabel: 'SE',
+    apiMarket: ApiMarket.Sweden,
     htmlLang: 'sv',
     adtractionScriptSrc: 'https://cdn.adt387.com/jsTag?ap=1412531808',
     ssn: {
@@ -58,6 +60,7 @@ export const locales: Record<LocaleLabel, LocaleData> = {
     path: 'se-en',
     isoLocale: IsoLocale.EnSe,
     marketLabel: 'SE',
+    apiMarket: ApiMarket.Sweden,
     htmlLang: 'en',
     adtractionScriptSrc: 'https://cdn.adt387.com/jsTag?ap=1412531808',
     ssn: {
@@ -75,6 +78,7 @@ export const locales: Record<LocaleLabel, LocaleData> = {
     path: 'no',
     isoLocale: IsoLocale.NbNo,
     marketLabel: 'NO',
+    apiMarket: ApiMarket.Norway,
     htmlLang: 'no',
     adtractionScriptSrc: 'https://cdn.adt387.com/jsTag?ap=1492109567',
     ssn: {
@@ -92,6 +96,7 @@ export const locales: Record<LocaleLabel, LocaleData> = {
     path: 'no-en',
     isoLocale: IsoLocale.EnNo,
     marketLabel: 'NO',
+    apiMarket: ApiMarket.Norway,
     htmlLang: 'en',
     adtractionScriptSrc: 'https://cdn.adt387.com/jsTag?ap=1492109567',
     ssn: {
@@ -109,6 +114,7 @@ export const locales: Record<LocaleLabel, LocaleData> = {
     path: 'dk',
     isoLocale: IsoLocale.DaDk,
     marketLabel: 'DK',
+    apiMarket: ApiMarket.Denmark,
     htmlLang: 'da',
     adtractionScriptSrc: 'https://cdn.adt387.com/jsTag?ap=1589794294',
     ssn: {
@@ -126,6 +132,7 @@ export const locales: Record<LocaleLabel, LocaleData> = {
     path: 'dk-en',
     isoLocale: IsoLocale.EnDk,
     marketLabel: 'DK',
+    apiMarket: ApiMarket.Denmark,
     htmlLang: 'en',
     adtractionScriptSrc: 'https://cdn.adt387.com/jsTag?ap=1589794294',
     ssn: {

--- a/src/client/pages/OfferDebugger/Debugger.tsx
+++ b/src/client/pages/OfferDebugger/Debugger.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useEffect, useCallback } from 'react'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary'
 import { Button } from 'components/buttons'
 import { useCreateOnboardingSessionMutation } from 'data/graphql'
 import { useMarket } from 'components/utils/CurrentLocale'
@@ -18,6 +19,26 @@ const Row = styled.div`
   padding-bottom: 1rem;
 `
 
+const ErrorFallback: React.FC<FallbackProps> = ({
+  error,
+  resetErrorBoundary,
+}) => (
+  <div>
+    <h2>Something went wrong 😔</h2>
+    <div>
+      <p>Error message:</p>
+      <pre style={{ whiteSpace: 'pre-wrap' }}>{error}</pre>
+    </div>
+    <Button
+      background={colorsV3.red500}
+      foreground={colorsV3.gray100}
+      onClick={resetErrorBoundary}
+    >
+      👉 Try starting over by creating a new session!
+    </Button>
+  </div>
+)
+
 export const Debugger: React.FC = () => {
   const market = useMarket()
   const locale = useCurrentLocale().isoLocale
@@ -27,27 +48,39 @@ export const Debugger: React.FC = () => {
   ] = useCreateOnboardingSessionMutation()
   const sessionId = data?.onboardingSession_create
 
-  const handleClickNewSession = async () => {
+  const createNewSession = useCallback(async () => {
     await createOnboardingSession({ variables: { country: market, locale } })
-  }
+  }, [createOnboardingSession, market, locale])
+
+  useEffect(() => {
+    // create initial onboarding session
+    createNewSession()
+  }, [createNewSession])
 
   return (
     <Wrapper>
       <h1>Offer Page Debugger</h1>
 
       <Row>
-        <h3>Session</h3>
-        <Button background={colorsV3.purple900} onClick={handleClickNewSession}>
+        <h3>Session: {sessionId}</h3>
+        <Button
+          background={colorsV3.purple500}
+          foreground={colorsV3.gray900}
+          onClick={createNewSession}
+        >
           Create new session
         </Button>
-
-        {sessionId && <p>Active session: {sessionId}</p>}
       </Row>
 
       {sessionId && (
         <Row>
-          <h3>Offer</h3>
-          <QuoteData sessionId={sessionId} />
+          <ErrorBoundary
+            FallbackComponent={ErrorFallback}
+            onReset={createNewSession}
+          >
+            <h3>Offer</h3>
+            <QuoteData sessionId={sessionId} />
+          </ErrorBoundary>
         </Row>
       )}
     </Wrapper>

--- a/src/client/pages/OfferDebugger/Debugger.tsx
+++ b/src/client/pages/OfferDebugger/Debugger.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from '@emotion/styled'
-import { colorsV2, colorsV3 } from '@hedviginsurance/brand'
+import { colorsV3 } from '@hedviginsurance/brand'
 import { FetchResult } from '@apollo/client'
 import { Button } from 'components/buttons'
 import {
@@ -13,6 +13,7 @@ import { QuoteData } from './components/QuoteData'
 
 const Wrapper = styled.div`
   max-width: 900px;
+  padding: 1rem;
   margin: 0 auto;
   color: ${colorsV3.gray100};
 `
@@ -43,22 +44,17 @@ export const Debugger: React.FC = () => {
   const session = useOnboardingSession()
   const sessionId = session.result?.data?.onboardingSession_create
 
+  const handleClickNewSession = async () => {
+    await session.create()
+  }
+
   return (
     <Wrapper>
       <h1>Offer Page Debugger</h1>
 
       <Row>
-        <Button
-          onClick={() => localStorage.clear()}
-          background={colorsV2.coral500}
-        >
-          Nuke all state 💣
-        </Button>
-      </Row>
-
-      <Row>
         <h3>Session</h3>
-        <Button background={colorsV3.purple900} onClick={session.create}>
+        <Button background={colorsV3.purple900} onClick={handleClickNewSession}>
           Create new session
         </Button>
 

--- a/src/client/pages/OfferDebugger/Debugger.tsx
+++ b/src/client/pages/OfferDebugger/Debugger.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import styled from '@emotion/styled'
+import { colorsV2, colorsV3 } from '@hedviginsurance/brand'
+import { FetchResult } from '@apollo/client'
+import { Button } from 'components/buttons'
+import {
+  CreateOnboardingSessionMutation,
+  useCreateOnboardingSessionMutation,
+} from 'data/graphql'
+import { useMarket } from 'components/utils/CurrentLocale'
+import { useCurrentLocale } from 'l10n/useCurrentLocale'
+import { QuoteData } from './components/QuoteData'
+
+const Wrapper = styled.div`
+  max-width: 900px;
+  margin: 0 auto;
+  color: ${colorsV3.gray100};
+`
+
+const Row = styled.div`
+  padding-bottom: 1rem;
+`
+
+type SessionResult = FetchResult<CreateOnboardingSessionMutation>
+
+const useOnboardingSession = () => {
+  const market = useMarket()
+  const locale = useCurrentLocale().isoLocale
+  const [createOnboardingSession] = useCreateOnboardingSessionMutation()
+  const [result, setResult] = React.useState<SessionResult>()
+
+  const create = async () => {
+    const result = await createOnboardingSession({
+      variables: { country: market, locale },
+    })
+    setResult(result)
+  }
+
+  return { create, result }
+}
+
+export const Debugger: React.FC = () => {
+  const session = useOnboardingSession()
+  const sessionId = session.result?.data?.onboardingSession_create
+
+  return (
+    <Wrapper>
+      <h1>Offer Page Debugger</h1>
+
+      <Row>
+        <Button
+          onClick={() => localStorage.clear()}
+          background={colorsV2.coral500}
+        >
+          Nuke all state 💣
+        </Button>
+      </Row>
+
+      <Row>
+        <h3>Session</h3>
+        <Button background={colorsV3.purple900} onClick={session.create}>
+          Create new session
+        </Button>
+
+        {sessionId && <p>Active session: {sessionId}</p>}
+      </Row>
+
+      {sessionId && (
+        <Row>
+          <h3>Offer</h3>
+          <QuoteData sessionToken={sessionId} />
+        </Row>
+      )}
+    </Wrapper>
+  )
+}

--- a/src/client/pages/OfferDebugger/Debugger.tsx
+++ b/src/client/pages/OfferDebugger/Debugger.tsx
@@ -26,8 +26,8 @@ const ErrorFallback: React.FC<FallbackProps> = ({
   <div>
     <h2>Something went wrong 😔</h2>
     <div>
-      <p>Error message:</p>
-      <pre style={{ whiteSpace: 'pre-wrap' }}>{error}</pre>
+      <p>Error message: {error.message}</p>
+      <pre style={{ whiteSpace: 'pre-wrap' }}>{error.stack}</pre>
     </div>
     <Button
       background={colorsV3.red500}

--- a/src/client/pages/OfferDebugger/Debugger.tsx
+++ b/src/client/pages/OfferDebugger/Debugger.tsx
@@ -39,7 +39,7 @@ const ErrorFallback: React.FC<FallbackProps> = ({
 )
 
 export const Debugger: React.FC = () => {
-  const locale = useCurrentLocale()
+  const { apiMarket, isoLocale } = useCurrentLocale()
   const [
     createOnboardingQuoteCart,
     { data },
@@ -48,9 +48,9 @@ export const Debugger: React.FC = () => {
 
   const createNewQuoteCart = useCallback(async () => {
     await createOnboardingQuoteCart({
-      variables: { market: locale.apiMarket, locale: locale.isoLocale },
+      variables: { market: apiMarket, locale: isoLocale },
     })
-  }, [createOnboardingQuoteCart, locale.apiMarket, locale.isoLocale])
+  }, [createOnboardingQuoteCart, apiMarket, isoLocale])
 
   useEffect(() => {
     // create initial onboarding session
@@ -62,7 +62,7 @@ export const Debugger: React.FC = () => {
       <h1>Offer Page Debugger</h1>
 
       <Row>
-        <h3>Session: {quoteCartId}</h3>
+        <h3>Quote Cart: {quoteCartId}</h3>
         <Button
           background={colorsV3.purple500}
           foreground={colorsV3.gray900}

--- a/src/client/pages/OfferDebugger/Debugger.tsx
+++ b/src/client/pages/OfferDebugger/Debugger.tsx
@@ -1,12 +1,8 @@
 import React from 'react'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
-import { FetchResult } from '@apollo/client'
 import { Button } from 'components/buttons'
-import {
-  CreateOnboardingSessionMutation,
-  useCreateOnboardingSessionMutation,
-} from 'data/graphql'
+import { useCreateOnboardingSessionMutation } from 'data/graphql'
 import { useMarket } from 'components/utils/CurrentLocale'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 import { QuoteData } from './components/QuoteData'
@@ -22,30 +18,17 @@ const Row = styled.div`
   padding-bottom: 1rem;
 `
 
-type SessionResult = FetchResult<CreateOnboardingSessionMutation>
-
-const useOnboardingSession = () => {
+export const Debugger: React.FC = () => {
   const market = useMarket()
   const locale = useCurrentLocale().isoLocale
-  const [createOnboardingSession] = useCreateOnboardingSessionMutation()
-  const [result, setResult] = React.useState<SessionResult>()
-
-  const create = async () => {
-    const result = await createOnboardingSession({
-      variables: { country: market, locale },
-    })
-    setResult(result)
-  }
-
-  return { create, result }
-}
-
-export const Debugger: React.FC = () => {
-  const session = useOnboardingSession()
-  const sessionId = session.result?.data?.onboardingSession_create
+  const [
+    createOnboardingSession,
+    { data },
+  ] = useCreateOnboardingSessionMutation()
+  const sessionId = data?.onboardingSession_create
 
   const handleClickNewSession = async () => {
-    await session.create()
+    await createOnboardingSession({ variables: { country: market, locale } })
   }
 
   return (

--- a/src/client/pages/OfferDebugger/Debugger.tsx
+++ b/src/client/pages/OfferDebugger/Debugger.tsx
@@ -68,7 +68,7 @@ export const Debugger: React.FC = () => {
       {sessionId && (
         <Row>
           <h3>Offer</h3>
-          <QuoteData sessionToken={sessionId} />
+          <QuoteData sessionId={sessionId} />
         </Row>
       )}
     </Wrapper>

--- a/src/client/pages/OfferDebugger/Debugger.tsx
+++ b/src/client/pages/OfferDebugger/Debugger.tsx
@@ -3,8 +3,7 @@ import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary'
 import { Button } from 'components/buttons'
-import { useCreateOnboardingSessionMutation } from 'data/graphql'
-import { useMarket } from 'components/utils/CurrentLocale'
+import { useCreateOnboardingQuoteCartMutation } from 'data/graphql'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 import { QuoteData } from './components/QuoteData'
 
@@ -40,46 +39,47 @@ const ErrorFallback: React.FC<FallbackProps> = ({
 )
 
 export const Debugger: React.FC = () => {
-  const market = useMarket()
-  const locale = useCurrentLocale().isoLocale
+  const locale = useCurrentLocale()
   const [
     createOnboardingSession,
     { data },
-  ] = useCreateOnboardingSessionMutation()
-  const sessionId = data?.onboardingSession_create
+  ] = useCreateOnboardingQuoteCartMutation()
+  const quoteCartId = data?.onboardingQuoteCart_create
 
-  const createNewSession = useCallback(async () => {
-    await createOnboardingSession({ variables: { country: market, locale } })
-  }, [createOnboardingSession, market, locale])
+  const createNewQuoteCart = useCallback(async () => {
+    await createOnboardingSession({
+      variables: { market: locale.apiMarket, locale: locale.isoLocale },
+    })
+  }, [createOnboardingSession, locale.apiMarket, locale.isoLocale])
 
   useEffect(() => {
     // create initial onboarding session
-    createNewSession()
-  }, [createNewSession])
+    createNewQuoteCart()
+  }, [createNewQuoteCart])
 
   return (
     <Wrapper>
       <h1>Offer Page Debugger</h1>
 
       <Row>
-        <h3>Session: {sessionId}</h3>
+        <h3>Session: {quoteCartId}</h3>
         <Button
           background={colorsV3.purple500}
           foreground={colorsV3.gray900}
-          onClick={createNewSession}
+          onClick={createNewQuoteCart}
         >
           Create new session
         </Button>
       </Row>
 
-      {sessionId && (
+      {quoteCartId && (
         <Row>
           <ErrorBoundary
             FallbackComponent={ErrorFallback}
-            onReset={createNewSession}
+            onReset={createNewQuoteCart}
           >
             <h3>Offer</h3>
-            <QuoteData sessionId={sessionId} />
+            <QuoteData quoteCartId={quoteCartId} />
           </ErrorBoundary>
         </Row>
       )}

--- a/src/client/pages/OfferDebugger/Debugger.tsx
+++ b/src/client/pages/OfferDebugger/Debugger.tsx
@@ -41,16 +41,16 @@ const ErrorFallback: React.FC<FallbackProps> = ({
 export const Debugger: React.FC = () => {
   const locale = useCurrentLocale()
   const [
-    createOnboardingSession,
+    createOnboardingQuoteCart,
     { data },
   ] = useCreateOnboardingQuoteCartMutation()
   const quoteCartId = data?.onboardingQuoteCart_create
 
   const createNewQuoteCart = useCallback(async () => {
-    await createOnboardingSession({
+    await createOnboardingQuoteCart({
       variables: { market: locale.apiMarket, locale: locale.isoLocale },
     })
-  }, [createOnboardingSession, locale.apiMarket, locale.isoLocale])
+  }, [createOnboardingQuoteCart, locale.apiMarket, locale.isoLocale])
 
   useEffect(() => {
     // create initial onboarding session

--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -167,13 +167,13 @@ const ButtonLoadingIndicator = styled(LoadingDots)`
 `
 
 export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
-  const { data, refetch } = useQuoteCartQuery({
-    variables: { id: quoteCartId },
-  })
-  const [createQuoteBundle] = useCreateQuoteBundleMutation()
-
   const currentLocale = useCurrentLocale()
   const currentMarket = useMarket()
+
+  const { data, refetch } = useQuoteCartQuery({
+    variables: { id: quoteCartId, locale: currentLocale.isoLocale },
+  })
+  const [createQuoteBundle] = useCreateQuoteBundleMutation()
 
   const [quoteBundleType, setQuoteBundleType] = useState(
     quotesByMarket[currentMarket][0].value,
@@ -192,7 +192,7 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
         case QuoteBundleType.DanishHomeAccident:
           await createQuoteBundle({
             variables: {
-              id: quoteCartId,
+              quoteCartId,
               quotes: [
                 {
                   type: QuoteType.DanishHome,
@@ -210,7 +210,7 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
         case QuoteBundleType.DanishHomeAccidentTravel:
           await createQuoteBundle({
             variables: {
-              id: quoteCartId,
+              quoteCartId,
               quotes: [
                 {
                   type: QuoteType.DanishHome,
@@ -232,7 +232,7 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
         case QuoteBundleType.SwedishApartmentAccident:
           await createQuoteBundle({
             variables: {
-              id: quoteCartId,
+              quoteCartId,
               quotes: [
                 {
                   type: QuoteType.SwedishApartment,
@@ -250,7 +250,7 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
         default:
           await createQuoteBundle({
             variables: {
-              id: quoteCartId,
+              quoteCartId,
               quotes: [
                 {
                   type: singleQuoteBundleToQuoteType(quoteBundleType),

--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -57,6 +57,8 @@ const singleQuoteBundleToQuoteType = (
       return QuoteType.DanishHome
     case QuoteBundleType.NorwegianHome:
       return QuoteType.NorwegianHome
+    case QuoteBundleType.NorwegianTravel:
+      return QuoteType.NorwegianTravel
     case QuoteBundleType.SwedishApartment:
       return QuoteType.SwedishApartment
     case QuoteBundleType.SwedishHouse:

--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import styled from '@emotion/styled'
-import { Form, Formik, FormikProps } from 'formik'
+import { Form, Formik, FormikProps, ErrorMessage } from 'formik'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { CreateQuoteVariables } from '@hedviginsurance/embark'
 import {
@@ -111,7 +111,7 @@ const getCurrentAvailableQuoteData = (
 
 const getDanishQuoteValues = (
   values: Values,
-  quoteType: 'danishTravel' | 'danishAccident',
+  quoteType: 'danishTravelData' | 'danishAccidentData',
 ) => {
   const { danishHomeContentsData, ...filteredValues } = values
   const { type, livingSpace, ...quoteTypeValues } = danishHomeContentsData!
@@ -153,6 +153,7 @@ export const QuoteData: React.FC<OfferProps> = ({ sessionId }) => {
     quotesByMarket[currentMarket][0].value,
   )
 
+  const [submitError, setSubmitError] = useState<Error>()
   const handleSubmit = async (values: Values) => {
     const input = {
       ...values,
@@ -173,7 +174,7 @@ export const QuoteData: React.FC<OfferProps> = ({ sessionId }) => {
             createOnboardingQuote({
               variables: {
                 id: sessionId,
-                input: getDanishQuoteValues(input, 'danishAccident'),
+                input: getDanishQuoteValues(input, 'danishAccidentData'),
               },
             }),
           ])
@@ -190,13 +191,13 @@ export const QuoteData: React.FC<OfferProps> = ({ sessionId }) => {
             createOnboardingQuote({
               variables: {
                 id: sessionId,
-                input: getDanishQuoteValues(input, 'danishAccident'),
+                input: getDanishQuoteValues(input, 'danishAccidentData'),
               },
             }),
             createOnboardingQuote({
               variables: {
                 id: sessionId,
-                input: getDanishQuoteValues(input, 'danishTravel'),
+                input: getDanishQuoteValues(input, 'danishTravelData'),
               },
             }),
           ])
@@ -229,10 +230,13 @@ export const QuoteData: React.FC<OfferProps> = ({ sessionId }) => {
       }
 
       await refetch()
-    } catch (e) {
-      console.error(e)
-      throw e
+    } catch (error) {
+      setSubmitError(error)
     }
+  }
+
+  if (submitError) {
+    throw submitError
   }
 
   return (

--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -9,8 +9,8 @@ import {
 } from 'data/graphql'
 import { Button, LinkButton } from 'components/buttons'
 import { InputField } from 'components/inputs'
-import { useMarket, Market } from 'components/utils/CurrentLocale'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
+import { MarketLabel } from 'l10n/locales'
 import { LoadingDots } from '../../../components/LoadingDots/LoadingDots'
 import { initialSeApartmentValues, SwedishApartment } from './QuoteFormSweden'
 import {
@@ -74,7 +74,7 @@ type QuoteData = {
   initialFormValues?: Record<string, unknown>
 }
 
-type QuotesByMarket = Record<Market, QuoteData[]>
+type QuotesByMarket = Record<MarketLabel, QuoteData[]>
 
 const quotesByMarket: QuotesByMarket = {
   DK: [
@@ -125,7 +125,7 @@ const quotesByMarket: QuotesByMarket = {
 }
 
 const getCurrentAvailableQuoteData = (
-  currentMarket: Market,
+  currentMarket: MarketLabel,
   currentQuoteType: QuoteBundleType,
 ) => {
   const marketQuoteTypes = quotesByMarket[currentMarket]
@@ -167,16 +167,15 @@ const ButtonLoadingIndicator = styled(LoadingDots)`
 `
 
 export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
-  const currentLocale = useCurrentLocale()
-  const currentMarket = useMarket()
+  const { isoLocale, marketLabel, path: localePath } = useCurrentLocale()
 
   const { data, refetch } = useQuoteCartQuery({
-    variables: { id: quoteCartId, locale: currentLocale.isoLocale },
+    variables: { id: quoteCartId, locale: isoLocale },
   })
   const [createQuoteBundle] = useCreateQuoteBundleMutation()
 
   const [quoteBundleType, setQuoteBundleType] = useState(
-    quotesByMarket[currentMarket][0].value,
+    quotesByMarket[marketLabel][0].value,
   )
 
   const [submitError, setSubmitError] = useState<Error>()
@@ -282,7 +281,7 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
         {() => (
           <InputField
             label="Type"
-            options={quotesByMarket[currentMarket]}
+            options={quotesByMarket[marketLabel]}
             value={quoteBundleType}
             onChange={(value: React.ChangeEvent<HTMLSelectElement>) =>
               setQuoteBundleType(value.target.value as QuoteBundleType)
@@ -294,7 +293,7 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
       {!data?.quoteCart.bundle ? (
         <Formik
           initialValues={
-            getCurrentAvailableQuoteData(currentMarket, quoteBundleType)
+            getCurrentAvailableQuoteData(marketLabel, quoteBundleType)
               ?.initialFormValues || {}
           }
           onSubmit={handleSubmit}
@@ -318,7 +317,7 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
                     placeholder="2012-12-12"
                     {...props.getFieldProps('birthDate')}
                   />
-                  {currentMarket === Market.Se && (
+                  {marketLabel === 'SE' && (
                     <InputField
                       label="ssn"
                       placeholder=""
@@ -377,7 +376,7 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
             background={colorsV3.gray100}
             foreground={colorsV3.gray900}
             to={{
-              pathname: `/${currentLocale.path}/new-member/offer`,
+              pathname: `/${localePath}/new-member/offer`,
               search: `?quoteCart=${quoteCartId}`,
             }}
           >

--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -128,7 +128,7 @@ const getSwedishAccidentQuoteValues = (values: Values) => {
     ...filteredValues,
     swedishAccidentData: {
       ...quoteTypeValues,
-      isStudent:
+      student:
         subType === ApartmentType.StudentBrf ||
         subType === ApartmentType.StudentRent,
     },

--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -138,7 +138,7 @@ const getDanishQuoteValues = (
   quoteType: 'danishTravelData' | 'danishAccidentData',
 ) => {
   const { danishHomeContentsData, ...filteredValues } = values
-  const { type, livingSpace, ...quoteTypeValues } = danishHomeContentsData!
+  const { subType, livingSpace, ...quoteTypeValues } = danishHomeContentsData!
   return {
     ...filteredValues,
     [quoteType]: quoteTypeValues,

--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import styled from '@emotion/styled'
-import { Form, Formik, FormikProps, ErrorMessage } from 'formik'
+import { Form, Formik, FormikProps } from 'formik'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { CreateQuoteVariables } from '@hedviginsurance/embark'
 import {

--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -1,0 +1,438 @@
+import React, { useEffect, useState } from 'react'
+import styled from '@emotion/styled'
+import { Form, Formik, FormikProps } from 'formik'
+import { v4 as uuid } from 'uuid'
+import { colorsV3 } from '@hedviginsurance/brand'
+import { CreateQuoteVariables } from '@hedviginsurance/embark'
+import {
+  CreateQuoteInput,
+  useCreateDanishHomeAccidentQuoteMutation,
+  useCreateDanishHomeAccidentTravelQuoteMutation,
+  useCreateSwedishHomeAccidentQuoteMutation,
+  useQuoteBundleLazyQuery,
+  ApartmentType,
+} from 'data/graphql'
+import { createQuote } from 'pages/Embark/createQuote'
+import { Button, LinkButton } from 'components/buttons'
+import { InputField } from 'components/inputs'
+import { StorageContainer, useStorage } from 'utils/StorageContainer'
+import {
+  getIsoLocale,
+  useCurrentLocale,
+  useMarket,
+  Market,
+} from 'components/utils/CurrentLocale'
+import { LoadingDots } from '../../../components/LoadingDots/LoadingDots'
+import { initialSeApartmentValues, SwedishApartment } from './QuoteFormSweden'
+import {
+  initialNoHomeValues,
+  initialNoTravelValues,
+  NorwegianHome,
+  NorwegianTravel,
+} from './QuoteFormNorway'
+import { DanishQuote, initialDkHomeValues } from './QuoteFormDenmark'
+
+type OfferProps = { sessionToken?: string | null }
+
+type Values = Partial<CreateQuoteInput>
+
+export type WithFormikProps = {
+  formik: FormikProps<any>
+}
+
+enum QuoteType {
+  DanishHome = 'danish-home',
+  DanishHomeAccident = 'danish-home-accident',
+  DanishHomeAccidentTravel = 'danish-home-accident-travel',
+  NorwegianHome = 'norwegian-home',
+  NorwegianTravel = 'norwegian-travel',
+  SwedishApartment = 'swedish-apartment',
+  SwedishHouse = 'swedish-house',
+  SwedishApartmentAccident = 'swedish-apartment-accident',
+}
+
+type QuoteData = {
+  label: string
+  value: QuoteType
+  initialFormValues?: Record<string, unknown>
+}
+
+type QuotesByMarket = Record<Market, QuoteData[]>
+
+const quotesByMarket: QuotesByMarket = {
+  DK: [
+    {
+      label: 'Danish Home',
+      value: QuoteType.DanishHome,
+      initialFormValues: initialDkHomeValues,
+    },
+    {
+      label: 'Danish Home + Accident',
+      value: QuoteType.DanishHomeAccident,
+      initialFormValues: initialDkHomeValues,
+    },
+    {
+      label: 'Danish Home + Accident + Travel',
+      value: QuoteType.DanishHomeAccidentTravel,
+      initialFormValues: initialDkHomeValues,
+    },
+  ],
+  NO: [
+    {
+      label: 'Norwegian Home',
+      value: QuoteType.NorwegianHome,
+      initialFormValues: initialNoHomeValues,
+    },
+    {
+      label: 'Norwegian Travel',
+      value: QuoteType.NorwegianTravel,
+      initialFormValues: initialNoTravelValues,
+    },
+  ],
+  SE: [
+    {
+      label: 'Swedish Apartment',
+      value: QuoteType.SwedishApartment,
+      initialFormValues: initialSeApartmentValues,
+    },
+    {
+      label: 'Swedish House',
+      value: QuoteType.SwedishHouse,
+    },
+    {
+      label: 'Swedish Apartment + Accident',
+      value: QuoteType.SwedishApartmentAccident,
+      initialFormValues: initialSeApartmentValues,
+    },
+  ],
+}
+
+const getCurrentAvailableQuoteData = (
+  currentMarket: Market,
+  currentQuoteType: QuoteType,
+) => {
+  const marketQuoteTypes = quotesByMarket[currentMarket]
+  const currentQuoteTypeData = marketQuoteTypes.find(
+    ({ value }) => value === currentQuoteType,
+  )
+  return currentQuoteTypeData
+}
+
+const getDanishQuoteValues = (
+  values: Values,
+  quoteType: 'danishTravel' | 'danishAccident',
+) => {
+  const { danishHomeContents, ...filteredValues } = values
+  const { type, livingSpace, ...QuoteTypeValues } = danishHomeContents!
+  return {
+    ...filteredValues,
+    [quoteType]: QuoteTypeValues,
+  } as CreateQuoteInput
+}
+
+const getSwedishAccidentQuoteValues = (values: Values) => {
+  const { swedishApartment, ...filteredValues } = values
+  const { type, ...QuoteTypeValues } = swedishApartment!
+  return {
+    ...filteredValues,
+    swedishAccident: {
+      ...QuoteTypeValues,
+      isStudent:
+        type === ApartmentType.StudentBrf || type === ApartmentType.StudentRent,
+    },
+  } as CreateQuoteInput
+}
+
+const ButtonLoadingIndicator = styled(LoadingDots)`
+  display: inline-flex;
+  margin-left: 0.5rem;
+`
+
+export const QuoteData: React.FC<OfferProps> = ({ sessionToken }) => {
+  const [quoteIds, setQuoteIds] = useState<string[]>([])
+  const [getQuotes, { data, refetch }] = useQuoteBundleLazyQuery()
+  const [createHomeAccidentQuote] = useCreateDanishHomeAccidentQuoteMutation()
+  const [
+    createHomeAccidentTravelQuote,
+  ] = useCreateDanishHomeAccidentTravelQuoteMutation()
+  const [
+    createSwedishHomeAccidentQuote,
+  ] = useCreateSwedishHomeAccidentQuoteMutation()
+
+  const [quoteCreatingError, setQuoteCreatingError] = useState<string | null>(
+    null,
+  )
+  const storageState = useStorage()
+  const currentLocale = useCurrentLocale()
+  const localeIsoCode = getIsoLocale(currentLocale)
+  const currentMarket = useMarket()
+
+  const [quoteType, setQuoteType] = useState(
+    quotesByMarket[currentMarket][0].value,
+  )
+
+  const handleSubmit = async (
+    values: Values,
+    storage: Record<string, unknown>,
+  ) => {
+    const input = {
+      ...values,
+      id: quoteIds[0],
+      currentInsurer: values.currentInsurer || undefined,
+      startDate: values.startDate || undefined,
+    }
+    if (quoteType === QuoteType.DanishHomeAccident) {
+      const accidentInput = getDanishQuoteValues(
+        { ...input, id: quoteIds[1] },
+        'danishAccident',
+      )
+      await createHomeAccidentQuote({
+        variables: {
+          homeInput: input as CreateQuoteInput,
+          accidentInput,
+        },
+      })
+    } else if (quoteType === QuoteType.DanishHomeAccidentTravel) {
+      const accidentInput = getDanishQuoteValues(
+        { ...input, id: quoteIds[1] },
+        'danishAccident',
+      )
+      const travelInput = getDanishQuoteValues(
+        { ...input, id: quoteIds[2] },
+        'danishTravel',
+      )
+      await createHomeAccidentTravelQuote({
+        variables: {
+          homeInput: input as CreateQuoteInput,
+          accidentInput,
+          travelInput,
+        },
+      })
+    } else if (quoteType === QuoteType.SwedishApartmentAccident) {
+      const accidentInput = getSwedishAccidentQuoteValues({
+        ...input,
+        id: quoteIds[1],
+      })
+      await createSwedishHomeAccidentQuote({
+        variables: {
+          homeInput: input as CreateQuoteInput,
+          accidentInput,
+        },
+      })
+    } else {
+      await createQuote(
+        storage,
+        localeIsoCode,
+      )({
+        input: input as CreateQuoteVariables['input'],
+      }).catch((error) => setQuoteCreatingError(error.message))
+    }
+
+    if (refetch) {
+      await refetch()
+    }
+  }
+
+  useEffect(() => {
+    const sessionQuoteIds = storageState.session.getSession()?.quoteIds ?? []
+    if (quoteIds.length === 0 && sessionQuoteIds[0]) {
+      setQuoteIds([...sessionQuoteIds])
+      return
+    }
+    if (quoteIds.length === 0 && !sessionQuoteIds.length) {
+      setQuoteIds([uuid()])
+    }
+    storageState.session.setSession({
+      ...storageState.session.getSession(),
+      quoteIds: quoteIds,
+    })
+  }, [getQuotes, localeIsoCode, quoteIds, storageState.session])
+
+  useEffect(() => {
+    if (quoteIds.every((quote) => quote?.length === 36) && sessionToken) {
+      getQuotes({
+        variables: { input: { ids: quoteIds }, locale: localeIsoCode },
+      })
+    }
+  }, [quoteIds, sessionToken, localeIsoCode, getQuotes])
+
+  useEffect(() => {
+    if (quoteType === QuoteType.DanishHomeAccident) {
+      setQuoteIds((prev) => [prev[0], uuid()])
+      return
+    }
+    if (quoteType === QuoteType.DanishHomeAccidentTravel) {
+      setQuoteIds((prev) => [prev[0], uuid(), uuid()])
+      return
+    }
+    if (quoteType === QuoteType.SwedishApartmentAccident) {
+      setQuoteIds((prev) => [prev[0], uuid()])
+      return
+    }
+    setQuoteIds((prev) => [prev[0]])
+  }, [quoteType])
+
+  return (
+    <StorageContainer>
+      {(storage) => (
+        <>
+          <Formik
+            initialValues={{}}
+            onSubmit={() => {
+              /* noop */
+            }}
+          >
+            {() => (
+              <InputField
+                label="Type"
+                options={quotesByMarket[currentMarket]}
+                value={quoteType}
+                onChange={(value: React.ChangeEvent<HTMLSelectElement>) =>
+                  setQuoteType(value.target.value as QuoteType)
+                }
+              />
+            )}
+          </Formik>
+          <Formik
+            initialValues={{ quoteIds }}
+            onSubmit={() => {
+              /* noop */
+            }}
+          >
+            {() => {
+              return quoteIds.map((quoteId, index) => (
+                <InputField
+                  key={`quote_ids_${index}`}
+                  label="Quote id"
+                  name="Quote id"
+                  placeholder="d6c60432-dc7b-4405-840e-b4fd8164e310"
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    const newValue = e.target.value
+                    setQuoteIds((prev) => {
+                      const newState = [...prev]
+                      newState[index] = newValue
+                      return newState
+                    })
+                  }}
+                  value={quoteId}
+                />
+              ))
+            }}
+          </Formik>
+
+          {!data?.quoteBundle && !quoteCreatingError && (
+            <>
+              <Formik
+                initialValues={
+                  getCurrentAvailableQuoteData(currentMarket, quoteType)
+                    ?.initialFormValues || {}
+                }
+                onSubmit={(values) => handleSubmit(values, storage)}
+              >
+                {(props) => (
+                  <>
+                    <Form>
+                      {!props.isSubmitting && (
+                        <>
+                          <InputField
+                            label="First name"
+                            placeholder=""
+                            {...props.getFieldProps('firstName')}
+                          />
+                          <InputField
+                            label="Last name"
+                            placeholder=""
+                            {...props.getFieldProps('lastName')}
+                          />
+                          <InputField
+                            label="Birth date"
+                            placeholder="2012-12-12"
+                            {...props.getFieldProps('birthDate')}
+                          />
+                          {currentMarket === Market.Se && (
+                            <InputField
+                              label="ssn"
+                              placeholder=""
+                              {...props.getFieldProps('ssn')}
+                            />
+                          )}
+                          <InputField
+                            label="Start Date (optional)"
+                            placeholder="2020-03-13"
+                            {...props.getFieldProps('startDate')}
+                          />
+                          <InputField
+                            label="Email"
+                            placeholder=""
+                            {...props.getFieldProps('email')}
+                          />
+
+                          {[
+                            QuoteType.SwedishApartment,
+                            QuoteType.SwedishApartmentAccident,
+                          ].includes(quoteType) && (
+                            <SwedishApartment formik={props} />
+                          )}
+                          {quoteType === QuoteType.NorwegianHome && (
+                            <NorwegianHome formik={props} />
+                          )}
+                          {quoteType === QuoteType.NorwegianTravel && (
+                            <NorwegianTravel formik={props} />
+                          )}
+                          {(quoteType === QuoteType.DanishHome ||
+                            quoteType === QuoteType.DanishHomeAccident ||
+                            quoteType ===
+                              QuoteType.DanishHomeAccidentTravel) && (
+                            <DanishQuote formik={props} />
+                          )}
+                        </>
+                      )}
+
+                      <Button
+                        type="submit"
+                        background={colorsV3.purple500}
+                        foreground={colorsV3.gray900}
+                        disabled={props.isSubmitting}
+                      >
+                        Create quote
+                        {props.isSubmitting && (
+                          <ButtonLoadingIndicator color={colorsV3.gray900} />
+                        )}
+                      </Button>
+                    </Form>
+                  </>
+                )}
+              </Formik>
+            </>
+          )}
+          {data?.quoteBundle && (
+            <>
+              <LinkButton
+                background={colorsV3.gray100}
+                foreground={colorsV3.gray900}
+                to={`/${currentLocale}/new-member/offer`}
+              >
+                Go to offer page →
+              </LinkButton>
+              <div style={{ padding: '2rem 0' }}>
+                <pre>{JSON.stringify(data, null, 2)}</pre>
+              </div>
+            </>
+          )}
+          {quoteCreatingError && (
+            <>
+              <h2>Something went wrong 😔</h2>
+              <div>
+                <u>Error message:</u>
+                <pre style={{ whiteSpace: 'pre-wrap' }}>
+                  {quoteCreatingError}
+                </pre>
+              </div>
+              <h3>👉 Try starting over by nuking all state!</h3>
+            </>
+          )}
+        </>
+      )}
+    </StorageContainer>
+  )
+}

--- a/src/client/pages/OfferDebugger/components/QuoteFormDenmark.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteFormDenmark.tsx
@@ -17,8 +17,8 @@ export const initialDkHomeValues = {
     floor: '2',
     apartment: 'tv',
     zipCode: '2100',
-    type: DanishHomeContentsType.Own,
-    isStudent: false,
+    subType: DanishHomeContentsType.Own,
+    student: false,
   },
 }
 
@@ -63,11 +63,11 @@ export const DanishQuote: React.FC<WithFormikProps> = ({ formik }) => {
           { label: 'Own', value: DanishHomeContentsType['Own'] },
           { label: 'Rent', value: DanishHomeContentsType['Rent'] },
         ]}
-        {...formik.getFieldProps('danishHomeContents.type')}
+        {...formik.getFieldProps('danishHomeContents.subType')}
       />
       <div style={{ paddingBottom: '2rem', fontSize: '1.25rem' }}>
         <label>
-          <Field type="checkbox" name="danishHomeContents.isStudent" />
+          <Field type="checkbox" name="danishHomeContents.student" />
           {"I'm a student"}
         </label>
       </div>

--- a/src/client/pages/OfferDebugger/components/QuoteFormDenmark.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteFormDenmark.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { Field } from 'formik'
+import { DanishHomeContentsType } from 'data/graphql'
+import { InputField } from 'components/inputs'
+import { WithFormikProps } from './QuoteData'
+
+export const initialDkHomeValues = {
+  firstName: 'Helle',
+  lastName: 'Hansen',
+  birthDate: '1988-08-08',
+  startDate: '',
+  email: 'helle.hansen@hedvig.com',
+  danishHomeContents: {
+    coInsured: 0,
+    livingSpace: 34,
+    street: 'Theodore Roosevelts Vej 1',
+    floor: '2',
+    apartment: 'tv',
+    zipCode: '2100',
+    type: DanishHomeContentsType.Own,
+    isStudent: false,
+  },
+}
+
+export const DanishQuote: React.FC<WithFormikProps> = ({ formik }) => {
+  return (
+    <>
+      <InputField
+        label="Co-insured"
+        placeholder="1"
+        type="number"
+        {...formik.getFieldProps('danishHomeContents.coInsured')}
+      />
+      <InputField
+        label="Living space"
+        placeholder="34"
+        type="number"
+        {...formik.getFieldProps('danishHomeContents.livingSpace')}
+      />
+      <InputField
+        label="Street"
+        placeholder="Theodore Roosevelts Vej 1"
+        {...formik.getFieldProps('danishHomeContents.street')}
+      />
+      <InputField
+        label="Floor"
+        placeholder="2"
+        {...formik.getFieldProps('danishHomeContents.floor')}
+      />
+      <InputField
+        label="Apartment"
+        placeholder="tv"
+        {...formik.getFieldProps('danishHomeContents.apartment')}
+      />
+      <InputField
+        label="Zip code"
+        placeholder="2100"
+        {...formik.getFieldProps('danishHomeContents.zipCode')}
+      />
+      <InputField
+        label="Type"
+        options={[
+          { label: 'Own', value: DanishHomeContentsType['Own'] },
+          { label: 'Rent', value: DanishHomeContentsType['Rent'] },
+        ]}
+        {...formik.getFieldProps('danishHomeContents.type')}
+      />
+      <div style={{ paddingBottom: '2rem', fontSize: '1.25rem' }}>
+        <label>
+          <Field type="checkbox" name="danishHomeContents.isStudent" />
+          {"I'm a student"}
+        </label>
+      </div>
+    </>
+  )
+}

--- a/src/client/pages/OfferDebugger/components/QuoteFormDenmark.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteFormDenmark.tsx
@@ -10,7 +10,7 @@ export const initialDkHomeValues = {
   birthDate: '1988-08-08',
   startDate: '',
   email: 'helle.hansen@hedvig.com',
-  danishHomeContents: {
+  danishHomeContentsData: {
     coInsured: 0,
     livingSpace: 34,
     street: 'Theodore Roosevelts Vej 1',

--- a/src/client/pages/OfferDebugger/components/QuoteFormNorway.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteFormNorway.tsx
@@ -14,7 +14,7 @@ const initialBaseValues = {
 
 export const initialNoHomeValues = {
   ...initialBaseValues,
-  norwegianHomeContents: {
+  norwegianHomeContentsData: {
     isYouth: false,
     coInsured: 0,
     livingSpace: 44,
@@ -26,7 +26,7 @@ export const initialNoHomeValues = {
 
 export const initialNoTravelValues = {
   ...initialBaseValues,
-  norwegianTravel: {
+  norwegianTravelData: {
     coInsured: 0,
     isYouth: false,
   },

--- a/src/client/pages/OfferDebugger/components/QuoteFormNorway.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteFormNorway.tsx
@@ -15,12 +15,12 @@ const initialBaseValues = {
 export const initialNoHomeValues = {
   ...initialBaseValues,
   norwegianHomeContentsData: {
-    isYouth: false,
+    youth: false,
     coInsured: 0,
     livingSpace: 44,
     street: 'Gulebøjsveien 1',
     zipCode: '1234',
-    type: NorwegianHomeContentsType.Rent,
+    subType: NorwegianHomeContentsType.Rent,
   },
 }
 
@@ -28,7 +28,7 @@ export const initialNoTravelValues = {
   ...initialBaseValues,
   norwegianTravelData: {
     coInsured: 0,
-    isYouth: false,
+    youth: false,
   },
 }
 
@@ -74,17 +74,12 @@ export const NorwegianHome: React.FC<WithFormikProps> = ({ formik }) => {
           { label: 'Own', value: 'OWN' },
           { label: 'Rent', value: 'RENT' },
         ]}
-        {...formik.getFieldProps('norwegianHomeContents.type')}
+        {...formik.getFieldProps('norwegianHomeContents.subType')}
       />
     </>
   )
 }
 
 export const NorwegianTravel: React.FC<WithFormikProps> = ({ formik }) => {
-  return (
-    <>
-      <NorwegianCommon formik={formik} />
-      <div>isYouth TODO</div>
-    </>
-  )
+  return <NorwegianCommon formik={formik} />
 }

--- a/src/client/pages/OfferDebugger/components/QuoteFormNorway.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteFormNorway.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import { NorwegianHomeContentsType } from 'data/graphql'
+import { InputField } from 'components/inputs'
+import { WithFormikProps } from './QuoteData'
+
+const initialBaseValues = {
+  firstName: 'Ole',
+  lastName: 'Olsen',
+  currentInsurer: '',
+  birthDate: '1959-11-23',
+  startDate: '',
+  email: 'ole.olsen@hedvig.com',
+}
+
+export const initialNoHomeValues = {
+  ...initialBaseValues,
+  norwegianHomeContents: {
+    isYouth: false,
+    coInsured: 0,
+    livingSpace: 44,
+    street: 'Gulebøjsveien 1',
+    zipCode: '1234',
+    type: NorwegianHomeContentsType.Rent,
+  },
+}
+
+export const initialNoTravelValues = {
+  ...initialBaseValues,
+  norwegianTravel: {
+    coInsured: 0,
+    isYouth: false,
+  },
+}
+
+const NorwegianCommon: React.FC<WithFormikProps> = ({ formik }) => (
+  <>
+    <InputField
+      label="Co-insured"
+      placeholder="1"
+      type="number"
+      {...formik.getFieldProps('norwegianTravel.coInsured')}
+    />
+    <InputField
+      label="Current Insurer (optional)"
+      placeholder=""
+      {...formik.getFieldProps('currentInsurer')}
+    />
+  </>
+)
+
+export const NorwegianHome: React.FC<WithFormikProps> = ({ formik }) => {
+  return (
+    <>
+      <NorwegianCommon formik={formik} />
+      <InputField
+        label="Living space"
+        placeholder="23"
+        type="number"
+        {...formik.getFieldProps('norwegianHomeContents.livingSpace')}
+      />
+      <InputField
+        label="Street"
+        placeholder="Gulebøjsveien 1"
+        {...formik.getFieldProps('norwegianHomeContents.street')}
+      />
+      <InputField
+        label="Zip code"
+        placeholder="1234"
+        {...formik.getFieldProps('norwegianHomeContents.zipCode')}
+      />
+      <InputField
+        label="Type"
+        options={[
+          { label: 'Own', value: 'OWN' },
+          { label: 'Rent', value: 'RENT' },
+        ]}
+        {...formik.getFieldProps('norwegianHomeContents.type')}
+      />
+    </>
+  )
+}
+
+export const NorwegianTravel: React.FC<WithFormikProps> = ({ formik }) => {
+  return (
+    <>
+      <NorwegianCommon formik={formik} />
+      <div>isYouth TODO</div>
+    </>
+  )
+}

--- a/src/client/pages/OfferDebugger/components/QuoteFormSweden.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteFormSweden.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { ApartmentType } from 'data/graphql'
+import { InputField } from 'components/inputs'
+import { WithFormikProps } from './QuoteData'
+
+export const initialSeApartmentValues = {
+  firstName: 'Sven',
+  lastName: 'Svensson',
+  currentInsurer: '',
+  birthDate: '1995-09-29',
+  ssn: '199509291234',
+  startDate: '',
+  email: 'sven.svensson@hedvig.com',
+  swedishApartment: {
+    street: 'Storgatan 1',
+    zipCode: '12345',
+    livingSpace: 23,
+    householdSize: 1,
+    type: ApartmentType.Rent,
+  },
+}
+
+export const SwedishApartment: React.FC<WithFormikProps> = ({ formik }) => {
+  return (
+    <>
+      <InputField
+        label="Household size"
+        placeholder="1"
+        type="number"
+        {...formik.getFieldProps('swedishApartment.householdSize')}
+      />
+      <InputField
+        label="Living space"
+        placeholder="23"
+        type="number"
+        {...formik.getFieldProps('swedishApartment.livingSpace')}
+      />
+      <InputField
+        label="Street"
+        placeholder="Gulebøjsveien 1"
+        {...formik.getFieldProps('swedishApartment.street')}
+      />
+      <InputField
+        label="Zip code"
+        placeholder="12345"
+        {...formik.getFieldProps('swedishApartment.zipCode')}
+      />
+      <InputField
+        label="Type"
+        options={[
+          { label: 'Brf', value: ApartmentType.Brf },
+          { label: 'Rent', value: ApartmentType.Rent },
+          { label: 'Brf (student)', value: ApartmentType.StudentBrf },
+          { label: 'Rent (student)', value: ApartmentType.StudentRent },
+        ]}
+        {...formik.getFieldProps('swedishApartment.type')}
+      />
+      <InputField
+        label="Current Insurer (optional)"
+        placeholder=""
+        {...formik.getFieldProps('currentInsurer')}
+      />
+    </>
+  )
+}

--- a/src/client/pages/OfferDebugger/components/QuoteFormSweden.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteFormSweden.tsx
@@ -11,12 +11,12 @@ export const initialSeApartmentValues = {
   ssn: '199509291234',
   startDate: '',
   email: 'sven.svensson@hedvig.com',
-  swedishApartment: {
+  swedishApartmentData: {
     street: 'Storgatan 1',
     zipCode: '12345',
     livingSpace: 23,
     householdSize: 1,
-    type: ApartmentType.Rent,
+    subType: ApartmentType.Rent,
   },
 }
 
@@ -27,23 +27,23 @@ export const SwedishApartment: React.FC<WithFormikProps> = ({ formik }) => {
         label="Household size"
         placeholder="1"
         type="number"
-        {...formik.getFieldProps('swedishApartment.householdSize')}
+        {...formik.getFieldProps('swedishApartmentData.householdSize')}
       />
       <InputField
         label="Living space"
         placeholder="23"
         type="number"
-        {...formik.getFieldProps('swedishApartment.livingSpace')}
+        {...formik.getFieldProps('swedishApartmentData.livingSpace')}
       />
       <InputField
         label="Street"
         placeholder="Gulebøjsveien 1"
-        {...formik.getFieldProps('swedishApartment.street')}
+        {...formik.getFieldProps('swedishApartmentData.street')}
       />
       <InputField
         label="Zip code"
         placeholder="12345"
-        {...formik.getFieldProps('swedishApartment.zipCode')}
+        {...formik.getFieldProps('swedishApartmentData.zipCode')}
       />
       <InputField
         label="Type"
@@ -53,7 +53,7 @@ export const SwedishApartment: React.FC<WithFormikProps> = ({ formik }) => {
           { label: 'Brf (student)', value: ApartmentType.StudentBrf },
           { label: 'Rent (student)', value: ApartmentType.StudentRent },
         ]}
-        {...formik.getFieldProps('swedishApartment.type')}
+        {...formik.getFieldProps('swedishApartmentData.subType')}
       />
       <InputField
         label="Current Insurer (optional)"

--- a/src/client/pages/OfferDebugger/index.tsx
+++ b/src/client/pages/OfferDebugger/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
+import { Redirect } from 'react-router'
 import { LoadingDots } from 'components/LoadingDots/LoadingDots'
+import { useCurrentLocale } from 'l10n/useCurrentLocale'
 
 const ActualDebugger = React.lazy(async () => {
   const module = await import(
@@ -9,8 +11,9 @@ const ActualDebugger = React.lazy(async () => {
 })
 
 export const OfferDebugger: React.FC = () => {
+  const { path: localePath } = useCurrentLocale()
   if (window.hedvigClientConfig.appEnvironment === 'production') {
-    return null
+    return <Redirect to={`/${localePath}/new-member`} />
   }
 
   return (

--- a/src/client/pages/OfferDebugger/index.tsx
+++ b/src/client/pages/OfferDebugger/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { LoadingDots } from 'components/LoadingDots/LoadingDots'
+
+const ActualDebugger = React.lazy(async () => {
+  const module = await import(
+    /* webpackChunkName: "offer-debugger" */ './Debugger'
+  )
+  return { default: module.Debugger }
+})
+
+export const OfferDebugger: React.FC = () => {
+  if (window.hedvigClientConfig.appEnvironment === 'production') {
+    return null
+  }
+
+  return (
+    <React.Suspense fallback={<LoadingDots />}>
+      <ActualDebugger />
+    </React.Suspense>
+  )
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -7,6 +7,7 @@ import { TrustlyFailPage } from './client/pages/ConnectPayment/components/Trustl
 import { TrustlySpinnerPage } from './client/pages/ConnectPayment/components/TrustlySpinnerPage'
 import { ConnectPaymentsDirectEntry } from './client/pages/ConnectPayment/ConnectPaymentsDirectEntry'
 import { Debugger } from './client/pages/Debugger'
+import { OfferDebugger } from './client/pages/OfferDebugger'
 import { Download } from './client/pages/Download'
 import { EmbarkRoot } from './client/pages/Embark'
 import { Forever } from './client/pages/Forever'
@@ -161,6 +162,11 @@ export const reactPageRoutes: ReactPageRoute[] = [
   {
     path: localePathPattern + '/new-member/debugger',
     Component: Debugger,
+    exact: true,
+  },
+  {
+    path: localePathPattern + '/new-member/offer-debugger',
+    Component: OfferDebugger,
     exact: true,
   },
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14193,6 +14193,13 @@ react-error-boundary@^3.1.0:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+react-error-boundary@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-overlay@^6.0.9:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"


### PR DESCRIPTION
## What?

Co-authored with @dendoesit.

Implement a new Offer Page Debugger that uses the new QuoteCart API: `/se-en/new-member/offer-debugger`.

The goal is _not_ to improve the debugger but the setup is simplified quite a bit:
- Create quote bundles rather than multiple quotes per request
- Skip session handling (we worry about that only in the real app, if we need to)
- Implement `ErrorBoundary` to deal with errors in a React-y way (I can revert this if no one likes it 😜)
- Skip UUID generation of quote IDs since API can return them for us 🎉 

> Currently, the debugger passes the quote cart ID to the offer page as a query parameter. That will work okay for now but we might need to go back and revise this. Let's see.

## Why?

The new debugger is implemented as a copy of the old one. This will make it easy to remove the old one when we are ready to do so. It also makes it easy to skip complicated stuff like dealing with auth tokens and sessions that we don't need to do with the new API.

A new dependency is added `react-error-boundary` to handle errors in a more React-y way. There seems to be some conflict with Sentry that catches errors without letting them bubble up normally. Does anyone know how that works? @styrelius @gustaveen?

**Referenced ticket(s): [GRW-583]**

## Screenshots / recordings

![Screenshot 2021-11-15 at 10 18 35](https://user-images.githubusercontent.com/1220232/141755175-5bf7df03-5fe4-48fe-91fd-56e325e8470a.png)

## Review app

Test it live: https://web-onboardi-grw-583-fe-hbvsqd.herokuapp.com/se-en/new-member/offer-debugger

[GRW-583]: https://hedvig.atlassian.net/browse/GRW-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ