### PR TITLE
refactor(GRW-689): propagate OfferNew/Checkout changes to Offer/Checkout

### DIFF
--- a/src/client/components/Badge/Badge.tsx
+++ b/src/client/components/Badge/Badge.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 
-type BadgeProps = {
+export type BadgeProps = {
   children: ReactNode
   disabled?: boolean
   size?: 'sm' | 'lg'

--- a/src/client/components/CampaignBadge/CampaignBadge.tsx
+++ b/src/client/components/CampaignBadge/CampaignBadge.tsx
@@ -40,7 +40,6 @@ export const CampaignBadge: React.FC<CampaignBadgeProps> = ({
       id: quoteCartId,
       locale: isoLocale,
     },
-    onCompleted: () => console.log('called applied'),
   })
   const campaignText = campaignData?.quoteCart.campaign?.displayValue ?? ''
 

--- a/src/client/components/CampaignBadge/CampaignBadge.tsx
+++ b/src/client/components/CampaignBadge/CampaignBadge.tsx
@@ -4,8 +4,6 @@ import styled from '@emotion/styled'
 import { Badge, BadgeProps } from 'components/Badge/Badge'
 
 import { useAppliedCampaignNameQuery } from 'data/graphql'
-import { OfferData } from 'pages/OfferNew/types'
-import { isNorwegianBundle } from 'pages/OfferNew/utils'
 import { useTextKeys } from 'utils/textKeys'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 
@@ -22,14 +20,14 @@ const CampaignBadgeStyled = styled.div`
 `
 
 export type CampaignBadgeProps = Omit<BadgeProps, 'children'> & {
-  offerData: OfferData
   quoteCartId: string
+  isNorwegianBundle: boolean
 }
 
 export const CampaignBadge: React.FC<CampaignBadgeProps> = ({
   className,
   quoteCartId,
-  offerData,
+  isNorwegianBundle,
   ...others
 }) => {
   const { isoLocale } = useCurrentLocale()
@@ -37,7 +35,7 @@ export const CampaignBadge: React.FC<CampaignBadgeProps> = ({
 
   const { data: campaignData, loading } = useAppliedCampaignNameQuery({
     variables: {
-      id: quoteCartId,
+      quoteCartId,
       locale: isoLocale,
     },
   })
@@ -46,9 +44,7 @@ export const CampaignBadge: React.FC<CampaignBadgeProps> = ({
   if (loading || !campaignText) return null
 
   const discounts: Array<React.ReactNode> = [
-    ...(isNorwegianBundle(offerData)
-      ? [textKeys.SIDEBAR_NO_BUNDLE_CAMPAIGN_TEXT()]
-      : []),
+    ...(isNorwegianBundle ? [textKeys.SIDEBAR_NO_BUNDLE_CAMPAIGN_TEXT()] : []),
     ...(campaignText ? [campaignText] : []),
   ]
 

--- a/src/client/components/CampaignBadge/CampaignBadge.tsx
+++ b/src/client/components/CampaignBadge/CampaignBadge.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import styled from '@emotion/styled'
+
+import { Badge, BadgeProps } from 'components/Badge/Badge'
+
+import { useAppliedCampaignNameQuery } from 'data/graphql'
+import { OfferData } from 'pages/OfferNew/types'
+import { isNorwegianBundle } from 'pages/OfferNew/utils'
+import { useTextKeys } from 'utils/textKeys'
+import { useCurrentLocale } from 'l10n/useCurrentLocale'
+
+const CampaignBadgeStyled = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  align-items: flex-start;
+
+  & > *:not(:last-child) {
+    margin-right: 0.5rem;
+  }
+`
+
+export type CampaignBadgeProps = Omit<BadgeProps, 'children'> & {
+  offerData: OfferData
+  quoteCartId: string
+}
+
+export const CampaignBadge: React.FC<CampaignBadgeProps> = ({
+  className,
+  quoteCartId,
+  offerData,
+  ...others
+}) => {
+  const { isoLocale } = useCurrentLocale()
+  const textKeys = useTextKeys()
+
+  const { data: campaignData, loading } = useAppliedCampaignNameQuery({
+    variables: {
+      id: quoteCartId,
+      locale: isoLocale,
+    },
+    onCompleted: () => console.log('called applied'),
+  })
+  const campaignText = campaignData?.quoteCart.campaign?.displayValue ?? ''
+
+  if (loading || !campaignText) return null
+
+  const discounts: Array<React.ReactNode> = [
+    ...(isNorwegianBundle(offerData)
+      ? [textKeys.SIDEBAR_NO_BUNDLE_CAMPAIGN_TEXT()]
+      : []),
+    ...(campaignText ? [campaignText] : []),
+  ]
+
+  return (
+    <CampaignBadgeStyled className={className}>
+      {discounts.map((text, index) => (
+        <Badge key={index} {...others}>
+          {text}
+        </Badge>
+      ))}
+    </CampaignBadgeStyled>
+  )
+}

--- a/src/client/data/graphql.tsx
+++ b/src/client/data/graphql.tsx
@@ -11480,7 +11480,7 @@ export type AddCampaignCodeMutation = { __typename?: 'Mutation' } & {
 }
 
 export type AppliedCampaignNameQueryVariables = Exact<{
-  id: Scalars['ID']
+  quoteCartId: Scalars['ID']
   locale: Locale
 }>
 
@@ -12858,8 +12858,8 @@ export type AddCampaignCodeMutationOptions = ApolloReactCommon.BaseMutationOptio
   AddCampaignCodeMutationVariables
 >
 export const AppliedCampaignNameDocument = gql`
-  query AppliedCampaignName($id: ID!, $locale: Locale!) {
-    quoteCart(id: $id) {
+  query AppliedCampaignName($quoteCartId: ID!, $locale: Locale!) {
+    quoteCart(id: $quoteCartId) {
       campaign {
         displayValue(locale: $locale)
       }
@@ -12879,7 +12879,7 @@ export const AppliedCampaignNameDocument = gql`
  * @example
  * const { data, loading, error } = useAppliedCampaignNameQuery({
  *   variables: {
- *      id: // value for 'id'
+ *      quoteCartId: // value for 'quoteCartId'
  *      locale: // value for 'locale'
  *   },
  * });

--- a/src/client/data/graphql.tsx
+++ b/src/client/data/graphql.tsx
@@ -11479,6 +11479,19 @@ export type AddCampaignCodeMutation = { __typename?: 'Mutation' } & {
     | ({ __typename?: 'BasicError' } & { errorMessage: BasicError['message'] })
 }
 
+export type AppliedCampaignNameQueryVariables = Exact<{
+  id: Scalars['ID']
+  locale: Locale
+}>
+
+export type AppliedCampaignNameQuery = { __typename?: 'Query' } & {
+  quoteCart: { __typename?: 'QuoteCart' } & {
+    campaign?: Maybe<
+      { __typename?: 'Campaign' } & Pick<Campaign, 'displayValue'>
+    >
+  }
+}
+
 export type AvailablePaymentMethodsQueryVariables = Exact<{
   [key: string]: never
 }>
@@ -12843,6 +12856,67 @@ export type AddCampaignCodeMutationResult = ApolloReactCommon.MutationResult<
 export type AddCampaignCodeMutationOptions = ApolloReactCommon.BaseMutationOptions<
   AddCampaignCodeMutation,
   AddCampaignCodeMutationVariables
+>
+export const AppliedCampaignNameDocument = gql`
+  query AppliedCampaignName($id: ID!, $locale: Locale!) {
+    quoteCart(id: $id) {
+      campaign {
+        displayValue(locale: $locale)
+      }
+    }
+  }
+`
+
+/**
+ * __useAppliedCampaignNameQuery__
+ *
+ * To run a query within a React component, call `useAppliedCampaignNameQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAppliedCampaignNameQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useAppliedCampaignNameQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *      locale: // value for 'locale'
+ *   },
+ * });
+ */
+export function useAppliedCampaignNameQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    AppliedCampaignNameQuery,
+    AppliedCampaignNameQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<
+    AppliedCampaignNameQuery,
+    AppliedCampaignNameQueryVariables
+  >(AppliedCampaignNameDocument, options)
+}
+export function useAppliedCampaignNameLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    AppliedCampaignNameQuery,
+    AppliedCampaignNameQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<
+    AppliedCampaignNameQuery,
+    AppliedCampaignNameQueryVariables
+  >(AppliedCampaignNameDocument, options)
+}
+export type AppliedCampaignNameQueryHookResult = ReturnType<
+  typeof useAppliedCampaignNameQuery
+>
+export type AppliedCampaignNameLazyQueryHookResult = ReturnType<
+  typeof useAppliedCampaignNameLazyQuery
+>
+export type AppliedCampaignNameQueryResult = ApolloReactCommon.QueryResult<
+  AppliedCampaignNameQuery,
+  AppliedCampaignNameQueryVariables
 >
 export const AvailablePaymentMethodsDocument = gql`
   query AvailablePaymentMethods {

--- a/src/client/graphql/AppliedCampaign.graphql
+++ b/src/client/graphql/AppliedCampaign.graphql
@@ -1,0 +1,7 @@
+query AppliedCampaignName($id: ID!, $locale: Locale!) {
+  quoteCart(id: $id) {
+    campaign {
+      displayValue(locale: $locale)
+    }
+  }
+}

--- a/src/client/graphql/AppliedCampaign.graphql
+++ b/src/client/graphql/AppliedCampaign.graphql
@@ -1,5 +1,5 @@
-query AppliedCampaignName($id: ID!, $locale: Locale!) {
-  quoteCart(id: $id) {
+query AppliedCampaignName($quoteCartId: ID!, $locale: Locale!) {
+  quoteCart(id: $quoteCartId) {
     campaign {
       displayValue(locale: $locale)
     }

--- a/src/client/pages/Offer/Checkout/index.tsx
+++ b/src/client/pages/Offer/Checkout/index.tsx
@@ -22,6 +22,7 @@ import {
   getQuoteIdsFromBundleVariant,
   getBundleVariantFromInsuranceTypesWithFallback,
   getInsuranceTypesFromBundleVariant,
+  isNorwegianBundle,
 } from 'pages/OfferNew/utils'
 import { PriceBreakdown } from 'pages/OfferNew/common/PriceBreakdown'
 import { useStorage } from 'utils/StorageContainer'
@@ -464,7 +465,7 @@ export const Checkout = ({
             <Section>
               <StyledCampaignBadge
                 quoteCartId={quoteCartId}
-                offerData={offerData}
+                isNorwegianBundle={isNorwegianBundle(offerData)}
               >
                 <DiscountTag offerData={offerData} />
               </StyledCampaignBadge>

--- a/src/client/pages/Offer/Checkout/index.tsx
+++ b/src/client/pages/Offer/Checkout/index.tsx
@@ -30,6 +30,7 @@ import { useLockBodyScroll } from 'utils/hooks/useLockBodyScroll'
 import { useFeature, Features } from 'utils/hooks/useFeature'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 import { CloseButton } from 'components/CloseButton/CloseButton'
+import { CampaignBadge } from 'components/CampaignBadge/CampaignBadge'
 import { DiscountTag } from 'components/DiscountTag/DiscountTag'
 import { setupQuoteCartSession } from 'containers/SessionContainer'
 import { reportUnderwritingLimits } from 'utils/sentry-client'
@@ -120,7 +121,7 @@ const Section = styled.div`
   width: 100%;
 `
 
-const DiscountTagWrapper = styled.div`
+const StyledCampaignBadge = styled(CampaignBadge)`
   margin-top: 2rem;
 `
 
@@ -461,9 +462,12 @@ export const Checkout = ({
           <InnerWrapper>
             <CloseButton onClick={onClose} />
             <Section>
-              <DiscountTagWrapper>
+              <StyledCampaignBadge
+                quoteCartId={quoteCartId}
+                offerData={offerData}
+              >
                 <DiscountTag offerData={offerData} />
-              </DiscountTagWrapper>
+              </StyledCampaignBadge>
               <Heading>{textKeys.CHECKOUT_HEADING()}</Heading>
               <PriceBreakdown
                 offerData={offerData}

--- a/src/client/pages/Offer/Introduction/Sidebar/index.tsx
+++ b/src/client/pages/Offer/Introduction/Sidebar/index.tsx
@@ -11,7 +11,7 @@ import {
 } from 'data/graphql'
 
 import { Button, TextButton } from 'components/buttons'
-import { Badge } from 'components/Badge/Badge'
+import { CampaignBadge } from 'components/CampaignBadge/CampaignBadge'
 import { OfferData } from 'pages/OfferNew/types'
 import { Price } from 'pages/OfferNew/common/price'
 import { PriceBreakdown } from 'pages/OfferNew/common/PriceBreakdown'
@@ -23,7 +23,7 @@ import {
   LARGE_SCREEN_MEDIA_QUERY,
   SMALL_SCREEN_MEDIA_QUERY,
 } from 'utils/mediaQueries'
-import { isBundle, isNorwegian } from 'pages/OfferNew/utils'
+import { isNorwegianBundle } from 'pages/OfferNew/utils'
 import { TOP_BAR_Z_INDEX } from 'components/TopBar'
 
 import { StartDate } from '../../../OfferNew/Introduction/Sidebar/StartDate'
@@ -60,20 +60,8 @@ const Container = styled.div`
   }
 `
 
-const DiscountInfo = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  margin-bottom: 0.5rem;
-`
-
-const DiscountBadge = styled(Badge)`
-  &:not(:last-child) {
-    margin-right: 0.5rem;
-    margin-bottom: 0.5rem;
-  }
+const StyledCampaignBadge = styled(CampaignBadge)`
+  margin-bottom: 1rem;
 `
 
 const Header = styled.div`
@@ -160,8 +148,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
     awaitRefetchQueries: true,
   })
 
-  const campaignText = campaign?.displayValue ?? ''
-
   const handleAddCampaignCode = useCallback(
     async (code: string) => {
       const { data: result } = await addCampaignCode({
@@ -190,17 +176,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
     }
   }, [quoteCartId, removeCampaignCode])
 
-  const isNorwegianBundle = isBundle(offerData) && isNorwegian(offerData)
-  const discounts: Array<React.ReactNode> = [
-    ...(isNorwegianBundle ? [textKeys.SIDEBAR_NO_BUNDLE_CAMPAIGN_TEXT()] : []),
-    ...(campaignText ? [campaignText] : []),
-  ]
-
   const showRemoveCampaignButton = campaign != null
   const isDiscountPrice =
     campaign?.incentive?.__typename === 'MonthlyCostDeduction' ||
     campaign?.incentive?.__typename === 'PercentageDiscountMonths' ||
-    isNorwegianBundle
+    isNorwegianBundle(offerData)
 
   return (
     <>
@@ -208,13 +188,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
         {() => (
           <Wrapper>
             <Container>
-              {discounts.length > 0 ? (
-                <DiscountInfo>
-                  {discounts.map((text, index) => (
-                    <DiscountBadge key={index}>{text}</DiscountBadge>
-                  ))}
-                </DiscountInfo>
-              ) : null}
+              <StyledCampaignBadge
+                quoteCartId={quoteCartId}
+                offerData={offerData}
+              />
               <Header>
                 <Title>Hedvig</Title>
                 <Price

--- a/src/client/pages/Offer/Introduction/Sidebar/index.tsx
+++ b/src/client/pages/Offer/Introduction/Sidebar/index.tsx
@@ -190,7 +190,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
             <Container>
               <StyledCampaignBadge
                 quoteCartId={quoteCartId}
-                offerData={offerData}
+                isNorwegianBundle={isNorwegianBundle(offerData)}
               />
               <Header>
                 <Title>Hedvig</Title>


### PR DESCRIPTION
## What?

We're in the process of integrate _QuoteCart API_ into _Offer_ page. Part of the strategy of this major refactor consists on doing the changes in an isolated mode. For example: If we need to do some changes on _OfferNew/Checkout/index.tsx_ we duplicate that file into _Offer/Checkout/index.tsx_ and make the changes there. That also means that any changes occurred in parallel on old offer files (_OfferNew/*_) needs to be propagated on the new files (_Offer/*_) as well. With that said, this PR is about to propagate recent changed occurred on _Checkout_ (#705 - add DiscountTag in Checkout view) into new _Checkout_ files. 


## Why?

We need to keep propagating these changes so we don't loose any added feature/fix during _QuoteCart API_ integration.


<img width="994" alt="Screenshot 2021-12-27 at 18 27 42" src="https://user-images.githubusercontent.com/19200662/147494272-2775ef5b-fcc4-41ec-bc11-d0d665960466.png">


**Ticket(s): [GRW-689](https://hedvig.atlassian.net/browse/GRW-689)**

### [Review app](https://web-onboardi-refactor-g-9yths1.herokuapp.com/se-en/new-member)

