### PR TITLE
Make sure we set correct html lang

### DIFF
--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -47,9 +47,10 @@ const template = (
   code: string | null,
 ) => {
   const pageMeta = getPageMeta(locale, route, code)
+  const htmlLang = locales[locale as LocaleLabel].htmlLang
 
   return `<!doctype html>
-  <html lang="en">
+  <html lang=${htmlLang}>
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0, maximum-scale=1.2, minimum-scale=1.0">

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -47,7 +47,7 @@ const template = (
   code: string | null,
 ) => {
   const pageMeta = getPageMeta(locale, route, code)
-  const htmlLang = locales[locale as LocaleLabel].htmlLang
+  const htmlLang = locales[locale as LocaleLabel]?.htmlLang ?? 'en'
 
   return `<!doctype html>
   <html lang=${htmlLang}>


### PR DESCRIPTION
## What?
Make sure we set correct html lang

## Why?
To identify the language of the site to give correct info to screen readers, search engines and such. The cookie banner also follows the set html lang, that's how I discovered it :) 

https://user-images.githubusercontent.com/6661511/147944389-b953c19d-7247-4ea8-ad9f-e0e26c12b0d2.mov


