### PR TITLE
GRW-765 Add helpertext and space support for phone number on new offer page

### DIFF
--- a/src/client/pages/Offer/Checkout/UserDetailsForm.tsx
+++ b/src/client/pages/Offer/Checkout/UserDetailsForm.tsx
@@ -4,6 +4,7 @@ import { FormikProps } from 'formik'
 import { LocaleData } from 'l10n/locales'
 import { useFeature, Features } from 'utils/hooks/useFeature'
 import { TextKeyMap } from 'utils/textKeys'
+import { useCurrentLocale } from 'l10n/useCurrentLocale'
 import { CreditCheckInfo } from '../../OfferNew/Checkout/CreditCheckInfo'
 import { QuoteInput } from '../Introduction/DetailsModal/types'
 import { TextInput, SsnInput } from './inputFields'
@@ -37,7 +38,11 @@ export const getCheckoutDetailsValidationSchema = (
     ...(isPhoneNumberRequired
       ? {
           phoneNumber: Yup.string()
-            .matches(locale.phoneNumber.formatRegex)
+            .transform((phone) => phone.replace(/\s/g, ''))
+            .matches(
+              locale.phoneNumber.formatRegex,
+              textKeys.GENERIC_ERROR_INPUT_FORMAT(),
+            )
             .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
         }
       : {}),
@@ -46,6 +51,7 @@ export const getCheckoutDetailsValidationSchema = (
 export const CheckoutDetailsForm: React.FC<{
   formikProps: FormikProps<QuoteInput>
 }> = ({ formikProps }) => {
+  const locale = useCurrentLocale()
   const { handleChange } = formikProps
   const [hasEnabledCreditCheckInfo, isPhoneNumberRequired] = useFeature([
     Features.CHECKOUT_CREDIT_CHECK,
@@ -101,6 +107,8 @@ export const CheckoutDetailsForm: React.FC<{
           type="tel"
           formikProps={formikProps}
           onChange={handleChange}
+          placeholder={locale.phoneNumber.placeholder}
+          helperText="CHECKOUT_PHONE_NUMBER_HELPERTEXT"
         />
       )}
       <SsnInput

--- a/src/client/pages/Offer/Checkout/index.tsx
+++ b/src/client/pages/Offer/Checkout/index.tsx
@@ -441,7 +441,7 @@ export const Checkout = ({
               birthDate,
               ssn,
               startDate,
-              phoneNumber,
+              phoneNumber: phoneNumber?.replace(/\s/g, ''),
               dataCollectionId,
               data: {
                 ...form.data,

--- a/src/client/pages/Offer/Checkout/inputFields.tsx
+++ b/src/client/pages/Offer/Checkout/inputFields.tsx
@@ -27,6 +27,7 @@ const CheckoutInput: React.FC<CheckoutInputProps &
       {...props}
       label={textKeys[field.label]()}
       placeholder={textKeys[field.placeholder ? field.placeholder : '']()}
+      helperText={textKeys[field.helperText ? field.helperText : '']()}
       type={field.type}
       id={props.id || props.name}
       value={getIn(formikProps.values, props.name)}
@@ -42,6 +43,7 @@ type TextInputProps = {
   type?: string
   formikProps: FormikProps<QuoteInput>
   placeholder?: string
+  helperText?: string
   onChange?: (e: FormEvent<any>) => void
 }
 
@@ -51,6 +53,7 @@ export const TextInput: React.FC<TextInputProps> = ({
   formikProps,
   type = 'text',
   placeholder = '',
+  helperText = '',
   onChange,
 }) => (
   <CheckoutInput
@@ -59,6 +62,7 @@ export const TextInput: React.FC<TextInputProps> = ({
       label,
       placeholder,
       type,
+      helperText,
     }}
     formikProps={formikProps}
     onChange={onChange}


### PR DESCRIPTION
## What?

* Add helper text to phone number field
* Add proper error message when format is invalid
* Make sure phone number field supports spaces

**Ticket(s): [GRW-765]**

## Screenshots / recordings 
![Screenshot 2022-02-03 at 13 47 14](https://user-images.githubusercontent.com/89857278/152346288-91aefefe-b704-4c3d-b7af-42984a9602ba.png)
![Screenshot 2022-02-03 at 13 48 04](https://user-images.githubusercontent.com/89857278/152346292-972288f9-3893-45c2-818a-1e647cff4172.png)
![Screenshot 2022-02-03 at 13 48 22](https://user-images.githubusercontent.com/89857278/152346293-379ad55f-4467-4f14-acc7-6b6307e6f198.png)

### [Review app]()



[GRW-765]: https://hedvig.atlassian.net/browse/GRW-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ