### PR TITLE
fix(GRW-770): Fix Debugger forms editing

### DIFF
--- a/src/client/components/inputs/index.tsx
+++ b/src/client/components/inputs/index.tsx
@@ -217,7 +217,6 @@ export interface TextInputProps extends CoreInputFieldProps {
 export const InputField: React.FC<TextInputProps> = ({
   label,
   mask,
-  name,
   showErrorMessage = true,
   type = 'text',
   options,


### PR DESCRIPTION
## What?

It wasn't be possible to edit _Debugger_ forms (`debugger`/`offer-debugger`)

## Why?

Inputs weren't getting `name` or `id` prop which is used by `formik.handleChange` callback to actual change their values.

**Ticket(s): [GRW-770](https://hedvig.atlassian.net/browse/GRW-770)**

### Review app

[debugger](https://web-onboardi-fix-grw-77-2ftwiw.herokuapp.com/se-en/new-member/debugger)
[offer-debugger](https://web-onboardi-fix-grw-77-2ftwiw.herokuapp.com/se-en/new-member/offer-debugger)


