### PR TITLE
Fix / Broken redirect from /offer to landing page

### DIFF
--- a/src/client/pages/OfferNew/index.tsx
+++ b/src/client/pages/OfferNew/index.tsx
@@ -46,8 +46,8 @@ const getQuoteIdsFromBundleVariant = (bundleVariant: QuoteBundleVariant) =>
   bundleVariant.bundle.quotes.map((quote) => quote.id)
 
 export const OfferNew: React.FC = () => {
-  const currentLocale = useCurrentLocale()
-  const localeIsoCode = currentLocale.isoLocale
+  const { path: localePath, isoLocale, phoneNumber } = useCurrentLocale()
+  const localeIsoCode = isoLocale
   const variation = useVariation()
 
   const [isInsuranceToggleEnabled] = useFeature([
@@ -135,14 +135,14 @@ export const OfferNew: React.FC = () => {
   }
 
   const checkoutMatch = useRouteMatch(`${localePathPattern}/new-member/sign`)
-  const toggleCheckout = createToggleCheckout(history, currentLocale.path)
+  const toggleCheckout = createToggleCheckout(history, localePath)
 
   if ((loadingQuoteBundle && !data) || quoteIdsIsLoading) {
     return <LoadingPage />
   }
 
   if (quoteIds.length === 0) {
-    return <Redirect to={`/${currentLocale}/new-member`} />
+    return <Redirect to={`/${localePath}/new-member`} />
   }
 
   if (!loadingQuoteBundle && !data) {
@@ -183,7 +183,7 @@ export const OfferNew: React.FC = () => {
       <SessionTokenGuard>
         {![Variation.IOS, Variation.ANDROID].includes(variation!) && (
           <TopBar isTransparent>
-            {currentLocale.phoneNumber ? (
+            {phoneNumber ? (
               <PhoneNumber
                 color="white"
                 onClick={(status) => handleClickPhoneNumber(status)}


### PR DESCRIPTION
## What?

<!-- What changes are made? If there are many changes, a list might be a good format. -->

Fix the redirect from `/offer` to landing page which happens if you try to go to `/offer` without a valid session.

## Why?

<!-- Why are these changes made? -->

The reason this was broken is that a switch had been made from the old `useCurrentLocale` hook to the new one in `/OfferNew/index.tsx`, but the `Redirect` path wasn't changed, which means it tries to use an object as the locale part of the path.



<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->

## Screenshots / recordings 
**Broken redirect:**

https://user-images.githubusercontent.com/42962286/144586748-460f98c1-0e40-4f8a-a1a0-3221f684a5f7.mov


**Fixed redirect:**

https://user-images.githubusercontent.com/42962286/144586766-cbed76ec-5e7f-444b-8a0a-cc094def9bd4.mov




<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

