### PR TITLE
Fix overflowing input text in Checkout

### DIFF
--- a/src/client/components/inputs/index.tsx
+++ b/src/client/components/inputs/index.tsx
@@ -72,8 +72,6 @@ export const Label = styled.label`
 `
 
 const StyledInput = styled.input`
-  position: relative;
-  z-index: 1;
   background: none;
   border: none;
   font-size: 1rem;
@@ -124,6 +122,7 @@ const SymbolWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  pointer-events: none;
 
   svg {
     width: 1rem;


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

This was the issue:

![image-20220203-143235](https://user-images.githubusercontent.com/1220232/152791044-139c8c97-9a38-415a-a5fb-7a1fcab5cae6.png)

Solution:
- Remove z-index setting for inputs
- Disable pointer events for chevron icon.

## Why?

`z-index` was used to make the icon clickable: https://github.com/HedvigInsurance/web-onboarding/pull/253
However, I think it's a better idea to disable pointer events since `z-index` always causes these unintended layout issues.

**Ticket(s): [GRW-773]**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->



[GRW-773]: https://hedvig.atlassian.net/browse/GRW-773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ