### PR TITLE
fix(CancellationOptions): revert code inserted by mistake

### DIFF
--- a/src/client/pages/Offer/Introduction/Sidebar/CancellationOptions.tsx
+++ b/src/client/pages/Offer/Introduction/Sidebar/CancellationOptions.tsx
@@ -57,13 +57,15 @@ export const CancellationOptions: React.FC<CancellationOptionsProps> = ({
     <>
       {quotes.map((quote) => {
         return (
-          <QuoteCancellationOption
-            key={quote.id}
-            {...rest}
-            isGenericQuote={quotes.length === 1}
-            quote={quote as OfferQuote}
-            quoteCartId={quoteCartId}
-          />
+          quote.currentInsurer?.switchable && (
+            <QuoteCancellationOption
+              key={quote.id}
+              {...rest}
+              isGenericQuote={quotes.length === 1}
+              quote={quote as OfferQuote}
+              quoteCartId={quoteCartId}
+            />
+          )
         )
       })}
     </>


### PR DESCRIPTION
## What?

`QuoteCancellationOption` is being displayed unconditionally due a change inserted by mistake in the codebase during the development of #735 . So this reverts to the original code.

