### PR TITLE
Revert change to debounce function for SSN

### DIFF
--- a/src/client/pages/Offer/Checkout/UserDetailsForm.tsx
+++ b/src/client/pages/Offer/Checkout/UserDetailsForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import * as Yup from 'yup'
 import { FormikProps } from 'formik'
 import { LocaleData } from 'l10n/locales'
@@ -67,9 +67,12 @@ export const CheckoutDetailsForm: React.FC<{
     submitForm,
   } = formikProps
 
-  const debouncedSubmitForm = debounce(() => {
-    submitForm()
-  }, 500)
+  const debouncedSubmitForm = useCallback(
+    debounce(() => {
+      submitForm()
+    }, 500),
+    [],
+  )
 
   useEffect(() => {
     if (ssn !== initialValues.ssn) debouncedSubmitForm()


### PR DESCRIPTION
## What?

We changed the way the debouncing works in the SSN field on checkout form. This creates an infinite submit loop.

This reverts the change
