### PR TITLE
Use editQuote query in checkout

### DIFF
--- a/src/client/data/graphql.tsx
+++ b/src/client/data/graphql.tsx
@@ -1596,6 +1596,7 @@ export type BundledQuote = {
   startDate?: Maybe<Scalars['LocalDate']>
   expiresAt: Scalars['LocalDate']
   email?: Maybe<Scalars['String']>
+  phoneNumber?: Maybe<Scalars['String']>
   dataCollectionId?: Maybe<Scalars['ID']>
   typeOfContract: TypeOfContract
   initiatedFrom: Scalars['String']
@@ -1799,7 +1800,7 @@ export type ChatState = {
   onboardingDone: Scalars['Boolean']
 }
 
-/** The signing of an onboarding session, that contains information about the current signing status. */
+/** The checkout state of a quote cart, that contains information about the current signing status. */
 export type Checkout = {
   __typename?: 'Checkout'
   /**  Current signing status of the session  */
@@ -1825,7 +1826,7 @@ export enum CheckoutStatus {
    * Synchronous signing methods, like simple sign, immediately produce this state.
    */
   Signed = 'SIGNED',
-  /** This signing is completed, which means the onboarding session has reached its terminal state. */
+  /** This signing is completed, which means the quote cart has reached its terminal state. */
   Completed = 'COMPLETED',
   /** The signing has failed - which means it also can be retried. */
   Failed = 'FAILED',
@@ -7604,15 +7605,12 @@ export type Mutation = {
   paymentConnection_connectPayment: ConnectPaymentResult
   paymentConnection_submitAdditionalPaymentDetails: ConnectPaymentResult
   paymentConnection_submitAdyenRedirection: ConnectPaymentFinished
-  /**
-   * Create a new onboarding session. This is not an authentication session, but rather an object that
-   * ties the onboarding journey together.
-   */
+  /** Create a new quote cart, used to tie the onboarding journey together. */
   onboardingQuoteCart_create: CreateQuoteCartResult
-  /** Create a quote as part of this onboarding session. */
+  /** Create a quote and add it to the given cart. */
   quoteCart_createQuoteBundle: CreateQuoteBundleResult
   /**
-   * Add a campaign by its code to this onboarding session. This campaign won't be "redeemed", but rather
+   * Add a campaign by its code to this cart. This campaign won't be "redeemed", but rather
    * left in a pending state on the onboarding until signing occurs and a member is created.
    *
    * Returns an error if there was a problem with redeeming it, or null upon success.
@@ -7622,17 +7620,17 @@ export type Mutation = {
   quoteCart_removeCampaign: RemoveCampaignResult
   /** Edit the cart. Will only update the fields that are present in the payload. */
   quoteCart_editQuote: EditQuoteResult
-  /** Add a payment token id to the quote cart */
+  /** Add a payment token id to the quote cart. */
   quoteCart_addPaymentToken: AddPaymentTokenResult
   /**
-   * Initiate signing of this onboarding, optionally tagging a subset of the quotes if not all of them are wanted.
+   * Initiate checkout, optionally tagging a subset of the quotes if not all of them are wanted.
    *
-   * Note, the session should only be moved into its signing state once the prior things, such as campaign, are
+   * Note, the session should only be moved into its checkout state once the prior things, such as campaign, are
    * considered done.
    */
   quoteCart_startCheckout: StartCheckoutResult
   /**
-   * Once an onboarding session is "signed", it can be finalized/consumed by this method, which will produce
+   * Once an cart is "signed", it can be finalized/consumed by this method, which will produce
    * an access token. This access token will serve as the means of authorization towards the member that was
    * created as part of the onboarding.
    *
@@ -8625,7 +8623,7 @@ export type QuoteBundleVariantBundleArgs = {
 }
 
 /**
- * An onboarding session is a type that exists to guide the client through an onboarding journey,
+ * An quote cart is a type that exists to guide the client through an onboarding journey,
  * as a means of storing intermediate state up until the point where it is "signed" and then flushed
  * into a proper "member".
  */
@@ -8633,9 +8631,9 @@ export type QuoteCart = {
   __typename?: 'QuoteCart'
   id: Scalars['ID']
   market: Market
-  /**  Campaign, if one has been attached by a code  */
+  /**  Campaign, if one has been attached by a code.  */
   campaign?: Maybe<Campaign>
-  /**  The quote bundle "view" of the quotes created as part of this onboarding  */
+  /**  The quote bundle "view" of the quotes created as part of this cart.  */
   bundle?: Maybe<QuoteBundle>
   /**  The ongoing signing state, if it has been initiated - or null if it has not.  */
   checkout?: Maybe<Checkout>
@@ -8645,7 +8643,7 @@ export type QuoteCart = {
 }
 
 /**
- * An onboarding session is a type that exists to guide the client through an onboarding journey,
+ * An quote cart is a type that exists to guide the client through an onboarding journey,
  * as a means of storing intermediate state up until the point where it is "signed" and then flushed
  * into a proper "member".
  */
@@ -11515,11 +11513,11 @@ export type CheckoutStatusQueryVariables = Exact<{
 }>
 
 export type CheckoutStatusQuery = { __typename?: 'Query' } & {
-  quoteCart: { __typename?: 'QuoteCart' } & {
-    checkout?: Maybe<
-      { __typename?: 'Checkout' } & Pick<Checkout, 'status' | 'statusText'>
-    >
-  }
+  quoteCart: { __typename?: 'QuoteCart' } & Pick<QuoteCart, 'id'> & {
+      checkout?: Maybe<
+        { __typename?: 'Checkout' } & Pick<Checkout, 'status' | 'statusText'>
+      >
+    }
 }
 
 export type CreateAccessTokenMutationVariables = Exact<{
@@ -11666,37 +11664,7 @@ export type CreateQuoteBundleMutation = { __typename?: 'Mutation' } & {
               >
             }
           >
-          campaign?: Maybe<
-            { __typename?: 'Campaign' } & Pick<
-              Campaign,
-              'code' | 'expiresAt'
-            > & {
-                incentive?: Maybe<
-                  | ({ __typename?: 'MonthlyCostDeduction' } & {
-                      amount?: Maybe<
-                        { __typename?: 'MonetaryAmountV2' } & Pick<
-                          MonetaryAmountV2,
-                          'amount' | 'currency'
-                        >
-                      >
-                    })
-                  | { __typename?: 'FreeMonths' }
-                  | { __typename?: 'NoDiscount' }
-                  | { __typename?: 'VisibleNoDiscount' }
-                  | ({ __typename?: 'PercentageDiscountMonths' } & Pick<
-                      PercentageDiscountMonths,
-                      'percentageDiscount' | 'quantity'
-                    >)
-                  | { __typename?: 'IndefinitePercentageDiscount' }
-                >
-                owner?: Maybe<
-                  { __typename?: 'CampaignOwner' } & Pick<
-                    CampaignOwner,
-                    'displayName' | 'id'
-                  >
-                >
-              }
-          >
+          campaign?: Maybe<{ __typename?: 'Campaign' } & CampaignDataFragment>
           checkout?: Maybe<
             { __typename?: 'Checkout' } & Pick<Checkout, 'status'>
           >
@@ -11758,6 +11726,56 @@ export type CreateSwedishHomeAccidentQuoteMutation = {
           { __typename?: 'UnderwritingLimit' } & Pick<UnderwritingLimit, 'code'>
         >
       })
+}
+
+export type EditBundleQuoteMutationVariables = Exact<{
+  quoteCartId: Scalars['ID']
+  locale: Locale
+  quoteId: Scalars['ID']
+  payload: Scalars['JSON']
+}>
+
+export type EditBundleQuoteMutation = { __typename?: 'Mutation' } & {
+  quoteCart_editQuote:
+    | ({ __typename?: 'QuoteCart' } & Pick<QuoteCart, 'id'> & {
+          bundle?: Maybe<
+            { __typename?: 'QuoteBundle' } & {
+              possibleVariations: Array<
+                { __typename?: 'QuoteBundleVariant' } & Pick<
+                  QuoteBundleVariant,
+                  'id' | 'tag'
+                > & {
+                    bundle: { __typename?: 'QuoteBundle' } & Pick<
+                      QuoteBundle,
+                      'displayName'
+                    > & {
+                        bundleCost: {
+                          __typename?: 'InsuranceCost'
+                        } & BundleCostDataFragmentFragment
+                        quotes: Array<
+                          {
+                            __typename?: 'BundledQuote'
+                          } & QuoteDataFragmentFragment
+                        >
+                      }
+                  }
+              >
+            }
+          >
+        })
+    | ({ __typename?: 'QuoteBundleError' } & Pick<
+        QuoteBundleError,
+        'message' | 'type'
+      > & {
+          limits?: Maybe<
+            Array<
+              { __typename?: 'UnderwritingLimit' } & Pick<
+                UnderwritingLimit,
+                'code'
+              >
+            >
+          >
+        })
 }
 
 export type EditQuoteMutationVariables = Exact<{
@@ -12235,44 +12253,6 @@ export type RemoveStartDateMutation = { __typename?: 'Mutation' } & {
     | { __typename?: 'UnderwritingLimitsHit' }
 }
 
-export type SetStartDateMutationVariables = Exact<{
-  quoteCartId: Scalars['ID']
-  locale: Locale
-  quoteId: Scalars['ID']
-  payload: Scalars['JSON']
-}>
-
-export type SetStartDateMutation = { __typename?: 'Mutation' } & {
-  quoteCart_editQuote:
-    | ({ __typename?: 'QuoteCart' } & Pick<QuoteCart, 'id'> & {
-          bundle?: Maybe<
-            { __typename?: 'QuoteBundle' } & {
-              possibleVariations: Array<
-                { __typename?: 'QuoteBundleVariant' } & Pick<
-                  QuoteBundleVariant,
-                  'id'
-                > & {
-                    bundle: { __typename?: 'QuoteBundle' } & Pick<
-                      QuoteBundle,
-                      'displayName'
-                    > & {
-                        bundleCost: {
-                          __typename?: 'InsuranceCost'
-                        } & BundleCostDataFragmentFragment
-                        quotes: Array<
-                          {
-                            __typename?: 'BundledQuote'
-                          } & QuoteDataFragmentFragment
-                        >
-                      }
-                  }
-              >
-            }
-          >
-        })
-    | ({ __typename?: 'QuoteBundleError' } & Pick<QuoteBundleError, 'message'>)
-}
-
 export type SignMethodForQuotesQueryVariables = Exact<{
   input: Array<Scalars['ID']> | Scalars['ID']
 }>
@@ -12447,6 +12427,7 @@ export type QuoteDataFragmentFragment = { __typename?: 'BundledQuote' } & Pick<
   | 'firstName'
   | 'lastName'
   | 'ssn'
+  | 'phoneNumber'
   | 'birthDate'
   | 'startDate'
   | 'expiresAt'
@@ -12737,6 +12718,7 @@ export const QuoteDataFragmentFragmentDoc = gql`
     firstName
     lastName
     ssn
+    phoneNumber
     birthDate
     startDate
     expiresAt
@@ -13069,6 +13051,7 @@ export type CampaignQueryResult = ApolloReactCommon.QueryResult<
 export const CheckoutStatusDocument = gql`
   query CheckoutStatus($quoteCartId: ID!) {
     quoteCart(id: $quoteCartId) {
+      id
       checkout {
         status
         statusText
@@ -13406,24 +13389,7 @@ export const CreateQuoteBundleDocument = gql`
           }
         }
         campaign {
-          incentive {
-            ... on MonthlyCostDeduction {
-              amount {
-                amount
-                currency
-              }
-            }
-            ... on PercentageDiscountMonths {
-              percentageDiscount
-              quantity
-            }
-          }
-          code
-          owner {
-            displayName
-            id
-          }
-          expiresAt
+          ...CampaignData
         }
         checkoutMethods
         checkout {
@@ -13441,6 +13407,7 @@ export const CreateQuoteBundleDocument = gql`
   }
   ${BundleCostDataFragmentFragmentDoc}
   ${QuoteDataFragmentFragmentDoc}
+  ${CampaignDataFragmentDoc}
 `
 export type CreateQuoteBundleMutationFn = ApolloReactCommon.MutationFunction<
   CreateQuoteBundleMutation,
@@ -13567,6 +13534,95 @@ export type CreateSwedishHomeAccidentQuoteMutationResult = ApolloReactCommon.Mut
 export type CreateSwedishHomeAccidentQuoteMutationOptions = ApolloReactCommon.BaseMutationOptions<
   CreateSwedishHomeAccidentQuoteMutation,
   CreateSwedishHomeAccidentQuoteMutationVariables
+>
+export const EditBundleQuoteDocument = gql`
+  mutation EditBundleQuote(
+    $quoteCartId: ID!
+    $locale: Locale!
+    $quoteId: ID!
+    $payload: JSON!
+  ) {
+    quoteCart_editQuote(
+      id: $quoteCartId
+      quoteId: $quoteId
+      payload: $payload
+    ) {
+      ... on QuoteCart {
+        id
+        bundle {
+          possibleVariations {
+            id
+            tag(locale: $locale)
+            bundle {
+              displayName(locale: $locale)
+              bundleCost {
+                ...BundleCostDataFragment
+              }
+              quotes {
+                ...QuoteDataFragment
+              }
+            }
+          }
+        }
+      }
+      ... on QuoteBundleError {
+        message
+        type
+        limits {
+          code
+        }
+      }
+    }
+  }
+  ${BundleCostDataFragmentFragmentDoc}
+  ${QuoteDataFragmentFragmentDoc}
+`
+export type EditBundleQuoteMutationFn = ApolloReactCommon.MutationFunction<
+  EditBundleQuoteMutation,
+  EditBundleQuoteMutationVariables
+>
+
+/**
+ * __useEditBundleQuoteMutation__
+ *
+ * To run a mutation, you first call `useEditBundleQuoteMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useEditBundleQuoteMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [editBundleQuoteMutation, { data, loading, error }] = useEditBundleQuoteMutation({
+ *   variables: {
+ *      quoteCartId: // value for 'quoteCartId'
+ *      locale: // value for 'locale'
+ *      quoteId: // value for 'quoteId'
+ *      payload: // value for 'payload'
+ *   },
+ * });
+ */
+export function useEditBundleQuoteMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    EditBundleQuoteMutation,
+    EditBundleQuoteMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
+    EditBundleQuoteMutation,
+    EditBundleQuoteMutationVariables
+  >(EditBundleQuoteDocument, options)
+}
+export type EditBundleQuoteMutationHookResult = ReturnType<
+  typeof useEditBundleQuoteMutation
+>
+export type EditBundleQuoteMutationResult = ApolloReactCommon.MutationResult<
+  EditBundleQuoteMutation
+>
+export type EditBundleQuoteMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  EditBundleQuoteMutation,
+  EditBundleQuoteMutationVariables
 >
 export const EditQuoteDocument = gql`
   mutation EditQuote($input: EditQuoteInput!) {
@@ -14606,90 +14662,6 @@ export type RemoveStartDateMutationResult = ApolloReactCommon.MutationResult<
 export type RemoveStartDateMutationOptions = ApolloReactCommon.BaseMutationOptions<
   RemoveStartDateMutation,
   RemoveStartDateMutationVariables
->
-export const SetStartDateDocument = gql`
-  mutation SetStartDate(
-    $quoteCartId: ID!
-    $locale: Locale!
-    $quoteId: ID!
-    $payload: JSON!
-  ) {
-    quoteCart_editQuote(
-      id: $quoteCartId
-      quoteId: $quoteId
-      payload: $payload
-    ) {
-      ... on QuoteCart {
-        id
-        bundle {
-          possibleVariations {
-            id
-            bundle {
-              displayName(locale: $locale)
-              bundleCost {
-                ...BundleCostDataFragment
-              }
-              quotes {
-                ...QuoteDataFragment
-              }
-            }
-          }
-        }
-      }
-      ... on QuoteBundleError {
-        message
-      }
-    }
-  }
-  ${BundleCostDataFragmentFragmentDoc}
-  ${QuoteDataFragmentFragmentDoc}
-`
-export type SetStartDateMutationFn = ApolloReactCommon.MutationFunction<
-  SetStartDateMutation,
-  SetStartDateMutationVariables
->
-
-/**
- * __useSetStartDateMutation__
- *
- * To run a mutation, you first call `useSetStartDateMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useSetStartDateMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [setStartDateMutation, { data, loading, error }] = useSetStartDateMutation({
- *   variables: {
- *      quoteCartId: // value for 'quoteCartId'
- *      locale: // value for 'locale'
- *      quoteId: // value for 'quoteId'
- *      payload: // value for 'payload'
- *   },
- * });
- */
-export function useSetStartDateMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    SetStartDateMutation,
-    SetStartDateMutationVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useMutation<
-    SetStartDateMutation,
-    SetStartDateMutationVariables
-  >(SetStartDateDocument, options)
-}
-export type SetStartDateMutationHookResult = ReturnType<
-  typeof useSetStartDateMutation
->
-export type SetStartDateMutationResult = ApolloReactCommon.MutationResult<
-  SetStartDateMutation
->
-export type SetStartDateMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  SetStartDateMutation,
-  SetStartDateMutationVariables
 >
 export const SignMethodForQuotesDocument = gql`
   query SignMethodForQuotes($input: [ID!]!) {

--- a/src/client/graphql/CheckoutStatus.graphql
+++ b/src/client/graphql/CheckoutStatus.graphql
@@ -1,5 +1,6 @@
 query CheckoutStatus($quoteCartId: ID!) {
   quoteCart(id: $quoteCartId) {
+    id
     checkout {
       status
       statusText

--- a/src/client/graphql/CreateQuoteBundle.graphql
+++ b/src/client/graphql/CreateQuoteBundle.graphql
@@ -18,24 +18,7 @@ mutation CreateQuoteBundle($quoteCartId: ID!, $quotes: [JSON!]!, $locale: Locale
         }
       }
       campaign {
-        incentive {
-          ... on MonthlyCostDeduction {
-            amount {
-              amount
-              currency
-            }
-          }
-          ... on PercentageDiscountMonths {
-            percentageDiscount
-            quantity
-          }
-        }
-        code
-        owner {
-          displayName
-          id
-        }
-        expiresAt
+        ...CampaignData
       }
       checkoutMethods
       checkout {

--- a/src/client/graphql/EditBundleQuote.graphql
+++ b/src/client/graphql/EditBundleQuote.graphql
@@ -1,4 +1,4 @@
-mutation SetStartDate(
+mutation EditBundleQuote(
   $quoteCartId: ID!
   $locale: Locale!
   $quoteId: ID!
@@ -10,6 +10,7 @@ mutation SetStartDate(
       bundle {
         possibleVariations {
           id
+          tag(locale: $locale)
           bundle {
             displayName(locale: $locale)
             bundleCost {
@@ -24,6 +25,10 @@ mutation SetStartDate(
     }
     ... on QuoteBundleError {
       message
+      type
+      limits {
+        code
+      }
     }
   }
 }

--- a/src/client/graphql/fragments/QuoteDataFragment.graphql
+++ b/src/client/graphql/fragments/QuoteDataFragment.graphql
@@ -13,6 +13,7 @@ fragment QuoteDataFragment on BundledQuote {
   firstName
   lastName
   ssn
+  phoneNumber
   birthDate
   startDate
   expiresAt

--- a/src/client/pages/Offer/Checkout/index.tsx
+++ b/src/client/pages/Offer/Checkout/index.tsx
@@ -356,10 +356,17 @@ export const Checkout = ({
 
   const startSign = async () => {
     setSignUiState('STARTED')
-    const { submitForm, dirty: isFormDataUpdated } = formik
+    const { submitForm, dirty: isFormDataUpdated, validateForm } = formik
 
     try {
       const quoteIds = getQuoteIdsFromBundleVariant(selectedQuoteBundleVariant)
+      const errors = await validateForm()
+
+      if (Object.keys(errors).length) {
+        setSignUiState('FAILED')
+        return
+      }
+
       if (isFormDataUpdated) await submitForm()
       const { data } = await startCheckout({
         variables: {

--- a/src/client/pages/Offer/Introduction/Sidebar/CancellationOptions.tsx
+++ b/src/client/pages/Offer/Introduction/Sidebar/CancellationOptions.tsx
@@ -4,7 +4,7 @@ import { format } from 'date-fns'
 import React from 'react'
 import { Switch } from 'components/Switch'
 import { Spinner } from 'components/utils'
-import { useSetStartDateMutation } from 'data/graphql'
+import { useEditBundleQuoteMutation } from 'data/graphql'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 import { OfferData, OfferQuote } from 'pages/OfferNew/types'
 import {
@@ -89,7 +89,7 @@ const QuoteCancellationOption: React.FC<QuoteCancellationOptionProps> = ({
 
   const [isLoading, setIsLoading] = React.useState(false)
 
-  const [setStartDate] = useSetStartDateMutation()
+  const [editQuote] = useEditBundleQuoteMutation()
 
   const isChecked = !quote.startDate
 
@@ -98,7 +98,7 @@ const QuoteCancellationOption: React.FC<QuoteCancellationOptionProps> = ({
       setShowError(false)
       setIsLoading(true)
 
-      await setStartDate({
+      await editQuote({
         variables: {
           quoteCartId,
           locale: isoLocale,

--- a/src/client/pages/Offer/Introduction/Sidebar/StartDate.tsx
+++ b/src/client/pages/Offer/Introduction/Sidebar/StartDate.tsx
@@ -14,7 +14,7 @@ import { ChevronDown } from 'components/icons/ChevronDown'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 import { MarketLabel } from 'l10n/locales'
 import { LoadingDots } from 'components/LoadingDots/LoadingDots'
-import { useSetStartDateMutation } from 'data/graphql'
+import { useEditBundleQuoteMutation } from 'data/graphql'
 import { OfferData, OfferQuote } from 'pages/OfferNew/types'
 import { hasCurrentInsurer, isBundle, isDanish } from 'pages/OfferNew/utils'
 import { gqlDateFormat } from 'pages/OfferNew/Introduction/Sidebar/utils'
@@ -190,7 +190,7 @@ const DateForm: React.FC<{
   )
   const [datePickerOpen, setDatePickerOpen] = useState(false)
 
-  const [setStartDate] = useSetStartDateMutation()
+  const [editQuote] = useEditBundleQuoteMutation()
 
   useEffect(() => {
     setDateValue(getDefaultDateValue(quote))
@@ -225,7 +225,7 @@ const DateForm: React.FC<{
 
       await Promise.all(
         quotesToBeUpdated.map((quote) =>
-          setStartDate({
+          editQuote({
             variables: {
               quoteCartId,
               locale: isoLocale,

--- a/src/client/utils/sentry-client.ts
+++ b/src/client/utils/sentry-client.ts
@@ -30,7 +30,7 @@ export const useUnderwritingLimitsHitReporter = (
 
 export const reportUnderwritingLimits = (
   quoteBundleError: QuoteBundleError,
-  updatedValues: Record<string, any>,
+  quoteIds?: ReadonlyArray<string>,
 ) => {
   if (quoteBundleError.limits?.length) {
     const codes = quoteBundleError.limits?.map(({ code }) => code)
@@ -38,7 +38,7 @@ export const reportUnderwritingLimits = (
     // TODO: Look into GDPR
     captureSentryError(
       Error('Underwriting limits hit when editing quote: ' + codes.join(', ')),
-      { updatedValues },
+      { quoteIds },
     )
   }
 }


### PR DESCRIPTION
## What?

* Uses the edit quote query from the new QuoteCart api when updating data in the checkout form
* Replaces the setStartDate query with editQuote query as it was the same query

## Why?

Makes for simpler code and logic.

### Note

This does not apply the same change to the User Details Form. This is because the createBundle query is atomic and therefore more suitable in the case where an update my fail on one quote but succeed in another.

**Ticket(s): [GRW-699]**


[GRW-699]: https://hedvig.atlassian.net/browse/GRW-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ