### PR TITLE
Fix / Offer page can't be scrolled

### DIFF
--- a/src/client/components/ModalNew.tsx
+++ b/src/client/components/ModalNew.tsx
@@ -86,8 +86,7 @@ export const Modal: React.FC<ModalProps> = ({
   onClose,
   children,
 }) => {
-  useLockBodyScroll({ lock: isVisible })
-
+  useLockBodyScroll({ isLocked: isVisible })
   return (
     <Wrapper
       initial={'hidden'}

--- a/src/client/components/ModalNew.tsx
+++ b/src/client/components/ModalNew.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { useLockBodyScroll } from '../utils/hooks/useLockBodyScroll'
 import { CloseButton } from './CloseButton/CloseButton'
 
-export interface ModalProps {
+export type ModalProps = {
   isVisible: boolean
   dynamicHeight?: boolean
   onClose: () => void
@@ -35,7 +35,7 @@ const ButtonWrapper = styled.div`
   right: 1rem;
 `
 
-interface ModalContainerProps {
+type ModalContainerProps = {
   dynamicHeight?: boolean
 }
 
@@ -47,8 +47,8 @@ const ModalContainer = styled(motion.div)<ModalContainerProps>`
   max-width: 56rem;
   max-height: 100vh;
 
-  ${(props) =>
-    !props.dynamicHeight &&
+  ${({ dynamicHeight }) =>
+    !dynamicHeight &&
     `
   min-height: 25rem;
   max-height: 56rem;`}
@@ -74,7 +74,7 @@ const ModalContainer = styled(motion.div)<ModalContainerProps>`
   }
 `
 
-const ModalInnerContainer = styled('div')`
+const ModalInnerContainer = styled.div`
   width: 100%;
   height: 100%;
 `

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -369,7 +369,6 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
       <Global
         styles={css`
           body {
-            overflow: hidden;
             background-color: ${colorsV3.gray100};
           }
         `}

--- a/src/client/pages/OfferNew/Checkout/index.tsx
+++ b/src/client/pages/OfferNew/Checkout/index.tsx
@@ -193,7 +193,7 @@ export const Checkout = ({
     }
   }, [isOpen])
 
-  useLockBodyScroll({ lock: visibilityState === VisibilityState.OPEN })
+  useLockBodyScroll({ isLocked: visibilityState === VisibilityState.OPEN })
 
   const [signUiState, setSignUiState] = useState<SignUiState>('NOT_STARTED')
   const [emailUpdateLoading, setEmailUpdateLoading] = useState(false)

--- a/src/client/utils/hooks/useLockBodyScroll.ts
+++ b/src/client/utils/hooks/useLockBodyScroll.ts
@@ -1,18 +1,19 @@
 import { useLayoutEffect } from 'react'
 
-type UseLockBodyScrollConfig = { lock: boolean }
+type UseLockBodyScrollConfig = { isLocked: boolean }
 
-export const useLockBodyScroll = ({ lock = true }: UseLockBodyScrollConfig) => {
+export const useLockBodyScroll = ({
+  isLocked = false,
+}: UseLockBodyScrollConfig) => {
   useLayoutEffect(() => {
     const previousOverflowStyle = window.getComputedStyle(document.body)
       .overflow
-
-    if (lock) {
+    if (isLocked) {
       document.body.style.overflow = 'hidden'
     }
 
     return () => {
       document.body.style.overflow = previousOverflowStyle
     }
-  }, [lock])
+  }, [isLocked])
 }


### PR DESCRIPTION
## What?

<!-- What changes are made? If there are many changes, a list might be a good format. -->
Attempt to fix bug with `/offer` page being initially un-scrollable when it's first loaded after going through the onboarding flow.

**Bonus:** Minor refactoring to follow the general code style/patterns in the codebase.


## Why?

<!-- Why are these changes made? -->

After introducing the use of a `Modal` in `EmbarkRoot` the `useLockBodyScroll` cleanup function will apply style `overflow: hidden;` to the body on `/offer` page. This is caused by the `EmbarkRoot` component (for some reason) setting this style on the body. Since we don't know what problem was solved when this styling was introduced (two years ago) we'll try to just remove it and do some thorough checking of a review app in different viewports/browsers/devices.

Another solution would be to change the logic of the `useScrollLock` `useLayoutEffect` cleanup function - instead of setting `document.body.style.overflow` to the previous (as in before the hook was called) body `overflow` style we could just set it to the default `overflow` style of the body`. 

But even if we change the hook we should probably not just set new styles of the body the way we do in `EmbarkRoot` so let's just remove that first :)


**Ticket(s): [GRW-610]**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->

### 👉  [Review app](https://web-onboardi-grw-610-fi-bxhcro.herokuapp.com/se-en/new-member)




[GRW-610]: https://hedvig.atlassian.net/browse/GRW-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ