### PR TITLE
Grw-1078 / Cpas add paymentTokenId

### DIFF
--- a/src/client/pages/Checkout/CheckoutPayment/index.tsx
+++ b/src/client/pages/Checkout/CheckoutPayment/index.tsx
@@ -22,7 +22,6 @@ export const Checkout = () => {
     quoteIds,
     selectedQuoteBundleVariant,
     checkoutStatus,
-    isPaymentConnected,
   } = data
 
   return (
@@ -34,7 +33,6 @@ export const Checkout = () => {
       quoteIds={quoteIds}
       selectedQuoteBundleVariant={selectedQuoteBundleVariant}
       checkoutStatus={checkoutStatus}
-      isPaymentConnected={isPaymentConnected}
     />
   )
 }

--- a/src/client/pages/ConnectPayment/components/useAdyenCheckout.tsx
+++ b/src/client/pages/ConnectPayment/components/useAdyenCheckout.tsx
@@ -15,6 +15,7 @@ import {
   PaymentConnectChannel,
   usePaymentMethodsQuery,
   PaymentMethodsQuery,
+  useAddPaymentTokenMutation,
 } from 'data/graphql'
 import { useStorage, StorageState } from 'utils/StorageContainer'
 import { EventName, ErrorEventType } from 'utils/tracking/gtm'
@@ -58,6 +59,7 @@ export const useAdyenCheckout = ({
   const [adyenState, setAdyenState] = useState<ADYEN_STATE>('NOT_LOADED')
   const [connectPaymentMutation] = usePaymentConnection_ConnectPaymentMutation()
   const storage = useStorage()
+  const [addPaymentTokenMutation] = useAddPaymentTokenMutation()
 
   const [
     submitAdditionalPaymentDetails,
@@ -111,6 +113,7 @@ export const useAdyenCheckout = ({
       quoteCartId,
       history,
       onSuccess,
+      addPaymentTokenMutation,
       storage,
       onError: (error) =>
         trackOfferEvent({
@@ -136,6 +139,7 @@ export const useAdyenCheckout = ({
     storage,
     trackOfferEvent,
     successMessage,
+    addPaymentTokenMutation,
   ])
 
   useEffect(() => {
@@ -151,6 +155,7 @@ interface AdyenCheckoutProps {
   currentLocale: LocaleData
   paymentMethodsResponse: Scalars['PaymentMethodsResponse']
   connectPaymentMutation: any
+  addPaymentTokenMutation: any
   submitAdditionalPaymentDetails: any
   history: ReturnType<typeof useHistory>
   onSuccess?: (paymentTokenId?: string) => void
@@ -167,6 +172,7 @@ const createAdyenCheckout = ({
   paymentMethodsResponse,
   connectPaymentMutation,
   submitAdditionalPaymentDetails,
+  addPaymentTokenMutation,
   quoteCartId,
   storage,
   onSuccess = () => {
@@ -270,6 +276,14 @@ const createAdyenCheckout = ({
           ...storage.session.getSession(),
           paymentTokenId,
           quoteCartId,
+        })
+
+        await addPaymentTokenMutation({
+          variables: {
+            id: quoteCartId,
+            paymentTokenId,
+          },
+          refetchQueries: ['QuoteCart'],
         })
 
         if (

--- a/src/client/utils/hooks/useQuoteCartData.ts
+++ b/src/client/utils/hooks/useQuoteCartData.ts
@@ -12,7 +12,6 @@ import {
   getCampaign,
   getPossibleVariations,
   getCheckoutStatus,
-  isPaymentConnected,
 } from 'api/quoteCartQuerySelectors'
 import {
   typeOfResidenceTextKeys,
@@ -230,6 +229,5 @@ export const useQuoteCartData = () => {
     loading,
     error,
     checkoutStatus: getCheckoutStatus(data),
-    isPaymentConnected: isPaymentConnected(data),
   }
 }


### PR DESCRIPTION


## What?

- Added payment token inside of Adyen.
-  Changed the logic of IsPaymentConnected to get triggered when payment has been succesful instead of if payment token is added to the quoteCart

## Why?

In order to get better tracking backend now return a paymentTokenID even if connect_payment fails. The id gets added to the quoteCart . This enables us to see what happened to the payment based on the quoteCart. 


