### PR TITLE
GRW-1062 / feat / add table component

### DIFF
--- a/src/client/components/Table/Table.stories.tsx
+++ b/src/client/components/Table/Table.stories.tsx
@@ -1,0 +1,170 @@
+import React from 'react'
+import { Story } from '@storybook/react'
+import { colorsV3 } from '@hedviginsurance/brand'
+import { ThinTick } from '../icons/ThinTick'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableProps,
+  TableRow,
+} from './Table'
+
+export default {
+  title: 'Components/Table',
+  component: Table,
+  parameters: {
+    backgrounds: {
+      default: 'gray100',
+    },
+  },
+  args: {
+    minWidth: '650px',
+  },
+}
+
+function createData(
+  name: string,
+  calories: number,
+  fat: number,
+  carbs: number,
+  protein: number,
+) {
+  return { name, calories, fat, carbs, protein }
+}
+
+const rows = [
+  createData('Frozen yoghurt', 159, 6.0, 24, 4.0),
+  createData('Ice cream sandwich', 237, 9.0, 37, 4.3),
+  createData('Eclair', 262, 16.0, 24, 6.0),
+  createData('Cupcake', 305, 3.7, 67, 4.3),
+  createData('Gingerbread', 356, 16.0, 49, 3.9),
+]
+
+const Template: Story<TableProps> = (args) => (
+  <Table {...args}>
+    <TableHead>
+      <TableRow>
+        <TableCell>Dessert (100g serving)</TableCell>
+        <TableCell align="right">Calories</TableCell>
+        <TableCell align="right">Fat&nbsp;(g)</TableCell>
+        <TableCell align="right">Carbs&nbsp;(g)</TableCell>
+        <TableCell align="right">Protein&nbsp;(g)</TableCell>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      {rows.map((row) => (
+        <TableRow key={row.name}>
+          <TableCell>{row.name}</TableCell>
+          <TableCell align="right">{row.calories}</TableCell>
+          <TableCell align="right">{row.fat}</TableCell>
+          <TableCell align="right">{row.carbs}</TableCell>
+          <TableCell align="right">{row.protein}</TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+)
+
+export const Default = Template.bind({})
+Default.args = {}
+
+function createDataCarInsuranceData(
+  name: string,
+  traffic: boolean,
+  half: boolean,
+  full: boolean,
+) {
+  return { name, traffic, half, full }
+}
+
+const comparisonRows = [
+  createDataCarInsuranceData('Personskador', true, true, true),
+  createDataCarInsuranceData('Skador på annans egendom', true, true, true),
+  createDataCarInsuranceData('Stöld och inbrott', false, true, true),
+  createDataCarInsuranceData('Brand', false, true, true),
+  createDataCarInsuranceData('Glasskador', false, true, true),
+  createDataCarInsuranceData('Bärgning', false, true, true),
+  createDataCarInsuranceData('Skador på bilen från olycka', false, false, true),
+]
+
+const premiumRows = [
+  createDataCarInsuranceData('Personskador', false, true, true),
+  createDataCarInsuranceData('Skador på annans egendom', false, true, true),
+]
+
+const ComparisonTemplate: Story<TableProps> = (args) => (
+  <>
+    <Table {...args}>
+      <TableHead>
+        <TableRow>
+          <TableCell></TableCell>
+          <TableCell align="center">Trafik</TableCell>
+          <TableCell align="center">Halv</TableCell>
+          <TableCell align="center">Hel</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {comparisonRows.map((row) => (
+          <TableRow key={row.name}>
+            <TableCell>{row.name}</TableCell>
+            <TableCell
+              align="center"
+              color={row.traffic ? undefined : colorsV3.gray300}
+            >
+              {row.traffic ? <ThinTick /> : <>&mdash;</>}
+            </TableCell>
+            <TableCell
+              align="center"
+              color={row.half ? undefined : colorsV3.gray300}
+            >
+              {row.half ? <ThinTick /> : <>&mdash;</>}
+            </TableCell>
+            <TableCell
+              align="center"
+              color={row.full ? undefined : colorsV3.gray300}
+            >
+              {row.full ? <ThinTick /> : <>&mdash;</>}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+    <Table {...args} mt="2rem">
+      <TableHead>
+        <TableRow>
+          <TableCell>ENDAST MED PREMIUM</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {premiumRows.map((row) => (
+          <TableRow key={row.name}>
+            <TableCell>{row.name}</TableCell>
+            <TableCell
+              align="center"
+              color={row.traffic ? undefined : colorsV3.gray300}
+            >
+              {row.traffic ? <ThinTick /> : <>&mdash;</>}
+            </TableCell>
+            <TableCell
+              align="center"
+              color={row.half ? undefined : colorsV3.gray300}
+            >
+              {row.half ? <ThinTick /> : <>&mdash;</>}
+            </TableCell>
+            <TableCell
+              align="center"
+              color={row.full ? undefined : colorsV3.gray300}
+            >
+              {row.full ? <ThinTick /> : <>&mdash;</>}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  </>
+)
+
+export const ComparisonTable = ComparisonTemplate.bind({})
+ComparisonTable.args = {}

--- a/src/client/components/Table/Table.test.tsx
+++ b/src/client/components/Table/Table.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { renderComponent } from 'test/utils'
+import { Table, TableBody, TableCell, TableHead, TableRow } from './Table'
+
+describe('Table', () => {
+  it('can render', () => {
+    const { container } = renderComponent(
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell>hello</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>,
+    )
+
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('can render table header', () => {
+    const { container } = renderComponent(
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>hello</TableCell>
+          </TableRow>
+        </TableHead>
+      </Table>,
+    )
+
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/client/components/Table/Table.tsx
+++ b/src/client/components/Table/Table.tsx
@@ -1,0 +1,82 @@
+import styled from '@emotion/styled'
+import React, { createContext, ReactNode, useContext } from 'react'
+import { colorsV3 } from '@hedviginsurance/brand'
+import { getMargins, Margins } from '../utils/margins'
+
+type WithChildrenProps = {
+  children?: ReactNode
+}
+
+export type TableProps = {
+  minWidth?: string
+  maxWidth?: string
+  fullWidth?: boolean
+} & Margins
+
+const Table = styled.table(
+  ({ minWidth, maxWidth, fullWidth, ...props }: TableProps) => ({
+    borderCollapse: 'collapse',
+    borderSpacing: 0,
+    minWidth,
+    maxWidth,
+    width: fullWidth ? '100%' : 'auto',
+    ...getMargins(props),
+  }),
+)
+
+const TableHeadElement = styled.thead()
+// This context is used to conditionally render a `th` inside `thead` elements, and `td` otherwise
+const TableHeadContext = createContext(false)
+
+const TableHead = ({ children }: WithChildrenProps) => {
+  return (
+    <TableHeadContext.Provider value={true}>
+      <TableHeadElement>{children}</TableHeadElement>
+    </TableHeadContext.Provider>
+  )
+}
+
+const TableRow = styled.tr()
+
+const TableBody = styled.tbody()
+
+const getTableCellStyles = ({ align = 'left', color }: TableCellProps) => ({
+  textAlign: align,
+  minWidth: '4rem',
+  color,
+})
+
+type TableCellProps = WithChildrenProps & {
+  align?: 'center' | 'left' | 'right'
+  color?: keyof typeof colorsV3 | undefined | string
+}
+
+const TableCellElement = styled.td((props: TableCellProps) => ({
+  ...getTableCellStyles(props),
+  padding: '0.5rem 0',
+
+  borderBottom: `1px solid ${colorsV3.gray300}`,
+}))
+
+const TableHeadCellElement = styled.th(
+  (props: Omit<TableCellProps, 'color'>) => ({
+    ...getTableCellStyles(props),
+    padding: '1rem 0',
+    fontSize: '0.875rem',
+    fontWeight: 'normal',
+    color: colorsV3.gray700,
+  }),
+)
+
+const TableCell = ({ children, ...props }: TableCellProps) => {
+  const context = useContext(TableHeadContext)
+
+  // Render a `th` when inside a `thead` and `td` otherwise
+  if (context) {
+    return <TableHeadCellElement {...props}>{children}</TableHeadCellElement>
+  }
+
+  return <TableCellElement {...props}>{children}</TableCellElement>
+}
+
+export { Table, TableHead, TableRow, TableCell, TableBody }

--- a/src/client/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/client/components/Table/__snapshots__/Table.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Table can render 1`] = `
+<table
+  class="css-qfk35h-Table e2t7qft0"
+>
+  <tbody
+    class="css-r22c21-TableBody e2t7qft3"
+  >
+    <tr
+      class="css-168pto2-TableRow e2t7qft2"
+    >
+      <td
+        class="css-1y781ub-TableCellElement e2t7qft4"
+      >
+        hello
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`Table can render table header 1`] = `
+<table
+  class="css-qfk35h-Table e2t7qft0"
+>
+  <thead
+    class="css-1q4jspl-TableHeadElement e2t7qft1"
+  >
+    <tr
+      class="css-168pto2-TableRow e2t7qft2"
+    >
+      <th
+        class="css-1dic96-TableHeadCellElement e2t7qft5"
+      >
+        hello
+      </th>
+    </tr>
+  </thead>
+</table>
+`;

--- a/src/client/components/icons/IconsOverview/IconsOverview.tsx
+++ b/src/client/components/icons/IconsOverview/IconsOverview.tsx
@@ -18,6 +18,7 @@ import { Tick } from '../Tick'
 import { Telephone } from '../Telephone'
 import { UnselectedOptionCircle } from '../UnselectedOptionCircle'
 import { ChevronDown } from '../ChevronDown'
+import { ThinTick } from '../ThinTick'
 
 const { gray100, gray300, gray900 } = colorsV3
 
@@ -92,7 +93,10 @@ export const IconsOverview = ({ background }: Props) => {
         <WarningTriangle />
       </IconWrapper>
       <IconWrapper title="Tick">
-        <Tick />
+        <Tick color={colorsV3.gray900} />
+      </IconWrapper>
+      <IconWrapper title="ThinTick">
+        <ThinTick color={colorsV3.gray900} />
       </IconWrapper>
       <IconWrapper title="Telephone">
         <Telephone />

--- a/src/client/components/icons/ThinTick.tsx
+++ b/src/client/components/icons/ThinTick.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { colorsV3 } from '@hedviginsurance/brand'
+import { TickProps } from './Tick'
+
+export const ThinTick = ({ color = colorsV3.gray900 }: TickProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="15"
+    viewBox="0 0 20 15"
+    fill="none"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M19.8818 1.51146L8.15214 14.0915L0.791992 6.41706L1.87459 5.3788L8.13679 11.9084L18.7847 0.488525L19.8818 1.51146Z"
+      fill={color}
+    />
+  </svg>
+)

--- a/src/client/components/utils/margins.ts
+++ b/src/client/components/utils/margins.ts
@@ -1,0 +1,26 @@
+export type Margins = {
+  // margin-left and margin-right
+  mx?: string
+  // margin-top and margin-bottom
+  my?: string
+  // margin-left
+  ml?: string
+  // margin-right
+  mr?: string
+  // margin-top
+  mt?: string
+  // margin-bottom
+  mb?: string
+  // all margins
+  m?: string
+}
+
+export const getMargins = (margins: Margins) => {
+  return {
+    ...(margins.m && { margin: margins.m }),
+    ...(margins.mt && { marginTop: margins.mt || margins.my }),
+    ...(margins.mb && { marginBottom: margins.mb || margins.my }),
+    ...(margins.ml && { marginLeft: margins.ml || margins.mx }),
+    ...(margins.mr && { marginRight: margins.mr || margins.mx }),
+  }
+}


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

This PR:
- Adds `ThinTick` icon which is in Figma files but missing from the repository (will happily take suggestions on naming...)
- Adds margins util so that we can add `mt`, `mx` etc margins for components instead of adding custom styling everywhere
- Adds Table component with API heavily inspired by [MUI](https://mui.com/material-ui/react-table/) and Kent C. Dodds [Compound Components](https://kentcdodds.com/blog/compound-components-with-react-hooks)

<!-- What changes are made? If there are many changes, a list might be a good format. -->


## Why?

GRW-1062 ticket says that we should add a comparison table to the offer page. This is a component for that use-case. One of the stories mimics what we need to show visually.

<!-- Why are these changes made? -->



**Ticket(s): [GRW-1062]**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

Our many ways to show checkmarks:

<img width="733" alt="image" src="https://user-images.githubusercontent.com/1343979/167119857-bbe87dbf-344f-4a36-8a25-e480df3b36f1.png">


Basic data:

<img width="826" alt="image" src="https://user-images.githubusercontent.com/1343979/167102809-9eba5fa7-c680-417d-a8fa-57dcc1369777.png">

As a comparison table:

<img width="974" alt="image" src="https://user-images.githubusercontent.com/1343979/167119670-e46b234b-ee43-4c9b-bd97-8efb0dd9e92d.png">


This is the [Figma sketch](https://www.figma.com/file/HEQXHw3ptHZTltJz38hZ9T/Car-Insurance-%C2%B7-EXPLORATION?node-id=1239%3A18556) that it was based on:
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/1343979/167119362-ddba876c-4e2d-4a2f-92ad-64f9705b1d6c.png">


<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->



[GRW-1062]: https://hedvig.atlassian.net/browse/GRW-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ