### PR TITLE
Fix / Checkout pages Footer styling

### DIFF
--- a/src/client/components/checkout/Footer.tsx
+++ b/src/client/components/checkout/Footer.tsx
@@ -18,13 +18,14 @@ type FooterButtonProps = {
 
 const Wrapper = styled.div`
   width: 100vw;
-  height: 5rem;
+  min-height: 5rem;
   padding: 1rem;
   position: fixed;
   bottom: 0;
   left: 0;
   display: flex;
   justify-content: center;
+  align-items: center;
   background-color: ${white};
   box-shadow: 0px -4px 8px rgba(0, 0, 0, 0.05),
     0px -8px 16px rgba(0, 0, 0, 0.05);
@@ -33,9 +34,15 @@ const InnerWrapper = styled.div`
   width: 100%;
   max-width: 628px;
   height: 100%;
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   align-items: center;
+`
+const PaymentInfoWrapper = styled.div`
+  justify-self: start;
+`
+const ButtonWrapper = styled.div`
+  justify-self: end;
 `
 
 export const Footer = ({ buttonText, buttonOnClick, buttonLinkTo }: Props) => {
@@ -47,9 +54,11 @@ export const Footer = ({ buttonText, buttonOnClick, buttonLinkTo }: Props) => {
   return (
     <Wrapper>
       <InnerWrapper>
-        <PaymentInfo />
+        <PaymentInfoWrapper>
+          <PaymentInfo />
+        </PaymentInfoWrapper>
         {buttonText && (
-          <>
+          <ButtonWrapper>
             {buttonLinkTo && (
               <LinkButton {...buttonProps} to={buttonLinkTo}>
                 {buttonText}
@@ -60,7 +69,7 @@ export const Footer = ({ buttonText, buttonOnClick, buttonLinkTo }: Props) => {
                 {buttonText}
               </Button>
             )}
-          </>
+          </ButtonWrapper>
         )}
       </InnerWrapper>
     </Wrapper>

--- a/src/client/components/checkout/PaymentInfo.tsx
+++ b/src/client/components/checkout/PaymentInfo.tsx
@@ -44,7 +44,7 @@ export const PaymentInfo = () => {
   const quoteBundle = data?.quoteCart.bundle
 
   if (error || !quoteBundle) {
-    return <div></div>
+    return null
   }
 
   const monthlyNetCost = quoteBundle.bundleCost.monthlyNet.amount


### PR DESCRIPTION

<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

Refactoring of `Footer` and `PaymentInfo` components so that the footer button will always be rendered in the same place, regardless of whether the `PaymentInfo` component returns content, or if it returns `null`, in case of error.

There shouldn't be any visual changes.


## Why?

Since in case of error in `PaymentInfo` there will also be errors somewhere else it feels like overkill to return some sort of error component here. Instead I just don't want to render anything. But since we might want to use the error modal with a semi-transparent backdrop in case of error (the same way it looks in case of signing error, although with different error modal content) I don't want to mess up the layout of the footer.



<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->

### [Review app without error](https://web-onboardi-fix-checko-jbvrib.herokuapp.com/no-en/new-member/checkout/details/ecbe985f-e93d-45b5-afe9-5e5104eb7372)
### [Review app with error](http://localhost:8040/no/new-member/checkout/details/hello)

