### PR TITLE
 added new tracking event

### DIFF
--- a/src/client/pages/Checkout/CheckoutPayment/CheckoutPayment.tsx
+++ b/src/client/pages/Checkout/CheckoutPayment/CheckoutPayment.tsx
@@ -65,6 +65,9 @@ const CheckoutPaymentWrapper = styled(CheckoutPageWrapper)`
 `
 
 const AdyenContainer = styled.div`
+  ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
+    padding-bottom: 5rem;
+  }
   #dropin-container {
     .adyen-checkout__payment-method {
       background: transparent;
@@ -227,7 +230,7 @@ export const CheckoutPayment = ({
     if (is3DsError) {
       history.replace('?')
       trackOfferEvent({
-        eventName: EventName.SignError,
+        eventName: EventName.PaymentConnectedFailed,
         options: { errorType: ErrorEventType.threeDS },
       })
       setIs3dsError(true)

--- a/src/client/pages/ConnectPayment/components/useAdyenCheckout.tsx
+++ b/src/client/pages/ConnectPayment/components/useAdyenCheckout.tsx
@@ -120,7 +120,7 @@ export const useAdyenCheckout = ({
       storage,
       onError: (error) =>
         trackOfferEvent({
-          eventName: EventName.SignError,
+          eventName: EventName.PaymentConnectedFailed,
           options: { error, errorType: ErrorEventType.PaymentError },
         }),
     })

--- a/src/client/utils/tracking/gtm/types.ts
+++ b/src/client/utils/tracking/gtm/types.ts
@@ -51,6 +51,7 @@ export enum EventName {
   ButtonClick = 'button_click',
   SignError = 'sign_error',
   PaymentDetailsConfirmed = 'payment_details_confirmed',
+  PaymentConnectedFailed = 'payment_connected_failed',
 }
 
 export enum ErrorEventType {


### PR DESCRIPTION


## What?

New tracking event for payment connection failure instead of signing. Minor adjustment for padding so we don't hide content on smaller screens. 

## Why?

Changed payment flow so a new event is required. 



