### PR TITLE
refact(GRW-1133): unify onboarding flow: onboarding-NO

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -40,7 +40,6 @@ enum EmbarkStory {
   NorwayComboEnglishQuoteCart = 'Web Onboarding NO - English Combo Quote Cart',
   NorwayComboNorwegianQuoteCart = 'Web Onboarding NO - Norwegian Combo Quote Cart',
   NorwayOnboarding = 'onboarding-NO',
-  NorwayOnboardingv2 = 'onboarding-NOv2',
 
   SwedenNeeder = 'Web Onboarding SE - Needer',
   SwedenSwitcher = 'Web Onboarding SE - Switcher',
@@ -348,9 +347,7 @@ export const routes: Route[] = [
                 case 'onboarding':
                   return {
                     baseUrl,
-                    name: isHouseEnabled
-                      ? EmbarkStory.NorwayOnboardingv2
-                      : EmbarkStory.NorwayOnboarding,
+                    name: EmbarkStory.NorwayOnboarding,
                     quoteCart: true,
                   }
               }


### PR DESCRIPTION
## Context
As we've launched House NO as an iteration of Accident NO we've created two onboarding flows:

- `onboarding-NO`: which handles Home Contents, Accident, and Travel promises
- `onboarding-NOv2`: which handles Home Contents, House, Accident, and Travel promises

However, the ultimate goal was to have a single onboarding flow in NO to improve maintainability. With that said, this series of PRs aims to unify the onboarding flow in NO.

## What?

Update `routes` so the correct flow gets loaded when `[no-en|no]/new-member` is accessed

## Why?

`onboarding-NOv2` ---> `onboarding-NO`

## Relates with
[embark](https://github.com/HedvigInsurance/embark/pull/981)
[racoon](https://github.com/HedvigInsurance/racoon/pull/228)

**Ticket(s): [GRW-1133](https://hedvig.atlassian.net/browse/GRW-1133)**