### PR TITLE
feat(onboarding-dk): enables onboarding flow unconditionally

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -256,7 +256,6 @@ export const routes: Route[] = [
             window.hedvigClientConfig.appEnvironment === 'production'
 
           const isCarEnabled = checkFeature(Feature.CAR_V1)
-          const isHouseEnabled = checkFeature(Feature.HOUSE_INSURANCE)
 
           switch (locale) {
             case 'dk':

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -299,12 +299,10 @@ export const routes: Route[] = [
                     quoteCart: true,
                   }
                 case 'onboarding':
-                  if (isHouseEnabled) {
-                    return {
-                      baseUrl,
-                      name: EmbarkStory.DenmarkOnboarding,
-                      quoteCart: true,
-                    }
+                  return {
+                    baseUrl,
+                    name: EmbarkStory.DenmarkOnboarding,
+                    quoteCart: true,
                   }
               }
               break


### PR DESCRIPTION
## What?

enables onboarding-DK flow unconditionally

## Why?

A main component of House DK is a single onboarding flow so as part of the release of it we should make that flow available unconditionally

**Ticket(s): [GRW-876](https://hedvig.atlassian.net/browse/GRW-876)**

