### PR TITLE
change offer-debugger button position

### DIFF
--- a/src/client/pages/OfferDebugger/components/QuoteData.tsx
+++ b/src/client/pages/OfferDebugger/components/QuoteData.tsx
@@ -446,6 +446,18 @@ export const QuoteData = ({ quoteCartId }: OfferProps) => {
         >
           {(props) => (
             <Form>
+              <Button
+                type="submit"
+                size="lg"
+                background={colorsV3.purple500}
+                foreground={colorsV3.gray900}
+                disabled={props.isSubmitting}
+              >
+                Create quote
+                {props.isSubmitting && (
+                  <ButtonLoadingIndicator color={colorsV3.gray900} />
+                )}
+              </Button>
               {!props.isSubmitting && (
                 <>
                   <InputField
@@ -504,19 +516,6 @@ export const QuoteData = ({ quoteCartId }: OfferProps) => {
                   )}
                 </>
               )}
-
-              <Button
-                type="submit"
-                size="lg"
-                background={colorsV3.purple500}
-                foreground={colorsV3.gray900}
-                disabled={props.isSubmitting}
-              >
-                Create quote
-                {props.isSubmitting && (
-                  <ButtonLoadingIndicator color={colorsV3.gray900} />
-                )}
-              </Button>
             </Form>
           )}
         </Formik>


### PR DESCRIPTION

## What?

Changed button in offer-debugger to bring it up.

## Why?

(make life easier ? ) I hate scrolling to the bottom of the page and I never change any of the inputs. This is a personal preference so please let's discuss if it is not good. 

Image : 
![image](https://user-images.githubusercontent.com/63097139/166878237-5c73369b-a3b5-42ec-84cf-de4e19e17e01.png)


