### PR TITLE
Refactor peril modal animation

### DIFF
--- a/src/client/components/ModalNew.tsx
+++ b/src/client/components/ModalNew.tsx
@@ -130,7 +130,8 @@ export const Modal: React.FC<ModalProps> = ({
         variants={{
           visible: {
             opacity: 1,
-            transform: 'translateX(-50%) translateY(-50%) scale(1)',
+            x: '-50%',
+            y: '-50%',
             transition: {
               type: 'spring',
               stiffness: 500,
@@ -140,7 +141,8 @@ export const Modal: React.FC<ModalProps> = ({
           },
           hidden: {
             opacity: 0,
-            transform: 'translateX(-50%) translateY(50%) scale(0.9)',
+            x: '-50%',
+            y: '50%',
           },
         }}
       >


### PR DESCRIPTION
## What?

Use properties that are GPU accelerated.
Remove scale animation.

## Why?

Animation performs very sluggishly in Safari. This is because it uses CPU acceleration instead of GPU acceleration. I've changes properties to only use those that should be GPU accelerated. However, GPU still doesn't kick in -- unclear why.

Still I think this setup is easier to read/understand.
I also think the scale animation was a bit unnecessary since we already have poor performance.

## Screenshots / recordings 

https://user-images.githubusercontent.com/1220232/142436918-4568aada-87c8-4a24-ae0d-cef1a0a92ff4.mov