### PR TITLE
feat(GRW-955): expose NO onboarding flow

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -38,6 +38,7 @@ enum EmbarkStory {
   NorwayHomeContentNorwegianQuoteCart = 'Web Onboarding NO - Norwegian Contents Quote Cart',
   NorwayComboEnglishQuoteCart = 'Web Onboarding NO - English Combo Quote Cart',
   NorwayComboNorwegianQuoteCart = 'Web Onboarding NO - Norwegian Combo Quote Cart',
+  NorwayOnboarding = 'onboarding-NO',
 
   SwedenNeeder = 'Web Onboarding SE - Needer',
   SwedenSwitcher = 'Web Onboarding SE - Switcher',
@@ -329,6 +330,12 @@ export const routes: Route[] = [
                       locale === 'no'
                         ? EmbarkStory.NorwayComboNorwegianQuoteCart
                         : EmbarkStory.NorwayComboEnglishQuoteCart,
+                    quoteCart: true,
+                  }
+                case 'onboarding':
+                  return {
+                    baseUrl,
+                    name: EmbarkStory.NorwayOnboarding,
                     quoteCart: true,
                   }
               }


### PR DESCRIPTION
## What?

Expose `onboarding-NO` embark flow to support selling _Accident Insurance_ in _NO_.

## Why?

As part of _Pentagon Accident NO_ project, we have:

- Merged all Norwegian _Embark_ flows into a single one: `onboarding-NO` (which already covers the selling of _Accident_ insurance)
- Created a new _Landing Page_ for _NO_ which is implemented under `racoon` project. However, instead of moving all _load Embark story_ logic into `racoon` right now we've decided to accomplish _Pentagon Accident NO_ project on it's early stages by redirecting from `racoon` -> `web-onboarding`. But first we need to make the new flow available on `web-onboarding`: That's what this PR is all about. 

<img width="397" alt="image" src="https://user-images.githubusercontent.com/19200662/162163967-0a9c4c2c-c707-456f-934f-7b937434bfe6.png"> 

**Ticket(s): [GRW-955](https://hedvig.atlassian.net/browse/GRW-955)**