### PR TITLE
GRW-794-fix-adding-extra-building-in-details-modal

### DIFF
--- a/src/client/pages/Offer/Introduction/DetailsModal/Details/components/DetailInput.tsx
+++ b/src/client/pages/Offer/Introduction/DetailsModal/Details/components/DetailInput.tsx
@@ -339,7 +339,7 @@ export const ExtraBuildingsInput: React.FC<ExtraBuildingsInputProps> = ({
             (_: any, index: number) => (
               <InputGroup key={index}>
                 <DetailInput
-                  name={`extraBuildings.${index}.type`}
+                  name={`data.extraBuildings.${index}.type`}
                   field={{
                     label:
                       'DETAILS_MODULE_EXTRABUILDINGS_TABLE_BUILDINGTYPE_CELL_LABEL_HOUSE',
@@ -352,12 +352,12 @@ export const ExtraBuildingsInput: React.FC<ExtraBuildingsInputProps> = ({
                   formikProps={formikProps}
                 />
                 <AreaInput
-                  name={`extraBuildings.${index}.area`}
+                  name={`data.extraBuildings.${index}.area`}
                   label="DETAILS_MODULE_EXTRABUILDINGS_TABLE_SIZE_CELL_LABEL_HOUSE"
                   formikProps={formikProps}
                 />
                 <BooleanInput
-                  name={`extraBuildings.${index}.hasWaterConnected`}
+                  name={`data.extraBuildings.${index}.hasWaterConnected`}
                   label="DETAILS_MODULE_EXTRABUILDINGS_TABLE_WATER_CELL_LABEL_HOUSE"
                   formikProps={formikProps}
                 />

--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -38,6 +38,7 @@ enum QuoteBundleType {
   SwedishApartment = 'swedish-apartment',
   SwedishHouse = 'swedish-house',
   SwedishApartmentAccident = 'swedish-apartment-accident',
+  SwedishHouseAccident = 'swedish-house-accident',
 }
 
 enum QuoteType {
@@ -122,6 +123,10 @@ const quotesByMarket: QuotesByMarket = {
       label: 'Swedish Apartment + Accident',
       value: QuoteBundleType.SwedishApartmentAccident,
       initialFormValues: initialSeApartmentValues,
+    },
+    {
+      label: 'Swedish House + Accident',
+      value: QuoteBundleType.SwedishHouseAccident,
     },
   ],
 }
@@ -290,6 +295,17 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
             locale: isoLocale,
             quoteCartId,
             quotes: [getSwedishHouseQuoteValues(input)],
+          },
+        })
+      } else if (quoteBundleType === QuoteBundleType.SwedishHouseAccident) {
+        result = await createQuoteBundle({
+          variables: {
+            locale: isoLocale,
+            quoteCartId,
+            quotes: [
+              getSwedishHouseQuoteValues(input),
+              getSwedishAccidentQuoteValues(input),
+            ],
           },
         })
       } else {


### PR DESCRIPTION
## What?

Adding extra buildings through the edit details form was not working. This fixes the issue.
Also, added support for House + Accident in the debugger for SE

Known Issues:

The display name of extra buildings seems to be missing. This is an API issue that has been reported

**Ticket(s): [GRW-794](https://hedvig.atlassian.net/browse/GRW-794)**

## Screenshots / recordings 

https://user-images.githubusercontent.com/89857278/153561711-8cb18d80-bcdb-46c8-8b12-df603564e0d6.mov

### [Review app](https://web-onboardi-grw-794-fi-u1hzna.herokuapp.com/se-en/new-member/offer/f03cab16-faf8-477e-b8c1-d8ebc5dae75c)



[GRW-793]: https://hedvig.atlassian.net/browse/GRW-793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ