### PR TITLE
bug(GRW-952): details modal save

### DIFF
--- a/src/client/components/ModalNew.tsx
+++ b/src/client/components/ModalNew.tsx
@@ -41,7 +41,7 @@ type ModalContainerProps = {
 }
 
 const ModalContainer = styled(motion.div)<ModalContainerProps>`
-  position: relative;
+  position: absolute;
   left: 50%;
   top: 50%;
   width: 100%;
@@ -55,7 +55,6 @@ const ModalContainer = styled(motion.div)<ModalContainerProps>`
   max-height: 56rem;`}
   background: ${colorsV3.gray100};
   border-radius: 8px;
-  position: absolute;
   transform: translateX(-50%) translateY(-50%);
   box-shadow: 0 0 14px rgba(0, 0, 0, 0.06);
   overflow-y: auto;
@@ -171,7 +170,7 @@ const Footer = styled.div<ModalFooterProps>`
   align-items: center;
   justify-content: center;
   ${({ sticky }) =>
-    !sticky &&
+    sticky &&
     `
     box-shadow: 0px -4px 8px rgba(0, 0, 0, 0.05), 0px -8px 16px rgba(0, 0, 0, 0.05);
     background: ${colorsV3.white};
@@ -180,6 +179,6 @@ const Footer = styled.div<ModalFooterProps>`
 `}
 `
 
-export const ModalFooter = ({ children }: ModalFooterProps) => {
-  return <Footer>{children}</Footer>
+export const ModalFooter = ({ children, sticky = true }: ModalFooterProps) => {
+  return <Footer sticky={sticky}>{children}</Footer>
 }

--- a/src/client/pages/Offer/Introduction/DetailsModal/index.tsx
+++ b/src/client/pages/Offer/Introduction/DetailsModal/index.tsx
@@ -284,8 +284,8 @@ export const DetailsModal = ({
       >
         {(formikProps) => (
           <>
-            <Container>
-              <Form>
+            <Form>
+              <Container>
                 <Headline>{textKeys.DETAILS_MODULE_HEADLINE()}</Headline>
                 <p>{textKeys.DETAILS_MODULE_BODY()}</p>
                 <Details
@@ -293,46 +293,51 @@ export const DetailsModal = ({
                   type={mainQuoteType}
                   formikProps={formikProps}
                 />
-              </Form>
-            </Container>
-            <ModalFooter>
-              <ButtonGroup fullWidth>
-                <Button
-                  type="submit"
-                  fullWidth
-                  disabled={isBundleCreationInProgress || !formikProps.isValid}
-                >
-                  {textKeys.DETAILS_MODULE_BUTTON()}
-                </Button>
-                <Button
-                  background={colorsV3.white}
-                  foreground={colorsV3.black}
-                  border
-                  fullWidth
-                  onClick={onClose}
-                >
-                  {textKeys.CLOSE()}
-                </Button>
-              </ButtonGroup>
+              </Container>
 
-              {isUnderwritingGuidelinesHit ? (
-                <ErrorMessage>
-                  {textKeys.DETAILS_MODULE_BUTTON_UNDERWRITING_GUIDELINE_HIT()}
-                </ErrorMessage>
-              ) : (
-                (unexpectedQuoteBundleError || isQuoteCreationFailed) && (
+              <ModalFooter>
+                <ButtonGroup fullWidth>
+                  <Button
+                    type="submit"
+                    fullWidth
+                    disabled={
+                      isBundleCreationInProgress || !formikProps.isValid
+                    }
+                  >
+                    {textKeys.DETAILS_MODULE_BUTTON()}
+                  </Button>
+                  <Button
+                    background={colorsV3.white}
+                    foreground={colorsV3.black}
+                    border
+                    fullWidth
+                    onClick={onClose}
+                  >
+                    {textKeys.CLOSE()}
+                  </Button>
+                </ButtonGroup>
+
+                {isUnderwritingGuidelinesHit ? (
                   <ErrorMessage>
-                    {textKeys.DETAILS_MODULE_BUTTON_ERROR()}
+                    {textKeys.DETAILS_MODULE_BUTTON_UNDERWRITING_GUIDELINE_HIT()}
                   </ErrorMessage>
-                )
-              )}
-
-              {!unexpectedQuoteBundleError &&
-                !isQuoteCreationFailed &&
-                !isUnderwritingGuidelinesHit && (
-                  <Warning>{textKeys.DETAILS_MODULE_BUTTON_WARNING()}</Warning>
+                ) : (
+                  (unexpectedQuoteBundleError || isQuoteCreationFailed) && (
+                    <ErrorMessage>
+                      {textKeys.DETAILS_MODULE_BUTTON_ERROR()}
+                    </ErrorMessage>
+                  )
                 )}
-            </ModalFooter>
+
+                {!unexpectedQuoteBundleError &&
+                  !isQuoteCreationFailed &&
+                  !isUnderwritingGuidelinesHit && (
+                    <Warning>
+                      {textKeys.DETAILS_MODULE_BUTTON_WARNING()}
+                    </Warning>
+                  )}
+              </ModalFooter>
+            </Form>
           </>
         )}
       </Formik>


### PR DESCRIPTION
## What?

Fix a bug where Details Modal wasn't triggering a API request when "Save" button is clicked;

**Ticket(s): [GRW-952](https://hedvig.atlassian.net/browse/GRW-952)**


## Screenshots / recordings 

https://user-images.githubusercontent.com/19200662/160577492-85ea90d2-ee20-47c8-a756-ab5322341270.mov

### [Review app](https://web-onboardi-bug-grw-95-ysdyyi.herokuapp.com/se-en/new-member/offer/049f731b-3b97-4b64-aaf6-85b82d871110)

