### PR TITLE
Switch to new Hedvig fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@datadog/browser-rum": "^4.7.0",
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.23",
-    "@hedviginsurance/brand": "^4.1.0",
+    "@hedviginsurance/brand": "^5.0.0",
     "@hedviginsurance/embark": "^2.9.1",
     "@segment/snippet": "^4.4.0",
     "@sentry/node": "^6.10.0",

--- a/src/client/components/DetailsModal/index.tsx
+++ b/src/client/components/DetailsModal/index.tsx
@@ -49,7 +49,7 @@ const Container = styled.div`
 `
 
 const Headline = styled.div`
-  font-family: ${fonts.FAVORIT};
+  font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   font-size: 2.5rem;
   line-height: 3.5rem;
   color: ${colorsV3.black};

--- a/src/client/components/Headline/Headline.tsx
+++ b/src/client/components/Headline/Headline.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/core'
 import { fonts, colorsV3 } from '@hedviginsurance/brand'
 import { MEDIUM_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
 
-const { FAVORIT } = fonts
+const { HEDVIG_LETTERS_STANDARD } = fonts
 const { gray900, gray100 } = colorsV3
 
 export type Props = {
@@ -26,7 +26,7 @@ const getBaseStyles = ({ colorVariant }: ColorProp) => {
   return css`
     margin: 0;
     padding: 0;
-    font-family: ${FAVORIT};
+    font-family: ${HEDVIG_LETTERS_STANDARD};
     font-weight: 400;
     color: ${color};
   `

--- a/src/client/components/Headline/Headline.tsx
+++ b/src/client/components/Headline/Headline.tsx
@@ -35,56 +35,51 @@ const getBaseStyles = ({ colorVariant }: ColorProp) => {
 const HeadlineXL = styled.span<StyleProps>`
   ${({ colorVariant }) => getBaseStyles({ colorVariant })}
   font-size: 3.5rem;
-  line-height: 4rem;
+  line-height: 1.2;
   letter-spacing: -0.02em;
 
   ${MEDIUM_SCREEN_MEDIA_QUERY} {
     font-size: 4.5rem;
-    line-height: 4.5rem;
   }
 `
 const HeadlineL = styled.span<StyleProps>`
   ${({ colorVariant }) => getBaseStyles({ colorVariant })}
   font-size: 2.5rem;
-  line-height: 2.75rem;
-  letter-spacing: -0.02em;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
 
   ${MEDIUM_SCREEN_MEDIA_QUERY} {
     font-size: 3.5rem;
-    line-height: 4rem;
+    letter-spacing: -0.02em;
   }
 `
 const HeadlineM = styled.span<StyleProps>`
   ${({ colorVariant }) => getBaseStyles({ colorVariant })}
   font-size: 2rem;
-  line-height: 2.5rem;
-  letter-spacing: -0.02em;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
 
   ${MEDIUM_SCREEN_MEDIA_QUERY} {
     font-size: 3rem;
-    line-height: 3.5rem;
   }
 `
 const HeadlineS = styled.span<StyleProps>`
   ${({ colorVariant }) => getBaseStyles({ colorVariant })}
   font-size: 1.5rem;
-  line-height: 2rem;
-  letter-spacing: -0.02em;
+  line-height: 1.2;
 
   ${MEDIUM_SCREEN_MEDIA_QUERY} {
     font-size: 2rem;
-    line-height: 2.5rem;
+    letter-spacing: -0.01em;
   }
 `
 const HeadlineXS = styled.span<StyleProps>`
   ${({ colorVariant }) => getBaseStyles({ colorVariant })}
   font-size: 1.25rem;
-  line-height: 1.75rem;
-  letter-spacing: -0.02em;
+  line-height: 1.2;
 
   ${MEDIUM_SCREEN_MEDIA_QUERY} {
     font-size: 1.5rem;
-    line-height: 2rem;
   }
 `
 const HeadlineOverline = styled.span<StyleProps>`

--- a/src/client/components/Modal.tsx
+++ b/src/client/components/Modal.tsx
@@ -1,5 +1,5 @@
 import { css, Global } from '@emotion/core'
-import { colors } from '@hedviginsurance/brand'
+import { colorsV3 } from '@hedviginsurance/brand'
 import React from 'react'
 import ReactModal from 'react-modal'
 
@@ -48,7 +48,7 @@ const defaultStyle: ReactModal.Styles = {
     left: '50%',
     borderRadius: 10,
     border: 'none',
-    backgroundColor: colors.WHITE,
+    backgroundColor: colorsV3.white,
   },
 }
 

--- a/src/client/pages/ConnectPayment/components/TrustlyModal.tsx
+++ b/src/client/pages/ConnectPayment/components/TrustlyModal.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { colors } from '@hedviginsurance/brand'
+import { colorsV3 } from '@hedviginsurance/brand'
 import React, { createRef, useEffect, useState } from 'react'
 import { Redirect } from 'react-router-dom'
 import Modal from 'components/Modal'
@@ -9,11 +9,11 @@ import { useTextKeys } from 'utils/textKeys'
 const Header = styled('div')({
   width: '100%',
   height: 40,
-  background: colors.DARK_GREEN,
+  background: '#009175',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  color: colors.WHITE,
+  color: colorsV3.white,
   fontSize: '14px',
   boxShadow: '0 0 11px rgba(0, 0, 0, 0.05)',
 })

--- a/src/client/pages/ConnectPayment/components/TrustlySpinnerPage.tsx
+++ b/src/client/pages/ConnectPayment/components/TrustlySpinnerPage.tsx
@@ -1,6 +1,6 @@
 import { keyframes } from '@emotion/core'
 import styled from '@emotion/styled'
-import { colors } from '@hedviginsurance/brand'
+import { colorsV3 } from '@hedviginsurance/brand'
 import React from 'react'
 
 const Wrapper = styled('div')({
@@ -20,7 +20,7 @@ const Spinner = styled('span')({
   display: 'inline-block',
   width: 32,
   height: 32,
-  border: `2px solid ${colors.LIGHT_GRAY}`,
+  border: `2px solid ${colorsV3.gray300}`,
   borderTopColor: 'transparent',
   borderRadius: '1em',
   animation: `${spin} 500ms linear infinite`,

--- a/src/client/pages/ConnectPayment/sections/ConnectPayment.tsx
+++ b/src/client/pages/ConnectPayment/sections/ConnectPayment.tsx
@@ -82,7 +82,7 @@ const Headline = styled.h1`
   line-height: 2.5rem;
   text-align: center;
   color: ${colorsV3.white};
-  font-family: ${fonts.FAVORIT};
+  font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   font-weight: 400;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {

--- a/src/client/pages/Landing/Landing.tsx
+++ b/src/client/pages/Landing/Landing.tsx
@@ -66,7 +66,8 @@ const Headline = styled.h1`
   margin-top: 0;
   margin-bottom: 1rem;
   font-size: 2rem;
-  letter-spacing: -0.02em;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
 
   ${MEDIUM_SCREEN_MEDIA_QUERY} {
     margin-bottom: 0.75rem;
@@ -74,7 +75,6 @@ const Headline = styled.h1`
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
     font-size: 3rem;
-    line-height: 3.5rem;
   }
 `
 
@@ -82,13 +82,11 @@ const Preamble = styled.p`
   margin-top: 0;
   margin-bottom: 1.25rem;
   font-size: 1.25rem;
-  line-height: 1.4;
+  line-height: 1.2;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
     margin-bottom: 2rem;
     font-size: 1.5rem;
-    line-height: 1.33;
-    letter-spacing: -2%;
   }
 `
 

--- a/src/client/pages/Landing/components/Card.tsx
+++ b/src/client/pages/Landing/components/Card.tsx
@@ -123,12 +123,10 @@ export const CardHeadline = styled.h2<{ disabled?: boolean }>`
   color: ${(props) => (props.disabled ? colorsV3.gray500 : colorsV3.gray900)};
 
   font-size: 1.25rem;
-  line-height: 1.4;
+  line-height: 1.2;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
     font-size: 1.5rem;
-    line-height: 1.33;
-    letter-spacing: -2%;
   }
 `
 

--- a/src/client/pages/Offer/Checkout/InsuranceSummary.tsx
+++ b/src/client/pages/Offer/Checkout/InsuranceSummary.tsx
@@ -12,7 +12,6 @@ const Wrapper = styled.div`
 `
 const Title = styled.div`
   font-size: 1.125rem;
-  letter-spacing: -0.23px;
   font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   padding: 1rem 0;
 `
@@ -23,7 +22,6 @@ const Table = styled.div`
   display: flex;
   flex-direction: column;
   font-size: 0.875rem;
-  letter-spacing: -0.2px;
 `
 export const Group = styled.div`
   display: flex;

--- a/src/client/pages/Offer/Checkout/InsuranceSummary.tsx
+++ b/src/client/pages/Offer/Checkout/InsuranceSummary.tsx
@@ -13,7 +13,7 @@ const Wrapper = styled.div`
 const Title = styled.div`
   font-size: 1.125rem;
   letter-spacing: -0.23px;
-  font-family: ${fonts.FAVORIT};
+  font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   padding: 1rem 0;
 `
 

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummary.tsx
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummary.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled.div`
 `
 const Title = styled.div`
   font-size: 1.125rem;
-  letter-spacing: -0.23px;
+  line-height: 1.2;
   font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   padding: 1rem 0;
 `
@@ -23,7 +23,6 @@ const Table = styled.div`
   display: flex;
   flex-direction: column;
   font-size: 0.875rem;
-  letter-spacing: -0.2px;
 `
 export const Group = styled.div`
   display: flex;

--- a/src/client/pages/OfferNew/Checkout/InsuranceSummary.tsx
+++ b/src/client/pages/OfferNew/Checkout/InsuranceSummary.tsx
@@ -13,7 +13,7 @@ const Wrapper = styled.div`
 const Title = styled.div`
   font-size: 1.125rem;
   letter-spacing: -0.23px;
-  font-family: ${fonts.FAVORIT};
+  font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   padding: 1rem 0;
 `
 

--- a/src/client/pages/OfferNew/Introduction/DetailsModal/index.tsx
+++ b/src/client/pages/OfferNew/Introduction/DetailsModal/index.tsx
@@ -46,7 +46,7 @@ const Container = styled.div`
 `
 
 const Headline = styled.div`
-  font-family: ${fonts.FAVORIT};
+  font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   font-size: 2.5rem;
   line-height: 3.5rem;
   color: ${colorsV3.black};

--- a/src/client/pages/OfferNew/Perils/PerilModal.tsx
+++ b/src/client/pages/OfferNew/Perils/PerilModal.tsx
@@ -68,8 +68,7 @@ const PickerItem = styled('button')`
 
 const PickerItemLabel = styled('div')`
   width: 6.25rem;
-  font-size: 0.9375rem;
-  letter-spacing: -0.23px;
+  font-size: 1rem;
   text-align: center;
   white-space: nowrap;
   color: ${colorsV3.gray700};
@@ -185,23 +184,21 @@ const Content = styled('div')`
 const Title = styled.div`
   font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   font-size: 2.5rem;
-  line-height: 3.5rem;
+  line-height: 1.2;
   color: ${colorsV3.gray900};
   margin-bottom: 1rem;
-  letter-spacing: -0.57px;
+  letter-spacing: -0.01em;
 
   @media (max-width: 600px) {
     font-size: 1.5rem;
-    line-height: 2rem;
     margin-bottom: 0.5rem;
   }
 `
 
 const Description = styled.div`
   font-size: 1.125rem;
-  line-height: 1.625rem;
+  line-height: 1.5;
   color: ${colorsV3.gray900};
-  letter-spacing: -0.26px;
 `
 
 const CoverageWrapper = styled.div`
@@ -241,18 +238,16 @@ const CoverageList = styled.div`
 
 const CoverageListTitle = styled.div`
   font-size: 1rem;
-  line-height: 1.5rem;
+  line-height: 1.5;
   color: ${colorsV3.gray900};
-  letter-spacing: -0.26px;
   font-weight: 600;
   margin-bottom: 0.75rem;
 `
 
 const CoverageListItem = styled.div`
   font-size: 1rem;
-  line-height: 1.5rem;
+  line-height: 1.5;
   color: ${colorsV3.gray700};
-  letter-spacing: -0.26px;
   padding-left: 2rem;
   position: relative;
   margin-bottom: 1rem;
@@ -297,7 +292,6 @@ const InfoBoxTitle = styled.div`
   font-size: 1rem;
   line-height: 1rem;
   color: ${colorsV3.gray900};
-  letter-spacing: -0.26px;
   font-weight: 600;
   margin-bottom: 0.75rem;
 `
@@ -306,7 +300,6 @@ const InfoBoxBody = styled.div`
   font-size: 0.875rem;
   line-height: 1.25rem;
   color: ${colorsV3.gray700};
-  letter-spacing: -0.26px;
 `
 
 export const PerilModal: React.FC<PerilModalProps & ModalProps> = ({

--- a/src/client/pages/OfferNew/Perils/PerilModal.tsx
+++ b/src/client/pages/OfferNew/Perils/PerilModal.tsx
@@ -183,7 +183,7 @@ const Content = styled('div')`
 `
 
 const Title = styled.div`
-  font-family: ${fonts.FAVORIT};
+  font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   font-size: 2.5rem;
   line-height: 3.5rem;
   color: ${colorsV3.gray900};

--- a/src/client/pages/OfferNew/components.tsx
+++ b/src/client/pages/OfferNew/components.tsx
@@ -12,8 +12,8 @@ export * from './common/price'
 export const Heading = styled('h2')`
   font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   font-size: 2rem;
-  line-height: 1.25;
-  letter-spacing: -0.91px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
   margin: 0;
 
   ${MEDIUM_SCREEN_MEDIA_QUERY} {
@@ -25,12 +25,11 @@ export const HeadingXS = styled.h3`
   margin: 0;
   font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   font-size: 1.25rem;
-  line-height: 1.4;
+  line-height: 1.2;
   color: ${colorsV3.gray900};
 
   ${MEDIUM_SCREEN_MEDIA_QUERY} {
     font-size: 1.5rem;
-    line-height: 1.33;
   }
 `
 
@@ -41,8 +40,7 @@ export const HeadingBlack = styled(Heading)`
 export const SubHeading = styled('h2')`
   font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   font-size: 1.5rem;
-  line-height: 1.5rem;
-  letter-spacing: -0.34px;
+  line-height: 1.2;
 
   @media (max-width: 600px) {
     font-size: 1.25rem;
@@ -56,7 +54,7 @@ export const SubHeadingBlack = styled(SubHeading)`
 export const SubSubHeading = styled('h2')`
   font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   font-size: 1.25rem;
-  line-height: 1.25rem;
+  line-height: 1.2rem;
 `
 
 export const SubSubHeadingBlack = styled(SubSubHeading)`
@@ -65,8 +63,7 @@ export const SubSubHeadingBlack = styled(SubSubHeading)`
 
 export const PreHeading = styled('div')`
   font-size: 1rem;
-  line-height: 1.5625rem;
-  letter-spacing: 2.67px;
+  line-height: 1.5;
   color: ${colorsV3.gray500};
   text-transform: uppercase;
   margin-bottom: 1.5625rem;

--- a/src/client/pages/OfferNew/components.tsx
+++ b/src/client/pages/OfferNew/components.tsx
@@ -10,7 +10,7 @@ import { SIDEBAR_WIDTH } from './Introduction/Sidebar/index'
 export * from './common/price'
 
 export const Heading = styled('h2')`
-  font-family: ${fonts.FAVORIT};
+  font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   font-size: 2rem;
   line-height: 1.25;
   letter-spacing: -0.91px;
@@ -23,7 +23,7 @@ export const Heading = styled('h2')`
 
 export const HeadingXS = styled.h3`
   margin: 0;
-  font-family: ${fonts.FAVORIT};
+  font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   font-size: 1.25rem;
   line-height: 1.4;
   color: ${colorsV3.gray900};
@@ -39,7 +39,7 @@ export const HeadingBlack = styled(Heading)`
 `
 
 export const SubHeading = styled('h2')`
-  font-family: ${fonts.FAVORIT};
+  font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   font-size: 1.5rem;
   line-height: 1.5rem;
   letter-spacing: -0.34px;
@@ -54,7 +54,7 @@ export const SubHeadingBlack = styled(SubHeading)`
 `
 
 export const SubSubHeading = styled('h2')`
-  font-family: ${fonts.FAVORIT};
+  font-family: ${fonts.HEDVIG_LETTERS_STANDARD};
   font-size: 1.25rem;
   line-height: 1.25rem;
 `

--- a/src/client/utils/globalStyles.tsx
+++ b/src/client/utils/globalStyles.tsx
@@ -10,11 +10,11 @@ export const GlobalCss: React.SFC = ({ children }) => (
 
         * {
           box-sizing: border-box;
-          font-family: ${fonts.FAVORIT}, sans-serif;
+          font-family: ${fonts.HEDVIG_LETTERS_STANDARD}, sans-serif;
         }
 
         body {
-          font-family: ${fonts.FAVORIT}, sans-serif;
+          font-family: ${fonts.HEDVIG_LETTERS_STANDARD}, sans-serif;
           font-size: 16px;
           line-height: 1.25;
           margin: 0;
@@ -32,7 +32,7 @@ export const GlobalCss: React.SFC = ({ children }) => (
         h4,
         h5,
         h6 {
-          font-family: ${fonts.FAVORIT}, sans-serif;
+          font-family: ${fonts.HEDVIG_LETTERS_STANDARD}, sans-serif;
           font-kerning: none;
           font-weight: 400;
         }

--- a/src/client/utils/globalStyles.tsx
+++ b/src/client/utils/globalStyles.tsx
@@ -11,6 +11,7 @@ export const GlobalCss: React.SFC = ({ children }) => (
         * {
           box-sizing: border-box;
           font-family: ${fonts.HEDVIG_LETTERS_STANDARD}, sans-serif;
+          font-feature-settings: 'liga';
         }
 
         body {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,11 +2183,6 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
   integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
 
-"@hedviginsurance/brand@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@hedviginsurance/brand/-/brand-4.1.0.tgz#e8de34dbfb826c15dbaeb582585c3a5f720b9ced"
-  integrity sha512-TYlxSmMQPiv8+DfgwKrV9B1Xr+vQA5VBx1EdfZR1gZNcc5QDK4Bk90oYC4A5nu3er71RyEHfjlHWJdqfAMGOJQ==
-
 "@hedviginsurance/brand@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@hedviginsurance/brand/-/brand-5.0.0.tgz#b070e0031019ed51b664ee2aa0e59752c01bc07f"


### PR DESCRIPTION
## What?

- Switch to new Hedvig fonts. Instead of FAVORIT we're using HEDVIG_LETTERS_STANDARD
- Bump Embark where I already updated the fonts
- Remove some deprecated colors, not even sure if those components are being used anymore?
- Adjust `line-heights` and `letter-spacing` with a new spec Zak and I worked on. We're now using unit less values for line-heights for ease of use.

![Typography](https://user-images.githubusercontent.com/6661511/164433514-274af79b-6f2f-4324-86ae-554e6ccca33f.png)


## Why?

We're launching the new typeface across all channels on Monday 25/4

## Screenshots / recordings 

https://user-images.githubusercontent.com/6661511/164434878-843149c4-1235-49db-896d-3a56632b55a3.mov


https://user-images.githubusercontent.com/6661511/164434889-0071c203-c2de-4877-9ee6-ebc834426566.mov


