### PR TITLE
GRW-598 / Fix / Update Giraffe API in Offer Debugger

### DIFF
--- a/src/client/data/graphql.tsx
+++ b/src/client/data/graphql.tsx
@@ -2607,11 +2607,13 @@ export type CreateOnboardingQuoteCartInput = {
 export type CreateQuoteBundleError = Error & {
   __typename?: 'CreateQuoteBundleError'
   message: Scalars['String']
+  /**  The type of the quote that could not be created.  */
+  type: Scalars['String']
   limits: Array<UnderwritingLimit>
 }
 
 export type CreateQuoteBundleInput = {
-  quoteData: Array<QuoteData>
+  payload: Array<Scalars['JSON']>
 }
 
 export type CreateQuoteBundleResult = QuoteCart | CreateQuoteBundleError
@@ -8526,11 +8528,6 @@ export type QuoteCart = {
   checkoutMethods: Array<CheckoutMethod>
 }
 
-export type QuoteData = {
-  type: Scalars['String']
-  payload: Scalars['JSON']
-}
-
 export type QuoteDetails =
   | SwedishApartmentQuoteDetails
   | SwedishHouseQuoteDetails
@@ -11431,7 +11428,7 @@ export type CreateOnboardingQuoteCartMutation = {
 
 export type CreateQuoteBundleMutationVariables = Exact<{
   quoteCartId: Scalars['ID']
-  quotes: Array<QuoteData> | QuoteData
+  quotes: Array<Scalars['JSON']> | Scalars['JSON']
 }>
 
 export type CreateQuoteBundleMutation = { __typename?: 'Mutation' } & {
@@ -12714,11 +12711,8 @@ export type CreateOnboardingQuoteCartMutationOptions = ApolloReactCommon.BaseMut
   CreateOnboardingQuoteCartMutationVariables
 >
 export const CreateQuoteBundleDocument = gql`
-  mutation CreateQuoteBundle($quoteCartId: ID!, $quotes: [QuoteData!]!) {
-    quoteCart_createQuoteBundle(
-      id: $quoteCartId
-      input: { quoteData: $quotes }
-    ) {
+  mutation CreateQuoteBundle($quoteCartId: ID!, $quotes: [JSON!]!) {
+    quoteCart_createQuoteBundle(id: $quoteCartId, input: { payload: $quotes }) {
       ... on QuoteCart {
         id
         bundle {

--- a/src/client/graphql/CreateQuoteBundle.graphql
+++ b/src/client/graphql/CreateQuoteBundle.graphql
@@ -1,5 +1,5 @@
-mutation CreateQuoteBundle($quoteCartId: ID!, $quotes: [QuoteData!]!) {
-  quoteCart_createQuoteBundle(id: $quoteCartId, input: { quoteData: $quotes }) {
+mutation CreateQuoteBundle($quoteCartId: ID!, $quotes: [JSON!]!) {
+  quoteCart_createQuoteBundle(id: $quoteCartId, input: { payload: $quotes }) {
     ... on QuoteCart {
       id
       bundle {

--- a/src/client/pages/OfferDebugger/Debugger.tsx
+++ b/src/client/pages/OfferDebugger/Debugger.tsx
@@ -64,11 +64,11 @@ export const Debugger: React.FC = () => {
       <Row>
         <h3>Quote Cart: {quoteCartId}</h3>
         <Button
-          background={colorsV3.purple500}
+          background={colorsV3.gray100}
           foreground={colorsV3.gray900}
           onClick={createNewQuoteCart}
         >
-          Create new session
+          Create new cart
         </Button>
       </Row>
 

--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -132,7 +132,19 @@ const getCurrentAvailableQuoteData = (
   const currentQuoteTypeData = marketQuoteTypes.find(
     ({ value }) => value === currentQuoteType,
   )
-  return currentQuoteTypeData
+
+  const randomId = Math.random()
+    .toString(36)
+    .substr(2, 5)
+  const email = `sven.svensson.${randomId}@hedvig.com`
+
+  return {
+    ...currentQuoteTypeData,
+    initialFormValues: {
+      ...currentQuoteTypeData?.initialFormValues,
+      email,
+    },
+  }
 }
 
 const getDanishQuoteValues = (values: any) => {
@@ -151,6 +163,7 @@ const getSwedishAccidentQuoteValues = (values: any) => {
     ...filteredValues,
     data: {
       ...quoteTypeValues,
+      type: QuoteType.SwedishAccident,
       student:
         subType === ApartmentType.StudentBrf ||
         subType === ApartmentType.StudentRent,
@@ -196,13 +209,7 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
                   type: QuoteType.SwedishApartment,
                 },
               },
-              {
-                ...input,
-                data: {
-                  ...getSwedishAccidentQuoteValues(input),
-                  type: QuoteType.SwedishAccident,
-                },
-              },
+              getSwedishAccidentQuoteValues(input),
             ],
           },
         })
@@ -374,6 +381,7 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
 
               <Button
                 type="submit"
+                size="lg"
                 background={colorsV3.purple500}
                 foreground={colorsV3.gray900}
                 disabled={props.isSubmitting}

--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from '@emotion/styled'
 import { Form, Formik, FormikProps } from 'formik'
 import { colorsV3 } from '@hedviginsurance/brand'
@@ -39,10 +39,10 @@ enum QuoteBundleType {
 }
 
 enum QuoteType {
-  DanishHome = 'danishHomeContent',
+  DanishHome = 'danishHomeContents',
   DanishAccident = 'danishAccident',
   DanishTravel = 'danishTravel',
-  NorwegianHome = 'norwegianHomeContent',
+  NorwegianHome = 'norwegianHomeContents',
   NorwegianTravel = 'norwegianTravel',
   SwedishApartment = 'apartment',
   SwedishHouse = 'house',
@@ -147,13 +147,9 @@ const getCurrentAvailableQuoteData = (
   }
 }
 
-const getDanishQuoteValues = (values: any) => {
-  const { data: danishHomeContent, ...filteredValues } = values
-  const { subType, livingSpace, ...quoteTypeValues } = danishHomeContent
-  return {
-    ...filteredValues,
-    data: quoteTypeValues,
-  }
+const getDanishQuoteDetailValues = (values: any) => {
+  const { subType, livingSpace, ...quoteTypeValues } = values.data
+  return quoteTypeValues
 }
 
 const getSwedishAccidentQuoteValues = (values: any) => {
@@ -228,7 +224,7 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
               {
                 ...input,
                 data: {
-                  ...getDanishQuoteValues(input),
+                  ...getDanishQuoteDetailValues(input),
                   type: QuoteType.DanishAccident,
                 },
               },
@@ -236,7 +232,7 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
           },
         })
       } else if (quoteBundleType === QuoteBundleType.DanishHomeAccidentTravel) {
-        const danishQuoteValues = getDanishQuoteValues(input)
+        const danishQuoteDetailValues = getDanishQuoteDetailValues(input)
 
         await createQuoteBundle({
           variables: {
@@ -252,14 +248,14 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
               {
                 ...input,
                 data: {
-                  ...danishQuoteValues,
+                  ...danishQuoteDetailValues,
                   type: QuoteType.DanishAccident,
                 },
               },
               {
                 ...input,
                 data: {
-                  ...danishQuoteValues,
+                  ...danishQuoteDetailValues,
                   type: QuoteType.DanishTravel,
                 },
               },

--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import styled from '@emotion/styled'
 import { Form, Formik, FormikProps } from 'formik'
 import { colorsV3 } from '@hedviginsurance/brand'

--- a/src/client/pages/OfferDebugger/components/QuoteFormDenmark.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteFormDenmark.tsx
@@ -10,7 +10,7 @@ export const initialDkHomeValues = {
   birthDate: '1988-08-08',
   startDate: '',
   email: 'helle.hansen@hedvig.com',
-  danishHomeContentsData: {
+  data: {
     coInsured: 0,
     livingSpace: 34,
     street: 'Theodore Roosevelts Vej 1',
@@ -29,33 +29,33 @@ export const DanishQuote: React.FC<WithFormikProps> = ({ formik }) => {
         label="Co-insured"
         placeholder="1"
         type="number"
-        {...formik.getFieldProps('danishHomeContents.coInsured')}
+        {...formik.getFieldProps('data.coInsured')}
       />
       <InputField
         label="Living space"
         placeholder="34"
         type="number"
-        {...formik.getFieldProps('danishHomeContents.livingSpace')}
+        {...formik.getFieldProps('data.livingSpace')}
       />
       <InputField
         label="Street"
         placeholder="Theodore Roosevelts Vej 1"
-        {...formik.getFieldProps('danishHomeContents.street')}
+        {...formik.getFieldProps('data.street')}
       />
       <InputField
         label="Floor"
         placeholder="2"
-        {...formik.getFieldProps('danishHomeContents.floor')}
+        {...formik.getFieldProps('data.floor')}
       />
       <InputField
         label="Apartment"
         placeholder="tv"
-        {...formik.getFieldProps('danishHomeContents.apartment')}
+        {...formik.getFieldProps('data.apartment')}
       />
       <InputField
         label="Zip code"
         placeholder="2100"
-        {...formik.getFieldProps('danishHomeContents.zipCode')}
+        {...formik.getFieldProps('data.zipCode')}
       />
       <InputField
         label="Type"
@@ -63,11 +63,11 @@ export const DanishQuote: React.FC<WithFormikProps> = ({ formik }) => {
           { label: 'Own', value: DanishHomeContentsType['Own'] },
           { label: 'Rent', value: DanishHomeContentsType['Rent'] },
         ]}
-        {...formik.getFieldProps('danishHomeContents.subType')}
+        {...formik.getFieldProps('data.subType')}
       />
       <div style={{ paddingBottom: '2rem', fontSize: '1.25rem' }}>
         <label>
-          <Field type="checkbox" name="danishHomeContents.student" />
+          <Field type="checkbox" name="data.student" />
           {"I'm a student"}
         </label>
       </div>

--- a/src/client/pages/OfferDebugger/components/QuoteFormNorway.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteFormNorway.tsx
@@ -14,7 +14,7 @@ const initialBaseValues = {
 
 export const initialNoHomeValues = {
   ...initialBaseValues,
-  norwegianHomeContentsData: {
+  data: {
     youth: false,
     coInsured: 0,
     livingSpace: 44,
@@ -26,7 +26,7 @@ export const initialNoHomeValues = {
 
 export const initialNoTravelValues = {
   ...initialBaseValues,
-  norwegianTravelData: {
+  data: {
     coInsured: 0,
     youth: false,
   },
@@ -38,7 +38,7 @@ const NorwegianCommon: React.FC<WithFormikProps> = ({ formik }) => (
       label="Co-insured"
       placeholder="1"
       type="number"
-      {...formik.getFieldProps('norwegianTravel.coInsured')}
+      {...formik.getFieldProps('data.coInsured')}
     />
     <InputField
       label="Current Insurer (optional)"
@@ -56,17 +56,17 @@ export const NorwegianHome: React.FC<WithFormikProps> = ({ formik }) => {
         label="Living space"
         placeholder="23"
         type="number"
-        {...formik.getFieldProps('norwegianHomeContents.livingSpace')}
+        {...formik.getFieldProps('data.livingSpace')}
       />
       <InputField
         label="Street"
         placeholder="Gulebøjsveien 1"
-        {...formik.getFieldProps('norwegianHomeContents.street')}
+        {...formik.getFieldProps('data.street')}
       />
       <InputField
         label="Zip code"
         placeholder="1234"
-        {...formik.getFieldProps('norwegianHomeContents.zipCode')}
+        {...formik.getFieldProps('data.zipCode')}
       />
       <InputField
         label="Type"
@@ -74,7 +74,7 @@ export const NorwegianHome: React.FC<WithFormikProps> = ({ formik }) => {
           { label: 'Own', value: 'OWN' },
           { label: 'Rent', value: 'RENT' },
         ]}
-        {...formik.getFieldProps('norwegianHomeContents.subType')}
+        {...formik.getFieldProps('data.subType')}
       />
     </>
   )

--- a/src/client/pages/OfferDebugger/components/QuoteFormSweden.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteFormSweden.tsx
@@ -11,7 +11,7 @@ export const initialSeApartmentValues = {
   ssn: '199509291234',
   startDate: '',
   email: 'sven.svensson@hedvig.com',
-  swedishApartmentData: {
+  data: {
     street: 'Storgatan 1',
     zipCode: '12345',
     livingSpace: 23,
@@ -27,23 +27,23 @@ export const SwedishApartment: React.FC<WithFormikProps> = ({ formik }) => {
         label="Household size"
         placeholder="1"
         type="number"
-        {...formik.getFieldProps('swedishApartmentData.householdSize')}
+        {...formik.getFieldProps('data.householdSize')}
       />
       <InputField
         label="Living space"
         placeholder="23"
         type="number"
-        {...formik.getFieldProps('swedishApartmentData.livingSpace')}
+        {...formik.getFieldProps('data.livingSpace')}
       />
       <InputField
         label="Street"
         placeholder="Gulebøjsveien 1"
-        {...formik.getFieldProps('swedishApartmentData.street')}
+        {...formik.getFieldProps('data.street')}
       />
       <InputField
         label="Zip code"
         placeholder="12345"
-        {...formik.getFieldProps('swedishApartmentData.zipCode')}
+        {...formik.getFieldProps('data.zipCode')}
       />
       <InputField
         label="Type"
@@ -53,7 +53,7 @@ export const SwedishApartment: React.FC<WithFormikProps> = ({ formik }) => {
           { label: 'Brf (student)', value: ApartmentType.StudentBrf },
           { label: 'Rent (student)', value: ApartmentType.StudentRent },
         ]}
-        {...formik.getFieldProps('swedishApartmentData.subType')}
+        {...formik.getFieldProps('data.subType')}
       />
       <InputField
         label="Current Insurer (optional)"


### PR DESCRIPTION
## What?

> FYI: there's some issue creating a house quote still. However, I think we can merge this and adress that separately.

The more generic version of the create bundle API has been released. This update addresses that.

This is the information we send now:

```json
{
    "quoteCartId": "7fe19900-8dd2-4aae-bc4b-d79119674850",
    "quotes": [
        {
            "firstName": "Sven",
            "lastName": "Svensson",
            "birthDate": "1995-09-29",
            "ssn": "199509291234",
            "email": "sven.svensson.trdlj@hedvig.com",
            "data": {
                "street": "Storgatan 1",
                "zipCode": "12345",
                "livingSpace": 23,
                "householdSize": 1,
                "subType": "RENT",
                "type": "apartment"
            }
        }
    ]
}
```

I also:

- made sure that we send a unique email (to avoid conflicts)
- differentiated the buttons in the debugger a bit better

## Why?

Keep up-to-date with the new QuoteCart API.

**Ticket(s): [GRW-598]**

## Screenshots / recordings

![Screenshot 2021-11-26 at 11 14 43](https://user-images.githubusercontent.com/1220232/143564696-0dd1229d-7d4a-4cec-b21a-8fbf32289822.png)

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->



[GRW-598]: https://hedvig.atlassian.net/browse/GRW-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ