### PR TITLE
fix(GRW-1116): update available options

### DIFF
--- a/src/client/components/DetailsModal/Details/NorwegianHouseDetails.tsx
+++ b/src/client/components/DetailsModal/Details/NorwegianHouseDetails.tsx
@@ -62,7 +62,7 @@ export const NorwegianHouseDetails: React.FC<{
   return (
     <Content>
       <ContentRow>
-        <ExtraBuildingsInput formikProps={formikProps} />
+        <ExtraBuildingsInput market="NO" formikProps={formikProps} />
       </ContentRow>
       <ContentColumn>
         <InputGroup>

--- a/src/client/components/DetailsModal/Details/SwedishHouseDetails.tsx
+++ b/src/client/components/DetailsModal/Details/SwedishHouseDetails.tsx
@@ -63,7 +63,7 @@ export const SwedishHouseDetails: React.FC<{
   return (
     <Content>
       <ContentRow>
-        <ExtraBuildingsInput formikProps={formikProps} />
+        <ExtraBuildingsInput market="SE" formikProps={formikProps} />
       </ContentRow>
       <ContentColumn>
         <InputGroup>

--- a/src/client/components/DetailsModal/Details/components/DetailInput.tsx
+++ b/src/client/components/DetailsModal/Details/components/DetailInput.tsx
@@ -315,6 +315,20 @@ export const ZipcodeInput: React.FC<ZipcodeInputProps> = ({
   )
 }
 
+const getExtraBuildingOptions = (market: MarketLabel) => {
+  if (market === 'NO') {
+    return [
+      ExtraBuildingType.Garage,
+      ExtraBuildingType.Guesthouse,
+      ExtraBuildingType.Carport,
+      ExtraBuildingType.Sauna,
+      ExtraBuildingType.Other,
+    ]
+  }
+
+  return Object.values(ExtraBuildingType)
+}
+
 const getExtraBuilding = (extraBuildingType: ExtraBuildingType): string => {
   const map = {
     [ExtraBuildingType.Attefall]: 'DETAILS_MODULE_EXTRABUILDINGS_ATTEFALL',
@@ -341,14 +355,17 @@ const getExtraBuilding = (extraBuildingType: ExtraBuildingType): string => {
 }
 
 type ExtraBuildingsInputProps = {
+  market: MarketLabel
   formikProps: FormikProps<QuoteInput>
 }
 
 export const ExtraBuildingsInput: React.FC<ExtraBuildingsInputProps> = ({
+  market,
   formikProps,
 }) => {
   const textKeys = useTextKeys()
   const extraBuildings = formikProps.values.data.extraBuildings
+  const extraBuldingsOptions = getExtraBuildingOptions(market)
 
   return (
     <FieldArray
@@ -380,7 +397,7 @@ export const ExtraBuildingsInput: React.FC<ExtraBuildingsInputProps> = ({
                   label:
                     'DETAILS_MODULE_EXTRABUILDINGS_TABLE_BUILDINGTYPE_CELL_LABEL_HOUSE',
                   placeholder: '',
-                  options: Object.values(ExtraBuildingType).map((value) => ({
+                  options: extraBuldingsOptions.map((value) => ({
                     label: getExtraBuilding(value),
                     value,
                   })),


### PR DESCRIPTION
## What?

Filter out ExtraBuildings options list on Norway so it matches the one we show during the Embark flow

## Why?

Not all options are available in Norway so there is no point on displaying all of them

**Ticket(s): [GRW-1116](https://hedvig.atlassian.net/browse/GRW-1116)**

## Screenshots / recordings 

<img width="896" alt="image" src="https://user-images.githubusercontent.com/19200662/169472483-48afb6a5-9958-43f1-83ba-a513388dc618.png">

