### PR TITLE
Forever page  contrast fix

### DIFF
--- a/src/client/pages/Forever/components/Intro/IntroStories.stories.tsx
+++ b/src/client/pages/Forever/components/Intro/IntroStories.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: IntroStories,
   parameters: {
     backgrounds: {
-      default: 'gray900',
+      default: 'gray100',
     },
   },
   decorators: [withActions()],

--- a/src/client/pages/Forever/components/Intro/IntroStories.tsx
+++ b/src/client/pages/Forever/components/Intro/IntroStories.tsx
@@ -110,7 +110,7 @@ const SkipButton = styled(Link)`
   color: ${colorsV3.gray500};
   &:hover,
   &:focus {
-    color: ${colorsV3.gray300};
+    color: ${colorsV3.gray900};
   }
 
   display: none;

--- a/src/client/pages/Forever/components/Intro/PreOnoardingScreen.stories.tsx
+++ b/src/client/pages/Forever/components/Intro/PreOnoardingScreen.stories.tsx
@@ -8,7 +8,7 @@ export default {
   component: PreOnboardingScreen,
   parameters: {
     backgrounds: {
-      default: 'gray900',
+      default: 'gray100',
     },
   },
 }

--- a/src/client/pages/Forever/components/Intro/components.tsx
+++ b/src/client/pages/Forever/components/Intro/components.tsx
@@ -30,7 +30,7 @@ export const TextContent = styled.div`
   max-width: 40rem;
   padding: 1.5rem;
   font-size: 2rem;
-  color: ${colorsV3.gray100};
+  color: ${colorsV3.gray900};
   opacity: 0;
   animation: ${slideIn} 1500ms forwards, ${fadeIn} 1500ms forwards;
 `

--- a/src/client/pages/Forever/components/RedeemCode.stories.tsx
+++ b/src/client/pages/Forever/components/RedeemCode.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: RedeemCode,
   parameters: {
     backgrounds: {
-      default: 'gray900',
+      default: 'gray100',
     },
   },
 }


### PR DESCRIPTION
Bugfix

Needs to be tested out in storybook.

## What?

Changed colors for text after the Forever page. 

## Why?

The contrast was too low so you could not see the text 


**Ticket(s): []**
https://hedvig.atlassian.net/browse/GRW-706


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

Before:


https://user-images.githubusercontent.com/63097139/148530287-1faa608e-e434-4f2b-a8e4-3d16fb74f85f.mp4


After: 

https://user-images.githubusercontent.com/63097139/148530242-27e56af6-74ae-4b00-ad0f-4ce66e63d874.mp4


