### PR TITLE
fix(CancellationOptions): align styles between versions

### DIFF
--- a/src/client/pages/Offer/Introduction/Sidebar/CancellationOptions.tsx
+++ b/src/client/pages/Offer/Introduction/Sidebar/CancellationOptions.tsx
@@ -24,13 +24,14 @@ const HandleSwitchingLabel = styled.label<{ isClickable: boolean }>`
 `
 
 const StyledSpinner = styled(Spinner)`
+  flex: none;
   height: 1.25rem;
   width: 1.25rem;
-  margin-right: 0.5rem;
+  margin-right: 1rem;
 `
 
 const StyledSwitch = styled(Switch)`
-  margin-right: 0.5rem;
+  margin-right: 1rem;
 `
 
 type CancellationOptionsProps = {

--- a/src/client/pages/OfferNew/Introduction/Sidebar/CancellationOptions.tsx
+++ b/src/client/pages/OfferNew/Introduction/Sidebar/CancellationOptions.tsx
@@ -23,7 +23,7 @@ const HandleSwitchingLabel = styled.label<{ isClickable: boolean }>`
 `
 
 const StyledSpinner = styled(Spinner)`
-  flex: 1 0 auto;
+  flex: none;
   height: 1.25rem;
   width: 1.25rem;
   margin-right: 1rem;


### PR DESCRIPTION
## What?

Consolidates the styles used by the two versions of `CancellationOptions` and fixes a bug related with spinner used by this component (check image in the following section)

## Why?

<img width="522" alt="Screenshot 2022-02-09 at 11 34 21" src="https://user-images.githubusercontent.com/19200662/153185360-e5214c99-6dca-4754-94c3-4b2ede8e0b85.png">

As a fix, I'm overriding `flex` CSS property while using `Spinner` inside `CancellationOptions` (link here). But maybe a more robust solution would be refactor `Spinner` by removing it's [`flex` property](https://github.com/HedvigInsurance/web-onboarding/blob/master/src/client/components/utils.ts#L12) since it might be complicating things. But `Spinner` is being used on several files which would require more effort to check that nothing was broken:

<img width="363" alt="Screenshot 2022-02-09 at 12 06 19" src="https://user-images.githubusercontent.com/19200662/153187673-f3dbd31c-b5f9-4bfb-9c51-a4e4bc1de7d9.png">

So, for now I've decided leave as it is. Let me know your opinions about it.

## Relates to

CPS CancellationOptions redesign - #743 

**Ticket(s)**
_NA_

## Screenshots / recordings 

<img width="1312" alt="Screenshot 2022-02-09 at 12 16 55" src="https://user-images.githubusercontent.com/19200662/153189603-e5f976e8-97a2-47b4-b01a-55f3021fe9ba.png">

<img width="1312" alt="Screenshot 2022-02-09 at 12 17 07" src="https://user-images.githubusercontent.com/19200662/153189583-600ab67e-a0d5-472c-87fb-5802c5ee5136.png">

## How to test

Access the review app linked below and complete the switcher flow in _Embark_. In case you don't have an account with a different insurance provider, you can just skip the part of the flow which is about to collect info about your current insurance provider by selecting any insurance provider at the beginning of the flow and then clicking on [Skip] button:

<img width="421" alt="Screenshot 2022-02-03 at 14 34 26" src="https://user-images.githubusercontent.com/19200662/152353008-8166e1dd-a62e-4e33-9af8-966f8ed0bdf2.png">

Make sure to select a provider that we're able to cancel current insurance. E.g: In Sweden, Trygghansa

### [Review app](https://web-onboardi-fix-cancel-tjtos6.herokuapp.com/se-en/new-member)

