### PR TITLE
feat(GRW-936): bump embark@2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.23",
     "@hedviginsurance/brand": "^4.1.0",
-    "@hedviginsurance/embark": "^2.6.1",
+    "@hedviginsurance/embark": "^2.7.0",
     "@segment/snippet": "^4.4.0",
     "@sentry/node": "^6.10.0",
     "@sentry/react": "^6.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2193,10 +2193,10 @@
   resolved "https://registry.yarnpkg.com/@hedviginsurance/brand/-/brand-4.2.0.tgz#88fcfe7f3c2caa4b68749e72194426835fb2470a"
   integrity sha512-812uhERaj+xRyTi/VMjOcYviMwfpc/DFYWBqFKy3LqUyyIBRQONRSJJ9MbPy82n2wKHZAtxG5aB4j74miO051g==
 
-"@hedviginsurance/embark@^2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.6.1.tgz#7c9a513c76a4ffd3c2b31ab5b86c5e70af772324"
-  integrity sha512-73xvNpQHQeK3qAfxQ+n1iflEhzqpuTUexYrOOAWbehqPzF6HBNYKTh9C+4MU1aunmiApyEIbjpMpietFug/+GA==
+"@hedviginsurance/embark@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.7.0.tgz#1c83a7645c8878a18ef267fb758fb9e9d63b7dda"
+  integrity sha512-5pkLSJrCBcaUSt8VIThYYlD5N6Aszwba2ws0lU/yI4TcWFSjiIuJJ/2xI3J/X2fDN+cYh3EkG9TX1Rhy5rMWvA==
   dependencies:
     "@emotion/react" "^11.4.1"
     "@emotion/styled" "^11.3.0"


### PR DESCRIPTION
## What?

Bumps `embark@2.6.1` --> `embark@2.7.0`


## Why?

So it get's access to _Single Option Select Action_

![image](https://user-images.githubusercontent.com/19200662/161242084-372547bc-a1b9-4b0c-9c2f-c27aca934186.png)

## [Ticket](https://hedvig.atlassian.net/browse/GRW-936)

