### PR TITLE
Fix address display without floor

### DIFF
--- a/src/client/pages/Offer/Checkout/InsuranceSummaryDetails.tsx
+++ b/src/client/pages/Offer/Checkout/InsuranceSummaryDetails.tsx
@@ -172,7 +172,7 @@ const getQuoteDetails = (
             street: homeData.street,
             zipCode: homeData.zipCode,
             apartment: data.apartment,
-            floor: data.floor?.toString(),
+            floor: data.floor,
           }),
         },
         {

--- a/src/client/pages/Offer/utils.ts
+++ b/src/client/pages/Offer/utils.ts
@@ -4,14 +4,14 @@ export interface Address {
   street: string
   zipCode: string
   apartment?: string
-  floor: number
+  floor?: number
 }
 
 export const parseAddress = (address: Address) => {
   const { street, apartment, floor } = address
 
   return street
-    .concat(floor !== 0 ? `, ${floor}.` : '')
+    .concat(floor && floor !== 0 ? `, ${floor}.` : '')
     .concat(apartment ? ` ${apartment}` : '')
 }
 

--- a/src/client/pages/Offer/utils.ts
+++ b/src/client/pages/Offer/utils.ts
@@ -1,20 +1,26 @@
 import { BundledQuote } from 'data/graphql'
-import { Address } from 'pages/OfferNew/types'
+
+export interface Address {
+  street: string
+  zipCode: string
+  apartment?: string
+  floor: number
+}
 
 export const parseAddress = (address: Address) => {
   const { street, apartment, floor } = address
 
   return street
-    .concat(floor ? `, ${floor}.` : '')
+    .concat(floor !== 0 ? `, ${floor}.` : '')
     .concat(apartment ? ` ${apartment}` : '')
 }
 
-export const getAddress = (quotes: BundledQuote[]) => {
-  const hasAddress = (quote: BundledQuote) => {
-    const interestedInFields = ['street', 'zipCode'] as const
-    return interestedInFields.every((field) => quote.data[field] != null)
-  }
+const hasAddress = (quote: BundledQuote) => {
+  const interestedInFields = ['street', 'zipCode'] as const
+  return interestedInFields.every((field) => quote.data[field] != null)
+}
 
+export const getAddress = (quotes: BundledQuote[]) => {
   const quoteWithAddress = quotes.find(hasAddress)
 
   return quoteWithAddress
@@ -22,7 +28,7 @@ export const getAddress = (quotes: BundledQuote[]) => {
         street: quoteWithAddress.data.street,
         zipCode: quoteWithAddress.data.zipCode,
         apartment: quoteWithAddress.data.apartment,
-        floor: quoteWithAddress.data.floor?.toString(),
+        floor: quoteWithAddress.data.floor,
       })
     : ''
 }

--- a/src/client/pages/OfferNew/types.ts
+++ b/src/client/pages/OfferNew/types.ts
@@ -72,7 +72,7 @@ export type GenericQuoteData = {
   livingSpace?: number
   subType?: string
   apartment?: string
-  floor: number
+  floor?: number
 
   ancillaryArea?: number
   numberOfBathrooms?: number

--- a/src/client/pages/OfferNew/types.ts
+++ b/src/client/pages/OfferNew/types.ts
@@ -72,7 +72,7 @@ export type GenericQuoteData = {
   livingSpace?: number
   subType?: string
   apartment?: string
-  floor?: number
+  floor: number
 
   ancillaryArea?: number
   numberOfBathrooms?: number


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

Update `GenericQuoteData`: floor is always a number.
Refactor `getAddress` to not include floor if "0".

## Why?

The floor was displayed for all addresses (even house) but shouldn't.

**Ticket(s): [GRW-924]**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->



[GRW-924]: https://hedvig.atlassian.net/browse/GRW-924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ