### PR TITLE
Feat / Create common Accordion component

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "path-to-regexp": "1.7.0",
     "querystring": "^0.2.0",
     "react": "^16.13.0",
-    "react-animate-height": "^2.0.6",
+    "react-animate-height": "2.1.2",
     "react-dom": "^16.13.0",
     "react-helmet": "5.2.0",
     "react-helmet-async": "0.2.0",

--- a/src/client/components/Accordion/Accordion.stories.tsx
+++ b/src/client/components/Accordion/Accordion.stories.tsx
@@ -1,0 +1,77 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import { Cross } from '../icons/Cross'
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionProps,
+  AccordionTrigger,
+  AccordionTriggerIcon,
+  AccordionTriggerIconProps,
+} from './Accordion'
+
+export default {
+  title: 'Components/Accordion',
+  component: Accordion,
+  parameters: {
+    backgrounds: {
+      default: 'gray100',
+    },
+  },
+}
+
+const Icon = styled(Cross)<AccordionTriggerIconProps>(({ isOpen }) => ({
+  transform: isOpen ? 'rotate(180deg)' : 'rotate(45deg)',
+  transition: 'transform 0.25s ease',
+  marginLeft: '0.5rem',
+}))
+
+export const Default = (args: AccordionProps) => (
+  <div style={{ width: '650px', height: '200px' }}>
+    <Accordion {...args}>
+      <AccordionItem>
+        <AccordionTrigger>
+          Icon?
+          <AccordionTriggerIcon />
+        </AccordionTrigger>
+        <AccordionContent>This example uses the default icon</AccordionContent>
+      </AccordionItem>
+      <AccordionItem>
+        <AccordionTrigger>
+          Accessible?
+          <AccordionTriggerIcon />
+        </AccordionTrigger>
+        <AccordionContent>
+          This component can be navigated with keyboard and has same ARIA
+          attributes as Radix
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  </div>
+)
+
+export const CustomIcon = (args: AccordionProps) => (
+  <div style={{ width: '650px', height: '200px' }}>
+    <Accordion {...args}>
+      <AccordionItem>
+        <AccordionTrigger>
+          Icon?
+          <Icon size="1rem" />
+        </AccordionTrigger>
+        <AccordionContent>This example uses a custom icon</AccordionContent>
+      </AccordionItem>
+      <AccordionItem>
+        <AccordionTrigger>
+          Accessible?
+          <Icon size="1rem" />
+        </AccordionTrigger>
+        <AccordionContent>
+          This component can be navigated with keyboard and has same ARIA
+          attributes as Radix
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  </div>
+)

--- a/src/client/components/Accordion/Accordion.tsx
+++ b/src/client/components/Accordion/Accordion.tsx
@@ -1,36 +1,209 @@
-import React from 'react'
+import React, { useContext, useState } from 'react'
 import styled from '@emotion/styled'
 import AnimateHeight from 'react-animate-height'
-import { colorsV3 } from '@hedviginsurance/brand'
+import { ChevronDown } from '../icons/ChevronDown'
 
-const AccordionRow = styled.button<Pick<AccordionItemProps, 'disabled'>>(
-  ({ disabled }) => ({
-    all: 'unset',
-    cursor: disabled ? 'initial' : 'pointer',
-  }),
+type AccordionContextInterface = {
+  selectedId: string
+  setSelectedId: (id: string) => void
+  mode: 'single' | 'multiple'
+}
+
+const AccordionContext = React.createContext<AccordionContextInterface | null>(
+  {} as AccordionContextInterface,
 )
 
-export const AccordionActiveContent = styled(AnimateHeight)`
-  font-size: 0.875rem;
-  color: ${colorsV3.gray700};
-`
-
-export type AccordionItemProps = {
-  isActive: boolean
-  setIsActive: (isActive: boolean) => void
+export type AccordionProps = {
   children: React.ReactNode
-  disabled: boolean
+  mode: 'single' | 'multiple'
 }
 
-export const AccordionItem = ({
-  isActive,
-  setIsActive,
-  children,
-  disabled,
-}: AccordionItemProps) => {
+/**
+ * Accordion provides a context for AccordionItems to exist in,
+ * it keeps track of which Items that are open and if only one
+ * or many items can be opened at the same time.
+ */
+export const Accordion = ({ children, mode = 'single' }: AccordionProps) => {
+  const [selectedId, setSelectedId] = useState('')
+
   return (
-    <AccordionRow onClick={() => setIsActive(isActive)} disabled={disabled}>
-      {children}
-    </AccordionRow>
+    <div>
+      <AccordionContext.Provider
+        value={{
+          selectedId,
+          setSelectedId,
+          mode: mode,
+        }}
+      >
+        {children}
+      </AccordionContext.Provider>
+    </div>
   )
 }
+
+type AccordionItemContextInterface = {
+  id: string
+  triggerId: string
+  isOpen: boolean
+  setIsOpen: (isOpen: boolean) => void
+}
+
+const AccordionItemContext = React.createContext<AccordionItemContextInterface | null>(
+  null,
+)
+
+export type AccordionItemProps = {
+  children: React.ReactNode
+  className?: string
+}
+
+/**
+ * AccordionItem provides a context for each item in the Accordion
+ * list, giving each Item a specific id that helps Accordion keep
+ * track of which items that are opened.
+ */
+export const AccordionItem = ({ children, className }: AccordionItemProps) => {
+  const [id] = useState(
+    Math.random()
+      .toString(36)
+      .substr(2, 5),
+  )
+  const [triggerId] = useState(
+    Math.random()
+      .toString(36)
+      .substr(2, 5),
+  )
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div className={className}>
+      <AccordionItemContext.Provider
+        value={{ id, triggerId, isOpen, setIsOpen }}
+      >
+        {children}
+      </AccordionItemContext.Provider>
+    </div>
+  )
+}
+
+const AccordionTriggerElement = styled.button<
+  Pick<AccordionTriggerProps, 'disabled'>
+>(({ disabled }) => ({
+  all: 'unset',
+  cursor: disabled ? 'initial' : 'pointer',
+  display: 'flex',
+  alignItems: 'center',
+  ':focus-visible': {
+    boxShadow: 'currentColor 0px 0px 0px 2px',
+  },
+}))
+
+type AccordionTriggerProps = {
+  children: React.ReactNode
+  className?: string
+  disabled?: boolean
+}
+
+/**
+ * AccordionTrigger is the clickable component that expands and closes
+ * an AccordionContent.
+ */
+export const AccordionTrigger = ({
+  children,
+  disabled,
+  className,
+}: AccordionTriggerProps) => {
+  const accordionItemContext = useContext(AccordionItemContext)
+  const accordionContext = useContext(AccordionContext)
+
+  if (!accordionContext)
+    throw new Error('AccordionContent cannot exist outside Accordion')
+  if (!accordionItemContext)
+    throw new Error('AccordionContent cannot exist outside AccordionItem')
+
+  const { id, triggerId, setIsOpen, isOpen } = accordionItemContext
+  const { setSelectedId } = accordionContext
+
+  const onClick = () => {
+    setIsOpen(!isOpen)
+    const newId = isOpen ? '' : id
+    setSelectedId(newId)
+  }
+
+  // Passes `isOpen` to any child components (used for styling a trigger icon for example)
+  const clonedChildren = React.Children.map(children, (child) => {
+    if (!React.isValidElement(child)) {
+      return child
+    }
+
+    return React.cloneElement(child, {
+      isOpen: isOpen,
+    })
+  })
+
+  return (
+    <AccordionTriggerElement
+      className={className}
+      onClick={onClick}
+      disabled={disabled}
+      id={triggerId}
+      aria-controls={id}
+      aria-expanded={isOpen}
+    >
+      {clonedChildren}
+    </AccordionTriggerElement>
+  )
+}
+
+type AccordionContentProps = {
+  children: React.ReactNode
+  className?: string
+}
+
+/**
+ * AccordionContent holds the content that gets expanded by AccordionTrigger
+ */
+export const AccordionContent = ({
+  children,
+  className,
+}: AccordionContentProps) => {
+  const accordionItemContext = useContext(AccordionItemContext)
+  const accordionContext = useContext(AccordionContext)
+
+  if (!accordionContext)
+    throw new Error('AccordionContent cannot exist outside Accordion')
+  if (!accordionItemContext)
+    throw new Error('AccordionContent cannot exist outside AccordionItem')
+
+  const { id, triggerId, isOpen } = accordionItemContext
+  const { selectedId, mode } = accordionContext
+
+  // When mode is "multiple", more than one item can be opened at the time, so
+  // only care about local itemContext to determine if open for that mode.
+  // For "single" mode, only one can be open at the time, so then the ids need to match
+  const isMultiple = mode === 'multiple'
+  const isContentOpen = isMultiple ? isOpen : selectedId === id
+
+  return (
+    <AnimateHeight
+      id={id}
+      aria-labelledby={triggerId}
+      height={isContentOpen ? 'auto' : 0}
+      className={className}
+    >
+      {children}
+    </AnimateHeight>
+  )
+}
+
+export type AccordionTriggerIconProps = {
+  isOpen?: boolean
+}
+
+export const AccordionTriggerIcon = styled(ChevronDown)<
+  AccordionTriggerIconProps
+>(({ isOpen }) => ({
+  transform: isOpen ? 'rotate(180deg)' : '',
+  transition: 'transform 0.25s ease',
+  marginLeft: '0.25rem',
+}))

--- a/src/client/pages/OfferNew/ComparisonTable/ComparisonTable.tsx
+++ b/src/client/pages/OfferNew/ComparisonTable/ComparisonTable.tsx
@@ -21,7 +21,7 @@ import { BREAKPOINTS } from 'utils/mediaQueries'
 import {
   AccordionItemProps,
   AccordionItem,
-  AccordionActiveContent,
+  AccordionContent,
 } from 'components/Accordion/Accordion'
 
 type ComparisonTableProps = {
@@ -88,11 +88,9 @@ export const ComparisonTable = ({ bundles }: ComparisonTableProps) => {
                       <AccordionButton isActive={activeIndex === index} />
                     )}
                   </Title>
-                  <AccordionActiveContent
-                    height={activeIndex === index ? 'auto' : 0}
-                  >
+                  <AccordionContent height={activeIndex === index ? 'auto' : 0}>
                     <p>{row.description}</p>
-                  </AccordionActiveContent>
+                  </AccordionContent>
                 </AccordionItem>
               </TitleTableCell>
 

--- a/src/client/pages/OfferNew/ComparisonTable/ComparisonTable.tsx
+++ b/src/client/pages/OfferNew/ComparisonTable/ComparisonTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { colorsV3 } from '@hedviginsurance/brand'
 import styled from '@emotion/styled'
 import { useMediaQuery } from 'react-responsive'
@@ -15,13 +15,13 @@ import {
   bundleHasPeril,
   getUniquePerilsForQuoteBundles,
 } from 'api/quoteBundleSelectors'
-import { ChevronDown } from 'components/icons/ChevronDown'
-import { ChevronUp } from 'components/icons/ChevronUp'
 import { BREAKPOINTS } from 'utils/mediaQueries'
 import {
-  AccordionItemProps,
   AccordionItem,
+  AccordionTrigger,
+  Accordion,
   AccordionContent,
+  AccordionTriggerIcon,
 } from 'components/Accordion/Accordion'
 
 type ComparisonTableProps = {
@@ -32,33 +32,21 @@ const TitleTableCell = styled(TableCell)`
   width: 100%;
 `
 
-const Title = styled.div`
-  display: flex;
-  align-items: center;
-  svg {
-    margin-left: 0.625rem;
-  }
-`
+const StyledAccordionContent = styled(AccordionContent)({
+  fontSize: '0.875rem',
+  color: colorsV3.gray700,
+})
 
 const PerilTableCell = styled(TableCell)`
   vertical-align: top;
 `
 
-const AccordionButton = ({
-  isActive,
-}: Pick<AccordionItemProps, 'isActive'>) => {
-  return (
-    <>{isActive ? <ChevronUp size="1rem" /> : <ChevronDown size="1rem" />}</>
-  )
-}
-
 export const ComparisonTable = ({ bundles }: ComparisonTableProps) => {
   const uniquePerils = getUniquePerilsForQuoteBundles(bundles)
-  const [activeIndex, setActiveIndex] = useState<number>()
   const isDesktop = useMediaQuery({ minWidth: BREAKPOINTS.mediumScreen })
 
   return (
-    <>
+    <Accordion mode="single">
       <Table fullWidth mt="2rem">
         <TableHead>
           <TableRow>
@@ -71,26 +59,17 @@ export const ComparisonTable = ({ bundles }: ComparisonTableProps) => {
           </TableRow>
         </TableHead>
         <TableBody>
-          {uniquePerils.map((row, index) => (
+          {uniquePerils.map((row) => (
             <TableRow key={row.title}>
               <TitleTableCell>
-                <AccordionItem
-                  key={row.title}
-                  isActive={activeIndex === index}
-                  setIsActive={(isActive) =>
-                    isDesktop && setActiveIndex(isActive ? undefined : index)
-                  }
-                  disabled={!isDesktop}
-                >
-                  <Title>
+                <AccordionItem>
+                  <AccordionTrigger disabled={!isDesktop}>
                     {row.title}
-                    {isDesktop && (
-                      <AccordionButton isActive={activeIndex === index} />
-                    )}
-                  </Title>
-                  <AccordionContent height={activeIndex === index ? 'auto' : 0}>
+                    {isDesktop && <AccordionTriggerIcon />}
+                  </AccordionTrigger>
+                  <StyledAccordionContent>
                     <p>{row.description}</p>
-                  </AccordionContent>
+                  </StyledAccordionContent>
                 </AccordionItem>
               </TitleTableCell>
 
@@ -109,6 +88,6 @@ export const ComparisonTable = ({ bundles }: ComparisonTableProps) => {
           ))}
         </TableBody>
       </Table>
-    </>
+    </Accordion>
   )
 }

--- a/src/client/pages/OfferNew/FaqSection.tsx
+++ b/src/client/pages/OfferNew/FaqSection.tsx
@@ -1,8 +1,6 @@
-import { css } from '@emotion/core'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import React from 'react'
-import AnimateHeight from 'react-animate-height'
 import ReactMarkdown from 'react-markdown/with-html'
 import {
   QuoteBundleVariant,
@@ -10,11 +8,16 @@ import {
   useGetContractFaqsQuery,
 } from 'data/graphql'
 import { useTextKeys } from 'utils/textKeys'
-import {
-  LARGE_SCREEN_MEDIA_QUERY,
-  MEDIUM_SCREEN_MEDIA_QUERY,
-} from 'utils/mediaQueries'
+import { LARGE_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionTriggerIconProps,
+} from 'components/Accordion/Accordion'
+import { Cross } from 'components/icons/Cross'
 import { Container, Heading, Column, ColumnSpacing } from './components'
 import { Tabs } from './Tabs/Tabs'
 
@@ -30,10 +33,7 @@ const SectionWrapper = styled.div`
   }
 `
 
-const AccordionsWrapper = styled.div`
-  list-style: none;
-  padding: 0;
-  margin: 0;
+const TabsWrapper = styled.div`
   margin-top: 1.5rem;
 
   ${LARGE_SCREEN_MEDIA_QUERY} {
@@ -41,10 +41,7 @@ const AccordionsWrapper = styled.div`
   }
 `
 
-const AccordionWrapper = styled('li')`
-  padding: 0;
-  margin: 0;
-
+const StyledAccordionItem = styled(AccordionItem)`
   &:not(:last-child) {
     margin-bottom: 1.5rem;
 
@@ -54,15 +51,13 @@ const AccordionWrapper = styled('li')`
   }
 `
 
-const AccordionHeadline = styled('h3')`
+const StyledAccordionTrigger = styled(AccordionTrigger)`
   font-size: 1.25rem;
   line-height: 1.4;
-  margin: 0;
 `
 
 const AccordionBody = styled(ReactMarkdown)`
-  margin-top: 0.5rem;
-  margin-bottom: 2rem;
+  padding-top: 0.5rem;
   line-height: 1.6;
 
   p,
@@ -73,69 +68,21 @@ const AccordionBody = styled(ReactMarkdown)`
   h5,
   h6 {
     &:first-of-type {
-      margin-top: 0;
+      padding-top: 0;
     }
   }
 `
 
-const ExpandToggler = styled.button`
-  all: unset;
-  cursor: pointer;
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+const ExpanderIcon = styled(Cross)<AccordionTriggerIconProps>(({ isOpen }) => ({
+  transform: isOpen ? 'rotate(0deg)' : 'rotate(45deg)',
+  marginLeft: '1rem',
+  transition: 'transform 150ms',
+  fill: colorsV3.gray900,
+}))
 
-  ${MEDIUM_SCREEN_MEDIA_QUERY} {
-    width: auto;
-    justify-content: flex-start;
-  }
-
-  &:focus {
-    outline: none;
-  }
-`
-
-interface Openable {
-  isOpen: boolean
-}
-
-const ExpanderIcon = styled.svg<Openable>`
-  ${({ isOpen }) => css`
-    transform: ${isOpen ? 'rotate(45deg)' : 'rotate(0deg)'};
-  `};
-  margin-left: 1rem;
-  transition: transform 150ms;
-  flex-shrink: 0;
-  width: 0.8rem;
-  height: 0.8rem;
-  fill: ${colorsV3.gray900};
-`
-
-interface AccordionProps {
+type AccordionProps = {
   headline: string
   body: string
-}
-
-const Accordion = ({ headline, body }: AccordionProps) => {
-  const [isOpen, setIsOpen] = React.useState(false)
-  const toggleIsOpen = () => setIsOpen(!isOpen)
-
-  return (
-    <AccordionWrapper>
-      <AccordionHeadline>
-        <ExpandToggler onClick={toggleIsOpen}>
-          {headline}
-          <ExpanderIcon viewBox="0 0 357 357" isOpen={isOpen}>
-            <path d="M357,204H204v153h-51V204H0v-51h153V0h51v153h153V204z" />
-          </ExpanderIcon>
-        </ExpandToggler>
-      </AccordionHeadline>
-      <AnimateHeight height={isOpen ? 'auto' : 0}>
-        <AccordionBody source={body} escapeHtml={false} />
-      </AnimateHeight>
-    </AccordionWrapper>
-  )
 }
 
 type FaqPanelProps = {
@@ -144,15 +91,19 @@ type FaqPanelProps = {
 
 const FaqPanel = ({ list }: FaqPanelProps) => {
   return (
-    <>
+    <Accordion mode="multiple">
       {list?.map((listItem) => (
-        <Accordion
-          key={listItem?.headline}
-          headline={listItem!.headline}
-          body={listItem!.body!}
-        />
+        <StyledAccordionItem key={listItem?.headline}>
+          <StyledAccordionTrigger>
+            {listItem!.headline}
+            <ExpanderIcon size="1rem" />
+          </StyledAccordionTrigger>
+          <AccordionContent>
+            <AccordionBody source={listItem!.body!} escapeHtml={false} />
+          </AccordionContent>
+        </StyledAccordionItem>
       ))}
-    </>
+    </Accordion>
   )
 }
 
@@ -225,9 +176,7 @@ export const FaqSection = ({ variants }: FaqSectionProps) => {
       <Container>
         <Column>
           <Heading>{textKeys.OFFER_FAQ_HEADING()}</Heading>
-          <AccordionsWrapper>
-            {items && <Tabs items={items} />}
-          </AccordionsWrapper>
+          <TabsWrapper>{items && <Tabs items={items} />}</TabsWrapper>
         </Column>
         <ColumnSpacing />
       </Container>

--- a/src/types/react-animate-height.d.ts
+++ b/src/types/react-animate-height.d.ts
@@ -8,6 +8,7 @@ declare module 'react-animate-height' {
     className?: string
     style?: CSSStyleDeclaration
     contentClassName?: string
+    id?: string
     animationStateClasses?: {
       animating?: string
       animatingUp?: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -14691,10 +14691,10 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-animate-height@^2.0.6:
-  version "2.0.23"
-  resolved "https://registry.yarnpkg.com/react-animate-height/-/react-animate-height-2.0.23.tgz#2e14ac707b20ae67b87766ccfd581e693e0e7ec7"
-  integrity sha512-DucSC/1QuxWEFzR9IsHMzrf2nrcZ6qAmLIFoENa2kLK7h72XybcMA9o073z7aHccFzdMEW0/fhAdnQG7a4rDow==
+react-animate-height@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-animate-height/-/react-animate-height-2.1.2.tgz#9b450fc64d46f10f5e07da8d0d5e2c47b9f15030"
+  integrity sha512-A9jfz/4CTdsIsE7WCQtO9UkOpMBcBRh8LxyHl2eoZz1ki02jpyUL5xt58gabd0CyeLQ8fRyQ+s2lyV2Ufu8Owg==
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.1"


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

This PR:
- Tweaks the common Accordion component so that it can be re-used in both FAQ section and Comparison modal
    - Adds `AccordionContext` so keep track of which items that are expanded
    - Adds a default icon that can be reused (also possible to use your own if you want to, see stories)
- Updates FAQ section to use the updated Accordion
- Updates Comparison modal to use the updated Accordion
- Updates `react-animate-height` to latest version that supports ARIA attributes and `id`

Example usage with "single" mode, where only one item is expanded at the time:
```tsx
  <Accordion mode="single">
    <AccordionItem>
      <AccordionTrigger>
        Icon?
        <AccordionTriggerIcon />
      </AccordionTrigger>
      <AccordionContent>
        This example uses the default icon
      </AccordionContent>
    </AccordionItem>
    <AccordionItem>
      <AccordionTrigger>
        Accessible?
        <AccordionTriggerIcon />
      </AccordionTrigger>
      <AccordionContent>
        This component can be navigated with keyboard and has same ARIA attributes as Radix
      </AccordionContent>
    </AccordionItem>
  </Accordion>
```

https://user-images.githubusercontent.com/1343979/171154292-1dc6688d-1c52-4dc0-bc49-e8e6cb71722e.mov

The mode can also be "multi" and then many items can be opened at once:


https://user-images.githubusercontent.com/1343979/171154472-26d1e5ec-7138-44e1-b3b8-f3758de6c26c.mov

I chose not to use [Radix](https://www.radix-ui.com/docs/primitives/components/accordion) since I couldn't figure out how to work with getting an icon marked as "open" without resorting to their custom `data-` attributes, and it feels like we would leak implementation details of Radix out into our app with that. Maybe someone else wants to take a stab at this in the future?

I've looked at which ARIA attributes Radix uses and used the same ones here, so hopefully it should be accessible. This is the generated HTML:

```html
<div>
  <div>
    <button
      class="css-pno28e-AccordionTriggerElement e1vc6s3q0"
      id="8k125"
      aria-controls="jsssw"
      aria-expanded="false"
    >
      Icon?<svg
        color="#aaaaaa"
        class="e1vc6s3q1 css-tq6o5v-IconRoot-AccordionTriggerIcon e9r5yzb0"
        viewBox="0 0 24 24"
        xmlns="http://www.w3.org/2000/svg"
      >
        <path
          fill-rule="evenodd"
          clip-rule="evenodd"
          d="M12 14.9393L4.53033 7.46967L3.46967 8.53033L12 17.0607L20.5303 8.53033L19.4697 7.46967L12 14.9393Z"
          fill="currentColor"
        ></path>
      </svg>
    </button>
    <div
      id="jsssw"
      aria-labelledby="8k125"
      class="rah-static rah-static--height-zero"
      aria-hidden="true"
      style="height: 0px; overflow: hidden"
    >
      <div style="display: none">This example uses the default icon</div>
    </div>
  </div>
  <div>
    <button
      class="css-pno28e-AccordionTriggerElement e1vc6s3q0"
      id="67mnp"
      aria-controls="7ak33"
      aria-expanded="false"
    >
      Accessible?<svg
        color="#aaaaaa"
        class="e1vc6s3q1 css-tq6o5v-IconRoot-AccordionTriggerIcon e9r5yzb0"
        viewBox="0 0 24 24"
        xmlns="http://www.w3.org/2000/svg"
      >
        <path
          fill-rule="evenodd"
          clip-rule="evenodd"
          d="M12 14.9393L4.53033 7.46967L3.46967 8.53033L12 17.0607L20.5303 8.53033L19.4697 7.46967L12 14.9393Z"
          fill="currentColor"
        ></path>
      </svg>
    </button>
    <div
      id="7ak33"
      aria-labelledby="67mnp"
      class="rah-static rah-static--height-zero"
      aria-hidden="true"
      style="height: 0px; overflow: hidden"
    >
      <div style="display: none">
        This component can be navigated with keyboard and has same ARIA
        attributes as Radix
      </div>
    </div>
  </div>
</div>

```


<!-- What changes are made? If there are many changes, a list might be a good format. -->


## Why?

<!-- Why are these changes made? -->
* It's nice to remove the duplicate implementations of accordions
* Accessibility is always good to improve


**Ticket(s): []**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

