### PR TITLE
Fix / Avoid defaulting to existing co-insured for falsy values

### DIFF
--- a/src/client/components/DetailsModal/index.tsx
+++ b/src/client/components/DetailsModal/index.tsx
@@ -244,8 +244,9 @@ export const DetailsModal = ({
         switch (key) {
           case 'numberCoInsured':
             acc[key] =
-              (form.data.householdSize && form.data.householdSize - 1) ||
-              data[key]
+              typeof form.data.householdSize === 'number'
+                ? form.data.householdSize - 1
+                : data[key]
             return acc
           case 'livingSpace':
           case 'squareMeters':


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

Fix edit details form when editing household size / number co-insured.

Before we defaulted to the current value when `householdSize - 1` was falsy. Since 0 is falsy in JS it meant that you couldn't change to `householdSize = 1` 🙃 

## Why?

You can't set household size to 1 in the edit details form.

**Ticket(s): []**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

