### PR TITLE
fix(GRW-896): remove no combo discount badge

### DIFF
--- a/src/client/components/CampaignBadge/CampaignBadge.tsx
+++ b/src/client/components/CampaignBadge/CampaignBadge.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled'
 import { Badge, BadgeProps } from 'components/Badge/Badge'
 
 import { useAppliedCampaignNameQuery } from 'data/graphql'
-import { useTextKeys } from 'utils/textKeys'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 
 /* https://coryrylan.com/blog/css-gap-space-with-flexbox */
@@ -23,19 +22,16 @@ const InlineFlexGap = styled.div`
 
 export type CampaignBadgeProps = Omit<BadgeProps, 'children'> & {
   quoteCartId: string
-  isNorwegianBundle: boolean
 }
 
 export const CampaignBadge: React.FC<CampaignBadgeProps> = ({
   className,
   quoteCartId,
-  isNorwegianBundle,
   ...others
 }) => {
   const { isoLocale } = useCurrentLocale()
-  const textKeys = useTextKeys()
 
-  const { data: campaignData, loading } = useAppliedCampaignNameQuery({
+  const { data: campaignData } = useAppliedCampaignNameQuery({
     variables: {
       quoteCartId,
       locale: isoLocale,
@@ -43,20 +39,11 @@ export const CampaignBadge: React.FC<CampaignBadgeProps> = ({
   })
   const campaignText = campaignData?.quoteCart.campaign?.displayValue ?? ''
 
-  const discounts: Array<React.ReactNode> = [
-    ...(isNorwegianBundle ? [textKeys.SIDEBAR_NO_BUNDLE_CAMPAIGN_TEXT()] : []),
-    ...(campaignText ? [campaignText] : []),
-  ]
-
-  if (loading || discounts.length === 0) return null
+  if (!campaignText) return null
 
   return (
     <InlineFlexGap className={className}>
-      {discounts.map((text, index) => (
-        <Badge key={index} {...others}>
-          {text}
-        </Badge>
-      ))}
+      <Badge {...others}>{campaignText}</Badge>
     </InlineFlexGap>
   )
 }

--- a/src/client/components/DiscountTag/DiscountTag.tsx
+++ b/src/client/components/DiscountTag/DiscountTag.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import { useRedeemedCampaignsQuery } from 'data/graphql'
 import { getDiscountText } from 'pages/OfferNew/Introduction/Sidebar/utils'
 import { OfferData } from 'pages/OfferNew/types'
-import { isNorwegianBundle } from 'pages/OfferNew/utils'
 import { useTextKeys } from 'utils/textKeys'
 import { Badge } from '../Badge/Badge'
 
@@ -33,17 +32,11 @@ export const DiscountTag: React.FC<DiscountTagProps> = ({ offerData }) => {
     offerData.cost.monthlyGross.currency,
   )
 
-  const discounts: Array<React.ReactNode> = [
-    ...(isNorwegianBundle(offerData)
-      ? [textKeys.SIDEBAR_NO_BUNDLE_DISCOUNT_TEXT()]
-      : []),
-    ...(discountText ? [discountText] : []),
-  ]
-  return discounts.length > 0 ? (
+  if (!discountText) return null
+
+  return (
     <DiscountInfo>
-      {discounts.map((text, index) => (
-        <Badge key={index}>{text}</Badge>
-      ))}
+      <Badge>{discountText}</Badge>
     </DiscountInfo>
-  ) : null
+  )
 }

--- a/src/client/pages/Landing/landingPageData.ts
+++ b/src/client/pages/Landing/landingPageData.ts
@@ -51,7 +51,6 @@ export const getProductsData = (): ProductsData => {
         linkSlug: isQuoteCartEnabled ? '/home-travel' : '/combo',
         headline: 'STARTPAGE_COMBO_HEADLINE',
         paragraph: 'STARTPAGE_COMBO_BODY',
-        badge: 'STARTPAGE_COMBO_DISCOUNT_TEXT',
       },
       {
         id: 'norwegianContents',

--- a/src/client/pages/Offer/Checkout/index.tsx
+++ b/src/client/pages/Offer/Checkout/index.tsx
@@ -19,7 +19,6 @@ import {
 import {
   getUniqueQuotesFromVariantList,
   getQuoteIdsFromBundleVariant,
-  isNorwegianBundle,
 } from 'pages/OfferNew/utils'
 import { PriceBreakdown } from 'pages/OfferNew/common/PriceBreakdown'
 import { useStorage } from 'utils/StorageContainer'
@@ -29,7 +28,6 @@ import { useFeature, Features } from 'utils/hooks/useFeature'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 import { CloseButton } from 'components/CloseButton/CloseButton'
 import { CampaignBadge } from 'components/CampaignBadge/CampaignBadge'
-import { DiscountTag } from 'components/DiscountTag/DiscountTag'
 import { setupQuoteCartSession } from 'containers/SessionContainer'
 import { useVariation } from 'utils/hooks/useVariation'
 import { StartDate } from 'pages/Offer/Introduction/Sidebar/StartDate'
@@ -514,12 +512,7 @@ export const Checkout = ({
           <InnerWrapper>
             <CloseButton onClick={onClose} />
             <Section>
-              <StyledCampaignBadge
-                quoteCartId={quoteCartId}
-                isNorwegianBundle={isNorwegianBundle(offerData)}
-              >
-                <DiscountTag offerData={offerData} />
-              </StyledCampaignBadge>
+              <StyledCampaignBadge quoteCartId={quoteCartId} />
               <Heading>{textKeys.CHECKOUT_HEADING()}</Heading>
               <PriceBreakdown
                 offerData={offerData}

--- a/src/client/pages/Offer/Introduction/Sidebar/index.tsx
+++ b/src/client/pages/Offer/Introduction/Sidebar/index.tsx
@@ -23,7 +23,6 @@ import {
   LARGE_SCREEN_MEDIA_QUERY,
   SMALL_SCREEN_MEDIA_QUERY,
 } from 'utils/mediaQueries'
-import { isNorwegianBundle } from 'pages/OfferNew/utils'
 import { TOP_BAR_Z_INDEX } from 'components/TopBar'
 
 import { StickyBottomSidebar } from '../../../OfferNew/Introduction/Sidebar/StickyBottomSidebar'
@@ -185,10 +184,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         {() => (
           <Wrapper data-testid="offer-sidebar">
             <Container>
-              <StyledCampaignBadge
-                quoteCartId={quoteCartId}
-                isNorwegianBundle={isNorwegianBundle(offerData)}
-              />
+              <StyledCampaignBadge quoteCartId={quoteCartId} />
               <Header>
                 <Title>Hedvig</Title>
                 <Price

--- a/src/client/pages/OfferNew/utils.ts
+++ b/src/client/pages/OfferNew/utils.ts
@@ -305,9 +305,6 @@ export const isNoDiscount = (campaigns: Campaign[]) =>
     campaigns[0].incentive.__typename === 'NoDiscount') ||
   false
 
-export const isNorwegianBundle = (offerData: OfferData): boolean =>
-  isBundle(offerData) && isNorwegian(offerData)
-
 // TODO: Make Contract Types more generic
 export type HomeInsuranceTypeOfContract = Exclude<
   TypeOfContract,


### PR DESCRIPTION
## What?

Removes "25% DISCOUNT" badge from NO Combo (Home & Travel)

## Why?

That discount is not applicable anymore

## Screenshots / recordings

### Before

<img width="1341" alt="Screenshot 2022-03-10 at 16 32 32" src="https://user-images.githubusercontent.com/19200662/157696147-c584e270-726e-4edd-b9ed-388d0bb2ec66.png">

<img width="1341" alt="Screenshot 2022-03-10 at 16 32 39" src="https://user-images.githubusercontent.com/19200662/157696110-984d0864-0005-4109-b85e-5eb9e314f923.png">

<img width="1341" alt="Screenshot 2022-03-10 at 16 32 43" src="https://user-images.githubusercontent.com/19200662/157696159-c3514ac1-5bca-4667-812d-55fd292aab36.png">

### After

<img width="1186" alt="Screenshot 2022-03-10 at 15 56 59" src="https://user-images.githubusercontent.com/19200662/157688837-948c136f-51d6-40af-a805-122adb2431ad.png">

<img width="1258" alt="Screenshot 2022-03-10 at 16 22 12" src="https://user-images.githubusercontent.com/19200662/157693862-8813d004-033c-4a86-9205-5aa558fdaead.png">

<img width="1242" alt="Screenshot 2022-03-10 at 16 31 16" src="https://user-images.githubusercontent.com/19200662/157695878-a1741a2a-1d96-4a52-b6eb-4454d0cb4942.png">


## Ticket

[GRW-896](https://hedvig.atlassian.net/browse/GRW-896)