### PR TITLE
fix / Use insurable limits from the server as they are

### DIFF
--- a/src/client/pages/OfferNew/Perils/AmountCollection/index.tsx
+++ b/src/client/pages/OfferNew/Perils/AmountCollection/index.tsx
@@ -20,19 +20,17 @@ type Props = {
   offer: OfferQuote
 }
 
-export const AmountCollection: React.FC<Props> = ({ offer }) => {
+export const AmountCollection = ({ offer }: Props) => {
   const textKeys = useTextKeys()
-
-  const limits = [...offer.insurableLimits.entries()]
 
   return (
     <Container>
       <HeadingXS>{textKeys.COVERAGE_INFO_HEADLINE()}</HeadingXS>
       <Grid>
-        {limits.map(([type, limit]) => (
-          <AmountItem key={type} tooltip={limit.description}>
-            <AmountItem.Label>{limit.label}</AmountItem.Label>
-            <AmountItem.Value>{limit.limit}</AmountItem.Value>
+        {offer.insurableLimits.map(({ label, description, limit }) => (
+          <AmountItem key={label} tooltip={description}>
+            <AmountItem.Label>{label}</AmountItem.Label>
+            <AmountItem.Value>{limit}</AmountItem.Value>
           </AmountItem>
         ))}
       </Grid>

--- a/src/client/pages/OfferNew/types.ts
+++ b/src/client/pages/OfferNew/types.ts
@@ -4,7 +4,6 @@ import {
   CompleteHouseQuoteDetails,
   CompleteQuote,
   InsurableLimit,
-  InsurableLimitType,
   InsuranceCost,
   InsuranceTerm,
   Query,
@@ -51,7 +50,7 @@ export type OfferQuote = Pick<
   | 'perils'
 > & {
   contractType: TypeOfContract
-  insurableLimits: ReadonlyMap<InsurableLimitType, InsurableLimit>
+  insurableLimits: InsurableLimit[]
   insuranceTerms: InsuranceTerm[]
   data: GenericQuoteData
 }

--- a/src/client/pages/OfferNew/utils.ts
+++ b/src/client/pages/OfferNew/utils.ts
@@ -2,8 +2,6 @@ import {
   BundledQuote,
   Campaign,
   DanishHomeContentsDetails,
-  InsurableLimit,
-  InsurableLimitType,
   NorwegianHomeContentsDetails,
   NorwegianTravelDetails,
   QuoteBundle,
@@ -43,12 +41,6 @@ export const getOfferData = (quoteBundle: QuoteBundle): OfferData => {
         ...bundleQuote,
         contractType: bundleQuote.typeOfContract,
         perils: bundleQuote.contractPerils,
-        insurableLimits: new Map(
-          bundleQuote.insurableLimits.map((insurableLimit) => [
-            insurableLimit.type,
-            insurableLimit,
-          ]),
-        ) as ReadonlyMap<InsurableLimitType, InsurableLimit>,
       }
     }),
     cost: quoteBundle.bundleCost,

--- a/src/client/utils/testData/offerDataMock.ts
+++ b/src/client/utils/testData/offerDataMock.ts
@@ -1,5 +1,4 @@
 import {
-  InsurableLimit,
   InsurableLimitType,
   NorwegianHomeContentsType,
   PerilV2,
@@ -8,22 +7,20 @@ import {
   CurrentInsurer,
   InsuranceTerm,
   SwedishApartmentType,
+  InsurableLimit,
 } from 'data/graphql'
 import { OfferData } from '../../pages/OfferNew/types'
 
-const insurableLimitMock = new Map([
-  [
-    InsurableLimitType.InsuredAmount,
-    {
-      description:
-        'Alla dina ägodelar är sammanlagt försäkrade upp till 1 miljon kronor',
-      label: 'Dina saker är försäkrade till totalt',
-      limit: '1 000 000 kr',
-      type: 'INSURED_AMOUNT',
-      __typename: 'InsurableLimit',
-    },
-  ],
-]) as ReadonlyMap<InsurableLimitType, InsurableLimit>
+const insurableLimitMock = [
+  {
+    description:
+      'Alla dina ägodelar är sammanlagt försäkrade upp till 1 miljon kronor',
+    label: 'Dina saker är försäkrade till totalt',
+    limit: '1 000 000 kr',
+    type: InsurableLimitType.InsuredAmount,
+    __typename: 'InsurableLimit',
+  } as InsurableLimit,
+]
 
 const insuranceTermsMock = [
   {


### PR DESCRIPTION



<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

Use insurable limits from the server as they are, without mapping on type

<!-- What changes are made? If there are many changes, a list might be a good format. -->


## Why?

We can sometimes get several insurable limits with the same `type` from BE since there's no restriction on unique-ness there: 

<img width="1014" alt="image" src="https://user-images.githubusercontent.com/1343979/173359284-256ffff9-2555-4742-b6df-604fa23fa4d5.png">

This caused some insurable limit items not to show in production because they were accidentally the same type. I think we should allow multiple items of the same type if the BE allows it.

The problem was that we mapped this array into a Map keyed on `type` which meant that we only showed one of the array items on the page:

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/1343979/173359696-95fe88ac-406d-4461-ae71-db857e620cf2.png">

After this PR we show all insurable limits as they are sent from BE:

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/1343979/173359903-117a8a07-f8b2-402d-9b69-7b409414f1f3.png">

I guess this was used to not get duplicates, but it seems it's not needed for bundles either, still works:


https://user-images.githubusercontent.com/1343979/173360122-b66fe86e-9606-4882-b8de-c34cf637e53a.mov



<!-- Why are these changes made? -->



**Ticket(s): []**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

