### PR TITLE
fix(Checkout): use proper quote ids while completing the purchase

### DIFF
--- a/src/client/api/createQuoteBundleMutationSelectors.ts
+++ b/src/client/api/createQuoteBundleMutationSelectors.ts
@@ -1,0 +1,24 @@
+import { CreateQuoteBundleMutation, QuoteBundleVariant } from 'data/graphql'
+import { getBundleVariantFromInsuranceTypesWithFallback } from 'pages/OfferNew/utils'
+import { InsuranceType } from 'utils/hooks/useSelectedInsuranceTypes'
+
+export function getSelectedBundleVariant(
+  quoteBundleMutation: CreateQuoteBundleMutation | null | undefined,
+  selectedInsuranceTypes: InsuranceType[],
+) {
+  if (
+    quoteBundleMutation?.quoteCart_createQuoteBundle.__typename !== 'QuoteCart'
+  ) {
+    return undefined
+  }
+
+  const bundleVariants = (quoteBundleMutation?.quoteCart_createQuoteBundle
+    ?.bundle?.possibleVariations ?? []) as Array<QuoteBundleVariant>
+
+  if (!bundleVariants.length) return undefined
+
+  return getBundleVariantFromInsuranceTypesWithFallback(
+    bundleVariants,
+    selectedInsuranceTypes,
+  )
+}


### PR DESCRIPTION
## What?

Make sure to use `quoteIds` generated from the _editing information process_

## Why?

When editing quote info we are actually creating new quotes instead of editing the existing ones. With that in mind, the problem was that in the scenario where users change some information like theirs names and then try to Complete the Purchase, we need to generate new quotes (editing) and then start the checkout process. The issue was that we weren't using the `quoteIds` generated by the editing process but the old ones, which makes users having to click [Complete Purchase] button twice so they can finish the purchase.

**Ticket(s): [GRW-844](https://hedvig.atlassian.net/browse/GRW-844)**

## How to test it

1. Use the Review app](https://web-onboardi-fix-grw-84-2cqwki.herokuapp.com/no-en/new-member/offer-debugger)mentioned below to create a NO Offer.
2. Fill up necessary info for Completing the purchase
3. Edit the name and then click on [Complete Purchase] button
    - **Actual behaviour**: You'll get an error on `StartCheckoutMutation`
      <img width="839" alt="Screenshot 2022-02-18 at 12 12 41" src="https://user-images.githubusercontent.com/19200662/154672295-b5fe2af0-d4c0-469e-8387-6bd1ca5344b9.png">
    - **Expected behaviour**: You should be able to complete the purchase    

### [Review app](https://web-onboardi-fix-grw-84-2cqwki.herokuapp.com/no-en/new-member/offer-debugger)

