### PR TITLE
GRW-1001 / Feature / Adapt offer page to show car insurance

### DIFF
--- a/src/client/api/createQuoteBundleMutationSelectors.ts
+++ b/src/client/api/createQuoteBundleMutationSelectors.ts
@@ -1,10 +1,14 @@
-import { CreateQuoteBundleMutation, QuoteBundleVariant } from 'data/graphql'
+import {
+  CreateQuoteBundleMutation,
+  QuoteBundleVariant,
+  TypeOfContract,
+} from 'data/graphql'
 import { getBundleVariantFromInsuranceTypesWithFallback } from 'pages/OfferNew/utils'
 import { InsuranceType } from 'utils/hooks/useSelectedInsuranceTypes'
 
 export function getSelectedBundleVariant(
   quoteBundleMutation: CreateQuoteBundleMutation | null | undefined,
-  selectedInsuranceTypes: InsuranceType[],
+  selectedInsuranceTypes: InsuranceType[] | TypeOfContract[],
 ) {
   if (
     quoteBundleMutation?.quoteCart_createQuoteBundle.__typename !== 'QuoteCart'

--- a/src/client/api/quoteBundleSelectors.ts
+++ b/src/client/api/quoteBundleSelectors.ts
@@ -99,3 +99,7 @@ export const includesExactlyAllContracts = (
 
   return bundleInsuranceTypes.every((type) => insuranceTypes.includes(type))
 }
+
+export const getFirstInsuranceType = (bundle: QuoteBundle) => {
+  return bundle.quotes?.[0]?.data.type
+}

--- a/src/client/api/quoteCartQuerySelectors.ts
+++ b/src/client/api/quoteCartQuerySelectors.ts
@@ -1,10 +1,15 @@
-import { QuoteCartQuery, QuoteBundleVariant, BundledQuote } from 'data/graphql'
+import {
+  QuoteCartQuery,
+  QuoteBundleVariant,
+  BundledQuote,
+  TypeOfContract,
+} from 'data/graphql'
 import { getBundleVariantFromInsuranceTypesWithFallback } from 'pages/OfferNew/utils'
 import { InsuranceType } from 'utils/hooks/useSelectedInsuranceTypes'
 
 export function getSelectedBundleVariant(
   quoteCartQuery: QuoteCartQuery | undefined,
-  selectedInsuranceTypes: InsuranceType[],
+  selectedInsuranceTypes: InsuranceType[] | TypeOfContract[],
 ) {
   const bundleVariants = (quoteCartQuery?.quoteCart?.bundle
     ?.possibleVariations ?? []) as Array<QuoteBundleVariant>
@@ -65,4 +70,10 @@ export function getAllQuotes(quoteCartQuery: QuoteCartQuery | undefined) {
   })
 
   return Object.values(quoteMap)
+}
+
+export const isCarInsuranceType = (bundleVariant: QuoteBundleVariant) => {
+  return bundleVariant.bundle.quotes.every(
+    (quote) => quote.data.type === 'SWEDISH_CAR',
+  )
 }

--- a/src/client/pages/Offer/Introduction/HeroOfferDetails.tsx
+++ b/src/client/pages/Offer/Introduction/HeroOfferDetails.tsx
@@ -121,7 +121,7 @@ export const HeroOfferDetails: React.FC<Props> = ({
     return query.get('showEdit') === 'true'
   })
   const { person } = offerData
-  const numberCoInsured = person.householdSize - 1
+  const numberCoInsured = (person.householdSize ?? 0) - 1
 
   const address = getAddress(allQuotes)
 

--- a/src/client/pages/Offer/Introduction/HeroOfferDetails.tsx
+++ b/src/client/pages/Offer/Introduction/HeroOfferDetails.tsx
@@ -121,7 +121,7 @@ export const HeroOfferDetails: React.FC<Props> = ({
     return query.get('showEdit') === 'true'
   })
   const { person } = offerData
-  const numberCoInsured = (person.householdSize ?? 0) - 1
+  const numberCoInsured = (person.householdSize ?? 1) - 1
 
   const address = getAddress(allQuotes)
 

--- a/src/client/pages/Offer/index.tsx
+++ b/src/client/pages/Offer/index.tsx
@@ -23,13 +23,15 @@ import {
   getPossibleVariations,
   getCampaign,
   getMonthlyCostDeductionIncentive,
+  isCarInsuranceType,
 } from 'api/quoteCartQuerySelectors'
 import { trackOfferEvent } from 'utils/tracking/trackOfferEvent'
 import {
   getOfferData,
   getUniqueQuotesFromVariantList,
-  getTypeOfContractFromBundleVariant,
   isOfferDataAvailable,
+  getInsuranceTypesFromBundleVariant,
+  getTypeOfContractFromBundleVariant,
 } from '../OfferNew/utils'
 import { AppPromotionSection } from '../OfferNew/AppPromotionSection'
 import { FaqSection } from '../OfferNew/FaqSection'
@@ -165,7 +167,9 @@ export const OfferPage = ({
     newSelectedBundleVariant: QuoteBundleVariant,
   ) => {
     setSelectedInsuranceTypes(
-      getTypeOfContractFromBundleVariant(newSelectedBundleVariant),
+      isCarInsuranceType(newSelectedBundleVariant)
+        ? getTypeOfContractFromBundleVariant(newSelectedBundleVariant)
+        : getInsuranceTypesFromBundleVariant(newSelectedBundleVariant),
     )
     trackOfferEvent(
       EventName.InsuranceSelectionToggle,
@@ -179,7 +183,9 @@ export const OfferPage = ({
     newSelectedBundleVariant: QuoteBundleVariant,
   ) => {
     setSelectedInsuranceTypes(
-      getTypeOfContractFromBundleVariant(newSelectedBundleVariant),
+      isCarInsuranceType(newSelectedBundleVariant)
+        ? getTypeOfContractFromBundleVariant(newSelectedBundleVariant)
+        : getInsuranceTypesFromBundleVariant(newSelectedBundleVariant),
     )
     trackOfferEvent(
       EventName.OfferCrossSell,

--- a/src/client/pages/Offer/index.tsx
+++ b/src/client/pages/Offer/index.tsx
@@ -28,7 +28,7 @@ import { trackOfferEvent } from 'utils/tracking/trackOfferEvent'
 import {
   getOfferData,
   getUniqueQuotesFromVariantList,
-  getInsuranceTypesFromBundleVariant,
+  getTypeOfContractFromBundleVariant,
   isOfferDataAvailable,
 } from '../OfferNew/utils'
 import { AppPromotionSection } from '../OfferNew/AppPromotionSection'
@@ -165,7 +165,7 @@ export const OfferPage = ({
     newSelectedBundleVariant: QuoteBundleVariant,
   ) => {
     setSelectedInsuranceTypes(
-      getInsuranceTypesFromBundleVariant(newSelectedBundleVariant),
+      getTypeOfContractFromBundleVariant(newSelectedBundleVariant),
     )
     trackOfferEvent(
       EventName.InsuranceSelectionToggle,
@@ -179,7 +179,7 @@ export const OfferPage = ({
     newSelectedBundleVariant: QuoteBundleVariant,
   ) => {
     setSelectedInsuranceTypes(
-      getInsuranceTypesFromBundleVariant(newSelectedBundleVariant),
+      getTypeOfContractFromBundleVariant(newSelectedBundleVariant),
     )
     trackOfferEvent(
       EventName.OfferCrossSell,

--- a/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
+++ b/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
@@ -110,7 +110,7 @@ export const HeroOfferDetails: React.FC<Props> = ({
 }) => {
   const [detailsModalIsOpen, setDetailsModalIsOpen] = useState(false)
   const { person, quotes } = offerData
-  const numberCoInsured = (person.householdSize ?? 0) - 1
+  const numberCoInsured = (person.householdSize ?? 1) - 1
 
   // TODO: Address information is present in offerData.address.
   // We should format that address instead of looking it up again

--- a/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
+++ b/src/client/pages/OfferNew/Introduction/HeroOfferDetails.tsx
@@ -110,7 +110,7 @@ export const HeroOfferDetails: React.FC<Props> = ({
 }) => {
   const [detailsModalIsOpen, setDetailsModalIsOpen] = useState(false)
   const { person, quotes } = offerData
-  const numberCoInsured = person.householdSize - 1
+  const numberCoInsured = (person.householdSize ?? 0) - 1
 
   // TODO: Address information is present in offerData.address.
   // We should format that address instead of looking it up again

--- a/src/client/pages/OfferNew/types.ts
+++ b/src/client/pages/OfferNew/types.ts
@@ -35,7 +35,7 @@ export type OfferPersonInfo = Pick<
   BundledQuote,
   'firstName' | 'lastName' | 'email' | 'ssn' | 'birthDate' | 'phoneNumber'
 > & {
-  householdSize: number
+  householdSize?: number
   address: Address | null
 }
 

--- a/src/client/utils/hooks/useSelectedInsuranceTypes.ts
+++ b/src/client/utils/hooks/useSelectedInsuranceTypes.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { useLocation, useHistory } from 'react-router'
+import { TypeOfContract } from 'data/graphql'
 
 // TODO: we should get this from giraffe schema
 export enum InsuranceType {
@@ -14,7 +15,7 @@ export enum InsuranceType {
   DANISH_TRAVEL = 'DANISH_TRAVEL',
 }
 
-const ALL_INSURANCE_TYPES = Object.values(InsuranceType)
+const ALL_INSURANCE_TYPES = Object.values(TypeOfContract)
 const SEARCH_PARAM_NAME = 'type'
 
 const deserializeSearchParams = (searchParams: URLSearchParams) => {
@@ -26,7 +27,7 @@ const validateInsuranceTypes = (
   rawTypes: Array<string>,
 ): Array<InsuranceType> =>
   rawTypes.filter((type) =>
-    ALL_INSURANCE_TYPES.includes((type as unknown) as InsuranceType),
+    ALL_INSURANCE_TYPES.includes((type as unknown) as TypeOfContract),
   ) as Array<InsuranceType>
 
 export const useSelectedInsuranceTypes = () => {
@@ -40,7 +41,7 @@ export const useSelectedInsuranceTypes = () => {
     searchParams,
   ])
 
-  const changeSelectedInsuranceTypes = (newTypes: Array<InsuranceType>) => {
+  const changeSelectedInsuranceTypes = (newTypes: Array<TypeOfContract>) => {
     searchParams.delete(SEARCH_PARAM_NAME)
 
     for (const type of newTypes) {

--- a/src/client/utils/hooks/useSelectedInsuranceTypes.ts
+++ b/src/client/utils/hooks/useSelectedInsuranceTypes.ts
@@ -15,7 +15,8 @@ export enum InsuranceType {
   DANISH_TRAVEL = 'DANISH_TRAVEL',
 }
 
-const ALL_INSURANCE_TYPES = Object.values(TypeOfContract)
+const ALL_INSURANCE_TYPES = Object.values(InsuranceType)
+const ALL_CONTRACT_TYPES = Object.values(TypeOfContract)
 const SEARCH_PARAM_NAME = 'type'
 
 const deserializeSearchParams = (searchParams: URLSearchParams) => {
@@ -25,9 +26,11 @@ const deserializeSearchParams = (searchParams: URLSearchParams) => {
 
 const validateInsuranceTypes = (
   rawTypes: Array<string>,
-): Array<InsuranceType> =>
-  rawTypes.filter((type) =>
-    ALL_INSURANCE_TYPES.includes((type as unknown) as TypeOfContract),
+): InsuranceType[] | TypeOfContract[] =>
+  rawTypes.filter(
+    (type) =>
+      ALL_INSURANCE_TYPES.includes((type as unknown) as InsuranceType) ||
+      ALL_CONTRACT_TYPES.includes((type as unknown) as TypeOfContract),
   ) as Array<InsuranceType>
 
 export const useSelectedInsuranceTypes = () => {
@@ -41,7 +44,9 @@ export const useSelectedInsuranceTypes = () => {
     searchParams,
   ])
 
-  const changeSelectedInsuranceTypes = (newTypes: Array<TypeOfContract>) => {
+  const changeSelectedInsuranceTypes = (
+    newTypes: Array<InsuranceType | TypeOfContract>,
+  ) => {
     searchParams.delete(SEARCH_PARAM_NAME)
 
     for (const type of newTypes) {

--- a/src/client/utils/tracking/gtm.ts
+++ b/src/client/utils/tracking/gtm.ts
@@ -28,7 +28,7 @@ type GTMUserProperties = {
 type GTMOfferData = {
   insurance_type: TrackableContractType
   referral_code: 'yes' | 'no'
-  number_of_people: number
+  number_of_people?: number
   insurance_price: number
   discounted_premium?: number
   currency: string


### PR DESCRIPTION

## What?

Adapt offer page to be able to show insurances that are not house/apartment

This PR mainly makes sure that the page doesn't crash when a non-house/apartment quote is provided, so that we can fan out the remaining tasks.

* Use contract type to determine which quote bundle that is selected, and what is shown in the URL. This is because all car quote variations have the same quote type, but not same contract type. This also happens to work for other bundles.
* Adapt SummaryDetails to only show information that's available with the current data.

Do we need some regression testing on this before I ship it to production? I have tested to render the offer page with all variations that exist in Sweden and it looks good.


<!-- What changes are made? If there are many changes, a list might be a good format. -->


## Why?

<!-- Why are these changes made? -->

Since we need to sell car insurance in web-onboarding we need to be able to show it in the offer screen. 


**Ticket(s): [GRW-1001]**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

House + accident SE local (just to show that it still works 😁 ):
![image](https://user-images.githubusercontent.com/1343979/165739367-27d16678-07ca-4a5b-8610-5cc42e3ca681.png)


Rendering a car quote cart:

![image](https://user-images.githubusercontent.com/1343979/165736616-f1ed9d98-e91a-4cd6-bd1c-3ab64bfc3c4e.png)

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->



[GRW-1001]: https://hedvig.atlassian.net/browse/GRW-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ