### PR TITLE
Use flexbox to align items to bottom when height differs

### DIFF
--- a/src/client/pages/OfferNew/Perils/AmountCollection/AmountItem.tsx
+++ b/src/client/pages/OfferNew/Perils/AmountCollection/AmountItem.tsx
@@ -15,7 +15,9 @@ const ICON_SIZE = '20px'
 const Container = styled.div`
   position: relative;
 
-  display: grid;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   gap: 0.5rem;
 
   padding: ${CONTAINER_PADDING};


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

Use flexbox to bottom-align content when the height (amount of content) differs between cards on the same row.

<!-- What changes are made? If there are many changes, a list might be a good format. -->


## Why?

<!-- Why are these changes made? -->

Before:

<img width="845" alt="Screenshot 2022-06-14 at 07 37 11" src="https://user-images.githubusercontent.com/1343979/173508069-2b298d2d-1693-4389-be16-1185b9af6875.png">

After (notice first card's content is aligned to bottom):


<img width="922" alt="Screenshot 2022-06-14 at 07 53 45" src="https://user-images.githubusercontent.com/1343979/173508089-87f2c36a-9530-4135-bba8-ccef6f53a41a.png">


**Ticket(s): []**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

