### PR TITLE
fix(Checkout): updated toggle method

### DIFF
--- a/src/client/pages/Offer/index.tsx
+++ b/src/client/pages/Offer/index.tsx
@@ -45,11 +45,13 @@ const createToggleCheckout = (
   locale?: LocaleLabel,
 ) => (isOpen: boolean) => {
   if (isOpen) {
-    history.push(
+    history.replace(
       `/${locale}/new-member/sign/${quoteCartId}${history.location.search}`,
     )
   } else {
-    history.goBack()
+    history.replace(
+      `/${locale}/new-member/offer/${quoteCartId}${history.location.search}`,
+    )
   }
 }
 

--- a/src/client/pages/OfferNew/index.tsx
+++ b/src/client/pages/OfferNew/index.tsx
@@ -36,9 +36,9 @@ const createToggleCheckout = (history: History<any>, locale?: string) => (
   isOpen: boolean,
 ) => {
   if (isOpen) {
-    history.push(`/${locale}/new-member/sign`)
+    history.replace(`/${locale}/new-member/sign`)
   } else {
-    history.goBack()
+    history.replace(`/${locale}/new-member/offer`)
   }
 }
 


### PR DESCRIPTION
## What?

- Changed `Checkout` toggle function so url gets updated properly; `redirect` is being used instead of `push` because IMHO as a user, I don't expect a UI like a _Sidebar_ incrementing browser's history list.


## Why?

- Given a link that triggers Checkout opening (/sign), when user clicks on 'close' button
app goes back in the browser history which results on an empty browser tab; By clicking on `Checkout` close button, user should be able to see/interact with _Offer_ page.

## Screenshots

### Current Behaviour

https://user-images.githubusercontent.com/19200662/148051562-452831a5-db9e-4114-99c1-6d8cfc9bdb74.mov

 
### New Behaviour

https://user-images.githubusercontent.com/19200662/148051576-b181a588-09f5-415c-a9e3-d34d74e72101.mov


