### PR TITLE
fix(GRW-1048): NO Accident - Current insurer skip button

### DIFF
--- a/src/client/pages/Offer/Introduction/Sidebar/StartDate.tsx
+++ b/src/client/pages/Offer/Introduction/Sidebar/StartDate.tsx
@@ -160,7 +160,7 @@ const getDefaultDateValue = (
     return parse(startDate, 'yyyy-MM-dd', new Date())
   }
 
-  if (currentInsurer) {
+  if (currentInsurer?.switchable) {
     return null
   }
 
@@ -250,7 +250,7 @@ const DateForm = ({
           )}
           {!loading && (
             <>
-              {!dateValue && currentInsurer && (
+              {currentInsurer?.switchable && !dateValue && (
                 <StartDateLabelSwitcher dataCollectionId={dataCollectionId} />
               )}
               {dateValue && getDateLabel()}
@@ -399,7 +399,7 @@ export const StartDate = ({
             disabled={
               loadingQuoteIds.length > 0 ||
               Boolean(
-                selectedQuotes[0].currentInsurer &&
+                selectedQuotes[0].currentInsurer?.switchable &&
                   !selectedQuotes[0].startDate,
               )
             }
@@ -429,7 +429,9 @@ export const StartDate = ({
                   modal={modal}
                   disabled={
                     loadingQuoteIds.length > 0 ||
-                    Boolean(quote.currentInsurer && !quote.startDate)
+                    Boolean(
+                      quote.currentInsurer?.switchable && !quote.startDate,
+                    )
                   }
                   fieldLayout={
                     isExpandedFirstItem


### PR DESCRIPTION
## What?

Changes the parameters used to determine the necessity of 'locking start date' selection based on _current insurer_

## Why?

The logic used previously in Offer Page for that goal can be described as follow:

> _An insurance that should be cancelled by Hedvig is the one which its quote has a **current insurer associated with it**. With that, there's no point of letting users picking a start date since it can be automatically defined: starts when your old insurance expires_

However that might not be so accurate since there's the possibility of having quotes which its current insurer aren't switchable, which means Hedvig can't cancel them automatically. Therefore, the logic has changed for something that can be described as following:

> _An insurance that should be cancelled by Hedvig is the one which its quote has a **switchable current insurer associated with it**. With that, there's no point of letting users picking a start date since it can be automatically defined: starts when your old insurance expires_

**Ticket(s): [GRW-1048](https://hedvig.atlassian.net/browse/GRW-1048)**

## Screenshots / recordings

<img width="463" alt="image" src="https://user-images.githubusercontent.com/19200662/167387727-8be5267d-221a-49c9-a6d7-eb15aed2958e.png">
