### PR TITLE
HAnalytics POC

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "@emotion/styled": "^10.0.23",
     "@hedviginsurance/brand": "^4.1.0",
     "@hedviginsurance/embark": "^2.5.1",
+    "@hedviginsurance/hanalytics-client": "1.0.6",
     "@segment/snippet": "^4.4.0",
     "@sentry/node": "^6.10.0",
     "@sentry/react": "^6.10.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@emotion/styled": "^10.0.23",
     "@hedviginsurance/brand": "^4.1.0",
     "@hedviginsurance/embark": "^2.5.1",
-    "@hedviginsurance/hanalytics-client": "1.0.6",
+    "@hedviginsurance/hanalytics-client": "1.0.7",
     "@segment/snippet": "^4.4.0",
     "@sentry/node": "^6.10.0",
     "@sentry/react": "^6.10.0",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -14,6 +14,7 @@ import {
 } from './utils/StorageContainer'
 import { useCurrentLocale } from './l10n/useCurrentLocale'
 import { useGTMTracking } from './utils/tracking/gtm'
+import { useHAnalytics } from './utils/tracking/hanalytics'
 
 const isProductionEnvironment =
   window.hedvigClientConfig.appEnvironment === 'production'
@@ -22,6 +23,7 @@ export const App: React.ComponentType<StorageState> = ({ session }) => {
   const { isoLocale } = useCurrentLocale()
   const history = useHistory()
   useGTMTracking()
+  useHAnalytics()
 
   return (
     <>

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -36,6 +36,7 @@ import { resolveHouseInformation } from './houseInformation'
 import { resolvePersonalInformation } from './personalInformation'
 import { resolveAddressAutocomplete } from './addressAutocompleteProvider'
 import { SetupFailedModal } from './ErrorModal'
+import { hAnalyticsTrackers } from '@hedviginsurance/hanalytics-client'
 
 const EmbarkStyling = styled.div`
   height: 100%;
@@ -295,6 +296,12 @@ export const EmbarkRoot: React.FunctionComponent<EmbarkRootProps> = (props) => {
     const payloadObject = { ...payload }
     Object.keys(payloadObject).forEach(
       (key) => payloadObject[key] === undefined && delete payloadObject[key],
+    )
+
+    hAnalyticsTrackers.embarkTrack(
+      props.name ?? "",
+      eventName,
+      payloadObject
     )
 
     pushToGTMDataLayer({

--- a/src/client/pages/OfferNew/Checkout/index.tsx
+++ b/src/client/pages/OfferNew/Checkout/index.tsx
@@ -35,6 +35,7 @@ import { SignFailModal } from './SignFailModal/SignFailModal'
 import { UserDetailsForm } from './UserDetailsForm'
 import { InsuranceSummary } from './InsuranceSummary'
 import { UpsellCard } from './UpsellCard'
+import { hAnalyticsTrackers } from '@hedviginsurance/hanalytics-client'
 
 type Openable = {
   visibilityState: VisibilityState
@@ -292,12 +293,18 @@ export const Checkout = ({
   })
 
   useEffect(() => {
+    hAnalyticsTrackers.receivedQuotes(quoteIds)
+  }, [quoteIds])
+
+  useEffect(() => {
     if (signStatus?.signState !== SignState.Completed) {
       return
     }
     if (variation === Variation.AVY) {
       handleSignedEvent(member.data?.member.id ?? null)
     }
+
+    hAnalyticsTrackers.quotesSigned(quoteIds)
   }, [member.data?.member, signStatus?.signState, variation])
 
   const canInitiateSign = Boolean(

--- a/src/client/utils/tracking/hanalytics.ts
+++ b/src/client/utils/tracking/hanalytics.ts
@@ -1,0 +1,37 @@
+import { hAnalyticsNetworking, hAnalyticsTrackers } from "@hedviginsurance/hanalytics-client"
+import { useEffect } from "react"
+import { useCurrentLocale } from "../../l10n/useCurrentLocale"
+import { useStorage } from "../StorageContainer"
+
+export const useHAnalytics = () => {
+    const locale = useCurrentLocale()
+    const environment = window.hedvigClientConfig.appEnvironment
+    const storageState = useStorage()
+    
+    useEffect(() => {
+        hAnalyticsNetworking.getConfig = () =>
+           ({
+                httpHeaders: {
+                    Authorization: `Bearer ${storageState.session.getSession()?.token}`
+                },
+                endpointURL: "https://hanalytics-production.herokuapp.com", // todo resolve correct endpoint
+                context: {
+                    locale: locale.isoLocale,
+                    app: {
+                        name: "WebOnboarding",
+                        namespace: environment,
+                        version: "1.0.0",
+                        build: "3000"
+                    },
+                    device: {
+                        id: "THE_DEVICE_ID"
+                    }
+                },
+                onSend: (event) => {
+                    /// send to google analytics or other tracking partner here
+                }
+            })
+        
+        hAnalyticsTrackers.identify()
+    }, [locale, environment])
+}

--- a/src/client/utils/tracking/hanalytics.ts
+++ b/src/client/utils/tracking/hanalytics.ts
@@ -28,7 +28,7 @@ export const useHAnalytics = () => {
                 httpHeaders: {
                     Authorization: getAuthorizationHeader()
                 },
-                endpointURL: "https://hanalytics-production.herokuapp.com", // todo resolve correct endpoint
+                endpointURL: "https://hanalytics-staging.herokuapp.com", // todo resolve correct endpoint
                 context: {
                     locale: locale.isoLocale,
                     app: {
@@ -45,8 +45,6 @@ export const useHAnalytics = () => {
                     /// send to google analytics or other tracking partner here
                 }
             })
-
-        console.log("hello from useHAnalytics")
         
         hAnalyticsTrackers.identify()
     }, [locale, environment, storageState])

--- a/src/client/utils/tracking/hanalytics.ts
+++ b/src/client/utils/tracking/hanalytics.ts
@@ -7,12 +7,26 @@ export const useHAnalytics = () => {
     const locale = useCurrentLocale()
     const environment = window.hedvigClientConfig.appEnvironment
     const storageState = useStorage()
+
+    const getAuthorizationHeader = () => {
+        if (!storageState) {
+            return ""
+        }
+
+        const sessionToken = storageState.session?.getSession()?.token
+
+        if (sessionToken) {
+            return `Bearer ${sessionToken}`
+        }
+
+        return ""
+    }
     
     useEffect(() => {
         hAnalyticsNetworking.getConfig = () =>
            ({
                 httpHeaders: {
-                    Authorization: `Bearer ${storageState.session.getSession()?.token}`
+                    Authorization: getAuthorizationHeader()
                 },
                 endpointURL: "https://hanalytics-production.herokuapp.com", // todo resolve correct endpoint
                 context: {
@@ -31,7 +45,9 @@ export const useHAnalytics = () => {
                     /// send to google analytics or other tracking partner here
                 }
             })
+
+        console.log("hello from useHAnalytics")
         
         hAnalyticsTrackers.identify()
-    }, [locale, environment])
+    }, [locale, environment, storageState])
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2179,10 +2179,10 @@
     ts-node "^8.4.1"
     uuid "^8.3.2"
 
-"@hedviginsurance/hanalytics-client@1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@hedviginsurance/hanalytics-client/-/hanalytics-client-1.0.6.tgz#ada043f6509c5e5caff9dede2d45ff7a4e2bbde6"
-  integrity sha512-3o1XOZloEBGPpE4kX86fheMEZehcRlFKr1PfK+29kkP5i7h/3MGLZ3CLYCEfoSSIEQtn9qh5Q9ImrdiDKT1tHQ==
+"@hedviginsurance/hanalytics-client@1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@hedviginsurance/hanalytics-client/-/hanalytics-client-1.0.7.tgz#73944bba2c9fe4816bda455fbb8e79dd6dd52506"
+  integrity sha512-vYUQngbzYEtZdRD81O4lqMLMMGisH5jYkaeM61vt37yxyLadw+bWWTdlv8sWoOqS84X7KLHqM7sTLsYdzhoTnA==
   dependencies:
     "@types/ua-parser-js" "^0.7.36"
     ua-parser-js "^1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2179,6 +2179,14 @@
     ts-node "^8.4.1"
     uuid "^8.3.2"
 
+"@hedviginsurance/hanalytics-client@1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@hedviginsurance/hanalytics-client/-/hanalytics-client-1.0.6.tgz#ada043f6509c5e5caff9dede2d45ff7a4e2bbde6"
+  integrity sha512-3o1XOZloEBGPpE4kX86fheMEZehcRlFKr1PfK+29kkP5i7h/3MGLZ3CLYCEfoSSIEQtn9qh5Q9ImrdiDKT1tHQ==
+  dependencies:
+    "@types/ua-parser-js" "^0.7.36"
+    ua-parser-js "^1.0.2"
+
 "@hedviginsurance/textkeyfy@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@hedviginsurance/textkeyfy/-/textkeyfy-2.0.1.tgz#70c0eaf8c674bbec0b50f7c88e46567c5390b2e8"
@@ -4075,6 +4083,11 @@
   integrity sha512-Gk9vaXfbzc5zCXI9eYE9BI5BNHEp4D3FWjgqBE/ePGYElLAP+KvxBcsdkwfIVvezs605oiyd/VrpiHe3Oeg+Aw==
   dependencies:
     "@types/jest" "*"
+
+"@types/ua-parser-js@^0.7.36":
+  version "0.7.36"
+  resolved "https://registry.yarnpkg.com/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz#9bd0b47f26b5a3151be21ba4ce9f5fa457c5f190"
+  integrity sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==
 
 "@types/uglify-js@*":
   version "3.13.0"
@@ -16836,6 +16849,11 @@ ua-parser-js@^0.7.18:
   version "0.7.24"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.24.tgz#8d3ecea46ed4f1f1d63ec25f17d8568105dc027c"
   integrity sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==
+
+ua-parser-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.2.tgz#e2976c34dbfb30b15d2c300b2a53eac87c57a775"
+  integrity sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==
 
 unbox-primitive@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
> This PR integrates https://github.com/HedvigInsurance/hanalytics into Web-Onboarding using its supplied TS client published as `@hedviginsurance/hanalytics-client`

### What is this?

This is a toolkit to collect analytics data type-safely on multiple platforms, we use this in the Android and iOS repositories to make sure we collect analytics data correctly. The data is collected and sent off to a server for processing and then lands in BQ to be analysed.

### Why integrating this on the web?

I was asked to do a POC on how this would integrate into a web target, so here this is.

### Not implemented features (yet)

Feature flags (aka experiments) hAnalytics has built-in support for that in Swift & Kotlin.

