### PR TITLE
Remove auth token when loading offer page (Quote Cart)

### DIFF
--- a/src/client/pages/Offer/index.tsx
+++ b/src/client/pages/Offer/index.tsx
@@ -36,6 +36,7 @@ import { FaqSection } from '../OfferNew/FaqSection'
 import { Perils } from '../OfferNew/Perils'
 import { InsuranceSelector } from '../OfferNew/InsuranceSelector'
 import { SetupFailedModal } from '../Embark/ErrorModal'
+import { apolloClient as realApolloClient } from '../../apolloClient'
 import { Introduction } from './Introduction'
 import { Checkout } from './Checkout'
 import { PageWrapper } from './PageWrapper'
@@ -90,6 +91,13 @@ export const OfferPage = ({
   ] = useSelectedInsuranceTypes()
 
   const history = useHistory()
+
+  useEffect(() => {
+    // clean up existing auth tokens
+    if (realApolloClient) {
+      realApolloClient.httpLink.options.headers.authorization = undefined
+    }
+  }, [])
 
   const {
     data: quoteCartQueryData,


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

Make sure we don't include any auth token when loading quote cart offer page.

## Why?

This gets picked up by the API and causes strange things to happen like the campaign code not being applied when calculating the price.

This is because the auth token is linked to a member entity. However, on the quote cart offer page, we can be sure that there's no relevant member to keep track of. If there's an auth token present -- it's an artifact.

When we move over to quote cart for all markets, this will no longer be needed.

**Ticket(s): []**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

