### PR TITLE
Add OneTrust domain to CSP to be able to load the cookie banner

### DIFF
--- a/src/server/middleware/helmet.ts
+++ b/src/server/middleware/helmet.ts
@@ -59,6 +59,7 @@ const defaultSrc = [
   '*.trustly.com',
   'cdn.mxpnl.com',
   'cdn.segment.com',
+  'cdn.cookielaw.org',
   'api.segment.io',
   'https://api-js.mixpanel.com',
   'checkoutshopper-live.adyen.com',


### PR DESCRIPTION
## What?
Add OneTrust domain to CSP to be able to load the cookie banner


## Why?
To be able to test the Cookie banner


