### PR TITLE
test(se-needer-house): update button label

### DIFF
--- a/e2e/cypress/integration/se-needer-house-flow.spec.ts
+++ b/e2e/cypress/integration/se-needer-house-flow.spec.ts
@@ -59,7 +59,7 @@ it('should get a price quote for a Swedish house', async () => {
     .type(`${faker.datatype.number({ min: 1930, max: 2010 })}{enter}`)
 
   // baths
-  cy.contains('button', 'Two bathrooms', { timeout: 1000 }).click()
+  cy.contains('button', '2', { timeout: 1000 }).click()
 
   // floors
   cy.contains('button', 'Four floors or less', { timeout: 1000 }).click()


### PR DESCRIPTION
## What?

Update _Se Needer House Flow_ e2e test so the assertion looks for the right label


## Why?

Is expected the button having the label "2" instead of "Two bathrooms"

<img width="1190" alt="Screenshot 2022-03-24 at 10 53 28" src="https://user-images.githubusercontent.com/19200662/159890372-530758bd-89de-41b3-925c-e20e4349eebc.png">

