### PR TITLE
GRW-1021 Add support for house NO in GTM tracking and small refactoring

### DIFF
--- a/src/client/api/quoteBundleSelectors.ts
+++ b/src/client/api/quoteBundleSelectors.ts
@@ -24,6 +24,26 @@ export const getQuotes = (bundle: QuoteBundle | undefined) => {
   return bundle?.quotes ?? []
 }
 
+export const hasHomeContents = (bundle: QuoteBundle) =>
+  bundle.quotes.some(
+    (quote) =>
+      quoteSelector.isSwedishApartment(quote) ||
+      quoteSelector.isSwedishHouse(quote) || // House Insurance in Sweden includes HomeContents coverage
+      quoteSelector.isDanishHomeContents(quote) ||
+      quoteSelector.isNorwegianHomeContents(quote),
+  )
+
+export const hasHouse = (bundle: QuoteBundle) =>
+  bundle.quotes.some((quote) => quoteSelector.isHouse(quote))
+
+export const getHomeOwnershipType = (bundle: QuoteBundle) => {
+  const homeInsurance = bundle.quotes.find((quote) =>
+    quoteSelector.isHomeContentsOrHouse(quote),
+  )
+
+  return homeInsurance ? quoteSelector.getSubType(homeInsurance) : undefined
+}
+
 export const hasAccident = (bundle: QuoteBundle) =>
   bundle.quotes.some((quote) => quoteSelector.isAccident(quote))
 
@@ -94,6 +114,10 @@ export const getBundleCurrency = (bundle: QuoteBundle) => {
   return bundle.bundleCost.monthlyNet.currency
 }
 
+export const getGrossPrice = (bundle: QuoteBundle) => {
+  return bundle.bundleCost.monthlyGross.amount
+}
+
 export const getTotalBundleCost = (bundle: QuoteBundle) => {
   return bundle.bundleCost.monthlyNet.amount
 }
@@ -143,6 +167,9 @@ const getHouseholdSizeFromBundledQuotes = (
 
   return
 }
+
+export const getHouseholdSize = (bundle: QuoteBundle) =>
+  getHouseholdSizeFromBundledQuotes(bundle.quotes)
 
 type QuoteWithAddress = Omit<BundledQuote, 'data'> & {
   data: { zipCode: string; street: string }

--- a/src/client/api/quoteCartQuerySelectors.ts
+++ b/src/client/api/quoteCartQuerySelectors.ts
@@ -54,6 +54,10 @@ export function getMonthlyCostDeductionIncentive(
     : undefined
 }
 
+export function isReferralCodeUsed(quoteCartQuery: QuoteCartQuery | undefined) {
+  return getMonthlyCostDeductionIncentive(quoteCartQuery) !== undefined
+}
+
 export function isPaymentConnected(quoteCartQuery: QuoteCartQuery | undefined) {
   const id = quoteCartQuery?.quoteCart.paymentConnection?.id
   return id !== undefined && id !== null

--- a/src/client/api/quoteSelector.ts
+++ b/src/client/api/quoteSelector.ts
@@ -16,6 +16,9 @@ export const isSwedishAccident = (quote: BundledQuote) =>
 export const isNorwegianHomeContents = (quote: BundledQuote) =>
   quote.data.type === InsuranceType.NORWEGIAN_HOME_CONTENT
 
+export const isNorwegianHouse = (quote: BundledQuote) =>
+  quote.data.type === InsuranceType.NORWEGIAN_HOUSE
+
 export const isNorwegianTravel = (quote: BundledQuote) =>
   quote.data.type === InsuranceType.NORWEGIAN_TRAVEL
 
@@ -62,3 +65,21 @@ const TRAVEL_INSURANCE_TYPES = [
 ]
 export const isTravel = (quote: BundledQuote) =>
   TRAVEL_INSURANCE_TYPES.includes(quote.data.type)
+
+const HOUSE_INSURANCE_TYPES = [
+  InsuranceType.NORWEGIAN_HOUSE,
+  InsuranceType.SWEDISH_HOUSE,
+]
+export const isHouse = (quote: BundledQuote) =>
+  HOUSE_INSURANCE_TYPES.includes(quote.data.type)
+
+const HOME_INSURANCE_TYPES = [
+  InsuranceType.SWEDISH_APARTMENT,
+  InsuranceType.SWEDISH_HOUSE,
+  InsuranceType.NORWEGIAN_HOME_CONTENT,
+  InsuranceType.DANISH_HOME_CONTENT,
+]
+export const isHomeContentsOrHouse = (quote: BundledQuote) =>
+  HOME_INSURANCE_TYPES.includes(quote.data.type)
+
+export const getSubType = (quote: BundledQuote) => quote.data.subType

--- a/src/client/pages/Offer/index.tsx
+++ b/src/client/pages/Offer/index.tsx
@@ -181,7 +181,7 @@ export const OfferPage = ({
         : getInsuranceTypesFromBundleVariant(newSelectedBundleVariant),
     )
     trackOfferEvent({
-      eventName: EventName.OfferCrossSell,
+      eventName: EventName.InsuranceSelectionToggle,
       options: {
         switchedFrom: selectedBundleVariant.bundle,
       },

--- a/src/client/utils/tracking/gtm/dataLayer.ts
+++ b/src/client/utils/tracking/gtm/dataLayer.ts
@@ -1,13 +1,20 @@
 import { AppEnvironment } from 'shared/clientConfig'
-import { TrackableContractType } from './types'
 
 export type GTMUserProperties = {
   market: string
   environment: AppEnvironment
 }
 
+type SwitchedFrom = {
+  is_student: boolean
+  has_home: boolean
+  has_house: boolean
+  has_accident: boolean
+  has_travel: boolean
+  ownership_type?: string
+}
+
 export type GTMOfferData = {
-  insurance_type: TrackableContractType
   referral_code: 'yes' | 'no'
   number_of_people?: number
   insurance_price: number
@@ -15,14 +22,14 @@ export type GTMOfferData = {
   currency: string
   is_student: boolean
   has_home: boolean
+  has_house: boolean
   has_accident: boolean
   has_travel: boolean
-  initial_offer: string
-  current_offer: string
+  ownership_type?: string
   member_id?: string
   quote_cart_id?: string
   flow_type?: string
-  current_insurer?: string
+  switched_from?: SwitchedFrom
 }
 
 export type GTMPageData = {

--- a/src/client/utils/tracking/gtm/trackOfferEvent.ts
+++ b/src/client/utils/tracking/gtm/trackOfferEvent.ts
@@ -1,18 +1,10 @@
 import * as quoteBundleSelector from 'api/quoteBundleSelectors'
 import { QuoteBundle } from 'data/graphql'
-import { quoteBundleTrackingContractType } from 'api/quoteBundleTrackingContractType'
 import { EmbarkStory } from 'utils/embarkStory'
 import { captureSentryError } from 'utils/sentry-client'
 
 import { GTMPhoneNumberData, pushToGTMDataLayer } from './dataLayer'
 import { ErrorEventType, EventName } from './types'
-
-import {
-  getTrackableContractCategory,
-  getInitialOfferFromSessionStorage,
-  setInitialOfferToSessionStorage,
-  getExternalInsuranceDataFromGQLCache,
-} from './helpers'
 
 export type OptionalParameters = {
   switchedFrom?: QuoteBundle
@@ -35,54 +27,51 @@ export const trackOfferEvent = (
   referralCodeUsed: boolean,
   options: OptionalParameters = {},
 ) => {
-  const mainQuote = quoteBundleSelector.getMainQuote(bundle)
-
   const { quoteCartId, ...optionsWithoutId } = options
   const { switchedFrom, phoneNumberData, memberId } = optionsWithoutId
-  const contractType = quoteBundleTrackingContractType(bundle)
-  const contractCategory = getTrackableContractCategory(contractType)
-  const grossPrice = Math.round(Number(bundle.bundleCost.monthlyGross.amount))
-  const netPrice = Math.round(Number(bundle.bundleCost.monthlyNet.amount))
-  const currentInsurer = mainQuote?.currentInsurer?.id ?? undefined
-  const dataCollectionId = mainQuote?.dataCollectionId
-  const externalInsuranceData = dataCollectionId
-    ? getExternalInsuranceDataFromGQLCache(dataCollectionId)
-    : {}
-
-  const initialOffer = getInitialOfferFromSessionStorage()
-  if (!initialOffer) {
-    setInitialOfferToSessionStorage(contractCategory)
-  }
+  const grossPrice = Math.round(
+    Number(quoteBundleSelector.getGrossPrice(bundle)),
+  )
+  const netPrice = Math.round(
+    Number(quoteBundleSelector.getTotalBundleCost(bundle)),
+  )
 
   try {
     pushToGTMDataLayer({
       event: eventName,
       offerData: {
-        insurance_type: contractType,
         referral_code: referralCodeUsed ? 'yes' : 'no',
-        number_of_people: mainQuote.data.numberCoInsured + 1,
+        number_of_people: quoteBundleSelector.getHouseholdSize(bundle),
         insurance_price: grossPrice,
         ...(grossPrice !== netPrice && { discounted_premium: netPrice }),
-        currency: bundle.bundleCost.monthlyNet.currency,
+        currency: quoteBundleSelector.getBundleCurrency(bundle),
         is_student:
           quoteBundleSelector.isStudentOffer(bundle) ||
           quoteBundleSelector.isYouthOffer(bundle),
-        has_home: true,
+        has_home: quoteBundleSelector.hasHomeContents(bundle),
+        has_house: quoteBundleSelector.hasHouse(bundle),
         has_accident: quoteBundleSelector.hasAccident(bundle),
         has_travel: quoteBundleSelector.hasTravel(bundle),
-        initial_offer: initialOffer ?? contractCategory,
-        current_offer: contractCategory,
+        ownership_type: quoteBundleSelector
+          .getHomeOwnershipType(bundle)
+          ?.toLowerCase(),
         quote_cart_id: quoteCartId,
         ...(switchedFrom && {
-          switched_from: getTrackableContractCategory(
-            quoteBundleTrackingContractType(switchedFrom),
-          ),
-          switched_to: contractCategory,
+          switch_from: {
+            has_home: quoteBundleSelector.hasHomeContents(switchedFrom),
+            has_house: quoteBundleSelector.hasHouse(switchedFrom),
+            has_accident: quoteBundleSelector.hasAccident(switchedFrom),
+            has_travel: quoteBundleSelector.hasTravel(switchedFrom),
+            ownership_type: quoteBundleSelector.getHomeOwnershipType(
+              switchedFrom,
+            ),
+            is_student:
+              quoteBundleSelector.isStudentOffer(switchedFrom) ||
+              quoteBundleSelector.isYouthOffer(switchedFrom),
+          },
         }),
         ...(memberId && { member_id: memberId }),
         flow_type: EmbarkStory.get() ?? undefined,
-        current_insurer: currentInsurer,
-        ...(currentInsurer && externalInsuranceData),
       },
       ...phoneNumberData,
       ...optionsWithoutId,

--- a/src/client/utils/tracking/hooks/useTrackOfferEvent.ts
+++ b/src/client/utils/tracking/hooks/useTrackOfferEvent.ts
@@ -3,8 +3,8 @@ import { QuoteCartDocument, QuoteCartQuery } from 'data/graphql'
 import { useQuoteCartIdFromUrl } from 'utils/hooks/useQuoteCartIdFromUrl'
 import { useSelectedInsuranceTypes } from 'utils/hooks/useSelectedInsuranceTypes'
 import {
-  getMonthlyCostDeductionIncentive,
   getSelectedBundleVariant,
+  isReferralCodeUsed,
 } from 'api/quoteCartQuerySelectors'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 import { apolloClient, ApolloClientUtils } from 'apolloClient'
@@ -31,8 +31,6 @@ export const useTrackOfferEvent = () => {
             locale: isoLocale,
           },
         })
-        const isReferralCodeUsed =
-          getMonthlyCostDeductionIncentive(quoteCartQueryData) !== undefined
         const selectedBundleVariant = getSelectedBundleVariant(
           quoteCartQueryData,
           selectedInsuranceTypes,
@@ -42,7 +40,7 @@ export const useTrackOfferEvent = () => {
           trackOfferEvent(
             eventName,
             selectedBundleVariant.bundle,
-            isReferralCodeUsed,
+            isReferralCodeUsed(quoteCartQueryData),
             {
               quoteCartId,
               ...options,


### PR DESCRIPTION
## What?

Adds the following and removes the following fields in the GTM event tracking
(-) insurance_type: Does not scale, can be deduced from the has_home, has_house, has_accident, has_travel, ownership_type
(+) has_house: To track if bundle has house insurance
(+) ownership_type: RENT | OWN
(-) initial offer & current_offer: Do not scale and will be deduced from the quoteCart id
(-) switch_to: not needed
(+) switch_from: does not scale, was changed to a list of booleans instead of specific strings for each type
(-) current_insurer: does not make sense we can have more than one (eg. NO house + travel) and does not scale

This has been sinced with @sonnyandersson1 


## Why?

Single strings for each bundle combination does not scale. 

