### PR TITLE
GRW-1178-1172-1173 Fix issues with isStudent in edit modal

### DIFF
--- a/src/client/api/quoteBundleSelectors.ts
+++ b/src/client/api/quoteBundleSelectors.ts
@@ -146,6 +146,14 @@ export const hasCar = (quotes: BundledQuote[]) => {
   return quotes.some(quoteSelector.isCar)
 }
 
+export const isStudent = (quotes: BundledQuote[]) => {
+  return quotes.some(quoteSelector.isStudent)
+}
+
+export const isYouth = (quotes: BundledQuote[]) => {
+  return quotes.some(quoteSelector.isYouth)
+}
+
 const getHouseholdSizeFromBundledQuotes = (
   quotes: ReadonlyArray<BundledQuote>,
 ): number | undefined => {

--- a/src/client/components/DetailsModal/index.tsx
+++ b/src/client/components/DetailsModal/index.tsx
@@ -217,8 +217,8 @@ export const DetailsModal = ({
     data: {
       ...mainQuoteData,
       ...(!quoteSelector.isCar(mainQuote) && {
-        isStudent: quoteSelector.isStudent(mainQuote),
-        isYouth: quoteSelector.isYouth(mainQuote),
+        isStudent: bundleSelector.isStudent(selectedQuoteBundle.bundle.quotes),
+        isYouth: bundleSelector.isYouth(selectedQuoteBundle.bundle.quotes),
         householdSize: numberCoInsured + 1,
         livingSpace: squareMeters ? squareMeters : livingSpace,
       }),
@@ -274,8 +274,9 @@ export const DetailsModal = ({
           default: {
             const formValue = form.data[key as keyof QuoteDetailsInput]
             acc[key as keyof QuoteDetailsInput] =
-              (formValue !== undefined && formValue !== null && formValue) ||
-              data[key]
+              formValue !== undefined && formValue !== null
+                ? formValue
+                : data[key]
             return acc
           }
         }


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

* First issue is that we choose house insurance MainQuote when it is there, but house insurance does not include the "isStudent" data. That is why the form shows isStudent as "no" even if it is a yes. The solution here is to look through the whole bundle for an insurance that has isStudent.
* Second issue is that we discard form values that are boolean and set to false, so there was no way to set isStudent from true to false

## Why?

Users should be able to edit the student status in the edit details modal



**Ticket(s): [GRW-1178] [GRW-1172] [GRW-1173]**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->



[GRW-1178]: https://hedvig.atlassian.net/browse/GRW-1178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRW-1172]: https://hedvig.atlassian.net/browse/GRW-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRW-1173]: https://hedvig.atlassian.net/browse/GRW-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ