### PR TITLE
fix(GRW-788): displays NO bundle discount

### DIFF
--- a/src/client/components/CampaignBadge/CampaignBadge.tsx
+++ b/src/client/components/CampaignBadge/CampaignBadge.tsx
@@ -41,12 +41,12 @@ export const CampaignBadge: React.FC<CampaignBadgeProps> = ({
   })
   const campaignText = campaignData?.quoteCart.campaign?.displayValue ?? ''
 
-  if (loading || !campaignText) return null
-
   const discounts: Array<React.ReactNode> = [
     ...(isNorwegianBundle ? [textKeys.SIDEBAR_NO_BUNDLE_CAMPAIGN_TEXT()] : []),
     ...(campaignText ? [campaignText] : []),
   ]
+
+  if (loading || discounts.length === 0) return null
 
   return (
     <CampaignBadgeStyled className={className}>

--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -35,6 +35,7 @@ enum QuoteBundleType {
   DanishHomeAccidentTravel = 'danish-home-accident-travel',
   NorwegianHome = 'norwegian-home',
   NorwegianTravel = 'norwegian-travel',
+  NorwegianHomeTravel = 'norwegian-home-travel',
   SwedishApartment = 'swedish-apartment',
   SwedishHouse = 'swedish-house',
   SwedishApartmentAccident = 'swedish-apartment-accident',
@@ -106,6 +107,11 @@ const quotesByMarket: QuotesByMarket = {
       label: 'Norwegian Travel',
       value: QuoteBundleType.NorwegianTravel,
       initialFormValues: initialNoTravelValues,
+    },
+    {
+      label: 'Norwegian Home + Travel',
+      value: QuoteBundleType.NorwegianHomeTravel,
+      initialFormValues: initialNoHomeValues,
     },
   ],
   SE: [
@@ -279,6 +285,29 @@ export const QuoteData: React.FC<OfferProps> = ({ quoteCartId }) => {
                 data: {
                   ...input.data,
                   type: QuoteType.DanishTravel,
+                },
+              },
+            ],
+          },
+        })
+      } else if (quoteBundleType === QuoteBundleType.NorwegianHomeTravel) {
+        result = await createQuoteBundle({
+          variables: {
+            locale: isoLocale,
+            quoteCartId,
+            quotes: [
+              {
+                ...input,
+                data: {
+                  ...input.data,
+                  type: QuoteType.NorwegianHome,
+                },
+              },
+              {
+                ...input,
+                data: {
+                  ...input.data,
+                  type: QuoteType.NorwegianTravel,
                 },
               },
             ],


### PR DESCRIPTION
## What?

- Fixes a bug on `CampaignBadge` component, responsible to skip the displaying of NO bundle discount (25%);
- Added support for the creation of _NO Home + Travel_ quotes to _Offer Debugger_

## Why?

The issue was happening because `CampaignBadge` was relying on the presence of an active campaign in order to build and display discount badges. However, that specific discount is not being added by the API (it feels like it should tho. Not sure 🤔)

## Screenshot(s)

<img width="1331" alt="Screenshot 2022-02-14 at 14 21 48" src="https://user-images.githubusercontent.com/19200662/153872370-6be8fc4c-bbe5-4a09-b319-d8e2750d1f92.png">
<img width="1331" alt="Screenshot 2022-02-14 at 14 21 55" src="https://user-images.githubusercontent.com/19200662/153872377-60aa4d56-f9b5-4ddc-b45e-198401d1c99d.png">

## How to test it

1. Access provided review app;
2. Create a _Norwegian Home + Travel_ quote and then go to the offer page
3. Check if _25% Discount_ is visible both on the _InfoSidebar_ and _Checkout_ components

**Ticket(s)**
[GRW-788](https://hedvig.atlassian.net/browse/GRW-788)

### [Review app](https://web-onboardi-fix-grw-78-ufz1ah.herokuapp.com/no-en/new-member/offer-debugger)

