### PR TITLE
bug(GRW-890): apollo cache override

### DIFF
--- a/src/client/apolloClient.ts
+++ b/src/client/apolloClient.ts
@@ -11,6 +11,7 @@ import { SubscriptionClient } from 'subscriptions-transport-ws'
 import { getMainDefinition } from '@apollo/client/utilities'
 import possibleTypes from '../../possibleGraphqlTypes.json'
 import { createSession, Session } from '../shared/sessionStorage'
+import { QuoteBundle } from './data/graphql'
 
 export interface ApolloClientUtils {
   subscriptionClient: SubscriptionClient
@@ -61,6 +62,20 @@ export const apolloClient = (() => {
         },
         InProgressReferral: {
           keyFields: (referral) => referral.name as string,
+        },
+        QuoteBundle: {
+          keyFields: (quoteBundle) => {
+            const quotes = (quoteBundle as QuoteBundle).quotes ?? []
+
+            if (quotes.length === 0) return
+
+            // QuoteBundle:<id>+<id>
+            return quotes.reduce(
+              (id, quote, index) =>
+                (id += `${quote.id}${index < quotes.length - 1 ? '+' : ''}`),
+              'QuoteBundle:',
+            )
+          },
         },
       },
     }),

--- a/src/client/data/graphql.tsx
+++ b/src/client/data/graphql.tsx
@@ -7893,7 +7893,7 @@ export type MutationQuoteCart_CreateSwedishBundleArgs = {
 }
 
 export type MutationQuoteCart_InitWidgetArgs = {
-  input?: Maybe<InitWidgetInput>
+  input: InitWidgetInput
 }
 
 export type MutationCreateQuoteArgs = {
@@ -8339,6 +8339,7 @@ export type Query = {
   contracts: Array<Contract>
   /** Returns whether a member has at least one contract */
   hasContract: Scalars['Boolean']
+  partner: RapioPartner
   quoteBundle: QuoteBundle
   /** Fetch quote cart by its ID. */
   quoteCart: QuoteCart
@@ -8514,6 +8515,10 @@ export type QueryHouseInformationArgs = {
 export type QueryAutoCompleteAddressArgs = {
   input: Scalars['String']
   options?: Maybe<AddressAutocompleteOptions>
+}
+
+export type QueryPartnerArgs = {
+  id: Scalars['ID']
 }
 
 export type QueryQuoteBundleArgs = {
@@ -8732,6 +8737,12 @@ export type QuoteDetails =
 export enum QuoteInitiatedFrom {
   CrossSell = 'CROSS_SELL',
   SelfChange = 'SELF_CHANGE',
+}
+
+export type RapioPartner = {
+  __typename?: 'RapioPartner'
+  id: Scalars['ID']
+  name: Scalars['String']
 }
 
 export type RedeemedCodeV2Result =
@@ -10680,6 +10691,8 @@ export enum TypeOfContract {
   NoHomeContentYouthRent = 'NO_HOME_CONTENT_YOUTH_RENT',
   NoTravel = 'NO_TRAVEL',
   NoTravelYouth = 'NO_TRAVEL_YOUTH',
+  NoAccident = 'NO_ACCIDENT',
+  NoAccidentYouth = 'NO_ACCIDENT_YOUTH',
   DkHomeContentOwn = 'DK_HOME_CONTENT_OWN',
   DkHomeContentRent = 'DK_HOME_CONTENT_RENT',
   DkHomeContentStudentOwn = 'DK_HOME_CONTENT_STUDENT_OWN',
@@ -11738,6 +11751,9 @@ export type CreateQuoteBundleMutation = { __typename?: 'Mutation' } & {
       > & {
           bundle?: Maybe<
             { __typename?: 'QuoteBundle' } & {
+              quotes: Array<
+                { __typename?: 'BundledQuote' } & Pick<BundledQuote, 'id'>
+              >
               possibleVariations: Array<
                 { __typename?: 'QuoteBundleVariant' } & Pick<
                   QuoteBundleVariant,
@@ -11836,6 +11852,9 @@ export type EditBundledQuoteMutation = { __typename?: 'Mutation' } & {
     | ({ __typename?: 'QuoteCart' } & Pick<QuoteCart, 'id'> & {
           bundle?: Maybe<
             { __typename?: 'QuoteBundle' } & {
+              quotes: Array<
+                { __typename?: 'BundledQuote' } & Pick<BundledQuote, 'id'>
+              >
               possibleVariations: Array<
                 { __typename?: 'QuoteBundleVariant' } & Pick<
                   QuoteBundleVariant,
@@ -12223,6 +12242,9 @@ export type QuoteCartQuery = { __typename?: 'Query' } & {
   > & {
       bundle?: Maybe<
         { __typename?: 'QuoteBundle' } & {
+          quotes: Array<
+            { __typename?: 'BundledQuote' } & Pick<BundledQuote, 'id'>
+          >
           possibleVariations: Array<
             { __typename?: 'QuoteBundleVariant' } & Pick<
               QuoteBundleVariant,
@@ -13563,6 +13585,9 @@ export const CreateQuoteBundleDocument = gql`
       ... on QuoteCart {
         id
         bundle {
+          quotes {
+            id
+          }
           possibleVariations {
             id
             tag(locale: $locale)
@@ -13739,6 +13764,9 @@ export const EditBundledQuoteDocument = gql`
       ... on QuoteCart {
         id
         bundle {
+          quotes {
+            id
+          }
           possibleVariations {
             id
             tag(locale: $locale)
@@ -14421,6 +14449,9 @@ export const QuoteCartDocument = gql`
     quoteCart(id: $id) {
       id
       bundle {
+        quotes {
+          id
+        }
         possibleVariations {
           id
           tag(locale: $locale)

--- a/src/client/graphql/CreateQuoteBundle.graphql
+++ b/src/client/graphql/CreateQuoteBundle.graphql
@@ -1,8 +1,15 @@
-mutation CreateQuoteBundle($quoteCartId: ID!, $quotes: [JSON!]!, $locale: Locale!) {
+mutation CreateQuoteBundle(
+  $quoteCartId: ID!
+  $quotes: [JSON!]!
+  $locale: Locale!
+) {
   quoteCart_createQuoteBundle(id: $quoteCartId, input: { payload: $quotes }) {
     ... on QuoteCart {
       id
       bundle {
+        quotes {
+          id
+        }
         possibleVariations {
           id
           tag(locale: $locale)

--- a/src/client/graphql/EditBundleQuote.graphql
+++ b/src/client/graphql/EditBundleQuote.graphql
@@ -8,6 +8,9 @@ mutation EditBundledQuote(
     ... on QuoteCart {
       id
       bundle {
+        quotes {
+          id
+        }
         possibleVariations {
           id
           tag(locale: $locale)

--- a/src/client/graphql/QuoteCart.graphql
+++ b/src/client/graphql/QuoteCart.graphql
@@ -2,6 +2,9 @@ query QuoteCart($id: ID!, $locale: Locale!) {
   quoteCart(id: $id) {
     id
     bundle {
+      quotes {
+        id
+      }
       possibleVariations {
         id
         tag(locale: $locale)


### PR DESCRIPTION
## What?

* Provide to _apollo_ InMemoryCache a way to generate an id for `QuoteBundle` types: it relies on quote ids;
* Update _graphql_ quoteCart related queries/mutations so we fetch quote ids while working with that type;

## Why?

`QuoteCart` type [defines a field called `bundle`](https://github.com/HedvigInsurance/giraffe/blob/master/src%2Fresolvers%2Fquote-cart%2FquoteCart.graphqls#L89) which type, [`QuoteBundle`](https://github.com/HedvigInsurance/giraffe/blob/master/src%2Fresolvers%2Fquote-bundle%2FquoteBundle.graphqls#L9), doesn't have a explicit form of identification. As a consequence, we might face some issues with _apollo_ caching as some queries might override the cache which may cause problems. 

To solve this issue we can provide to _apollo_ `InMemoryCache` a way to define a custom id for `QuoteBundle` type and make sure we fetch the necessary data for that id be built while working with that type.

**Ticket(s): [GRW-890](https://hedvig.atlassian.net/browse/GRW-890)**

## Drawbacks

* We need to keep in mind that it's **really important** to request `quotes { id }` while working with `QuoteBundle` type. Otherwise the custom id generation will not work;
* Apollo cache increases significantly  during editions because we don't clear cache stale data while creating a new quote bundle. I've tested with `editQuote` api real quick and it seems this problem doesn't happen with it (which make sense, since we're not creating new quotes but just updating them).

## How test it

You can access the [review app](https://web-onboardi-bug-grw-89-ynytlz.herokuapp.com/se-en/new-member/offer/3934f0ce-5118-4123-8d59-9a5bd28b9673) and check _Cache_ tab into _Apollo Dev Tools_. It should be able to see that `QuoteBundle` types are being normalised:

<img width="836" alt="Screenshot 2022-03-09 at 13 23 59" src="https://user-images.githubusercontent.com/19200662/157441740-a121d8ec-7ff2-4b15-95e8-f472acfe56bf.png">

### [Review app](https://web-onboardi-bug-grw-89-ynytlz.herokuapp.com/se-en/new-member/offer/3934f0ce-5118-4123-8d59-9a5bd28b9673)

### Related with

[chore: update due graphl api type changes](https://github.com/HedvigInsurance/web-onboarding/pull/856)

