### PR TITLE
GRW-1200 / feat / Track onboarding events

### DIFF
--- a/src/client/pages/Landing/Landing.tsx
+++ b/src/client/pages/Landing/Landing.tsx
@@ -1,7 +1,7 @@
 import { css, Global } from '@emotion/core'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { TopBar, TopBarFiller } from 'components/TopBar'
 import { BackgroundImage } from 'components/BackgroundImage'
@@ -16,6 +16,7 @@ import {
 } from 'utils/mediaQueries'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 import { LanguagePicker } from 'components/LanguagePicker/LanguagePicker'
+import { useTrackEvent } from 'utils/tracking/gtm/useTrackEvent'
 import { getProductsData } from './landingPageData'
 import { Card, CardHeadline, CardParagraph } from './components/Card'
 
@@ -154,6 +155,14 @@ export const Landing = () => {
   const { marketLabel, path: localePath } = useCurrentLocale()
   const variation = useVariation()
   const productsData = useMemo(getProductsData, [])
+
+  const [track, { hasTracked }] = useTrackEvent('begin_onboarding_home_page', {
+    referer: window.hedvigClientConfig.referer,
+  })
+
+  useEffect(() => {
+    if (!hasTracked) track()
+  }, [track, hasTracked])
 
   return (
     <AnimatePresence>

--- a/src/client/utils/tracking/gtm/dataLayer.ts
+++ b/src/client/utils/tracking/gtm/dataLayer.ts
@@ -35,10 +35,6 @@ export type GTMPageData = {
   market: string
 }
 
-export type GTMEventData = {
-  type: string
-}
-
 export type GTMPhoneNumberData = {
   path: string
   status: 'opened' | 'closed'
@@ -50,7 +46,7 @@ export type DataLayerObject = {
   offerData?: GTMOfferData
   pageData?: GTMPageData
   passageData?: Record<string, string | undefined>
-  eventData?: GTMEventData
+  eventData?: Record<string, string>
   phoneNumberData?: GTMPhoneNumberData
 }
 

--- a/src/client/utils/tracking/gtm/useTrackEvent.test.ts
+++ b/src/client/utils/tracking/gtm/useTrackEvent.test.ts
@@ -1,0 +1,115 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { useTrackEvent } from './useTrackEvent'
+
+const mockPushToGTMDataLayer = jest.fn()
+
+jest.mock('./dataLayer', () => ({
+  pushToGTMDataLayer: (args: any) => mockPushToGTMDataLayer(args),
+}))
+
+describe('useTrackEvent', () => {
+  beforeEach(() => {
+    mockPushToGTMDataLayer.mockRestore()
+  })
+
+  it('should not call pushToGTMDataLayer before returned function is executed', () => {
+    // align
+    renderHook(() => useTrackEvent('some_event'))
+
+    // act
+
+    // assert
+    expect(mockPushToGTMDataLayer).toHaveBeenCalledTimes(0)
+  })
+
+  it('should call pushToGTMDataLayer when returned function is executed', () => {
+    // align
+    const { result } = renderHook(() => useTrackEvent('some_event'))
+    const track = result.current
+
+    // act
+    track()
+
+    // assert
+    expect(mockPushToGTMDataLayer).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call pushToGTMDataLayer with event name', () => {
+    // align
+    const event = 'some_event'
+    const { result } = renderHook(() => useTrackEvent(event))
+    const track = result.current
+
+    // act
+    track()
+
+    // assert
+    expect(mockPushToGTMDataLayer).toHaveBeenCalledWith({
+      event,
+      eventData: {},
+    })
+  })
+
+  it('should call pushToGTMDataLayer same amount of times as returned function is executed', () => {
+    // align
+    const { result } = renderHook(() => useTrackEvent('some_event'))
+    const track = result.current
+
+    // act
+    track()
+    track()
+
+    // assert
+    expect(mockPushToGTMDataLayer).toHaveBeenCalledTimes(2)
+  })
+
+  it('should call pushToGTMDataLayer with original object', () => {
+    // align
+    const event = 'some_event'
+    const eventData = { some: 'data' }
+    const { result } = renderHook(() => useTrackEvent(event, eventData))
+    const track = result.current
+
+    // act
+    track()
+
+    // assert
+    expect(mockPushToGTMDataLayer).toHaveBeenCalledWith({ event, eventData })
+  })
+
+  it('should call pushToGTMDataLayer with new object', () => {
+    // align
+    const event = 'some_event'
+    const eventData = { some: 'data' }
+    const newData = { some: 'new data', more: 'data' }
+    const { result } = renderHook(() => useTrackEvent(event, eventData))
+    const track = result.current
+
+    // act
+    track(newData)
+
+    // assert
+    expect(mockPushToGTMDataLayer).toHaveBeenCalledWith({
+      event,
+      eventData: newData,
+    })
+  })
+
+  it('should call pushToGTMDataLayer with new object and keep original object properties if not overwritten', () => {
+    // align
+    const event = 'some_event'
+    const eventData = { some: 'data' }
+    const newData = { more: 'data' }
+    const { result } = renderHook(() => useTrackEvent(event, eventData))
+    const track = result.current
+
+    // act
+    track(newData)
+
+    // assert
+    expect(mockPushToGTMDataLayer).toHaveBeenCalledWith({
+      event,
+      eventData: { ...eventData, ...newData },
+    })
+  })
+})

--- a/src/client/utils/tracking/gtm/useTrackEvent.test.ts
+++ b/src/client/utils/tracking/gtm/useTrackEvent.test.ts
@@ -1,3 +1,4 @@
+import { act } from '@testing-library/react'
 import { renderHook } from '@testing-library/react-hooks'
 import { useTrackEvent } from './useTrackEvent'
 
@@ -25,10 +26,10 @@ describe('useTrackEvent', () => {
   it('should call pushToGTMDataLayer when returned function is executed', () => {
     // align
     const { result } = renderHook(() => useTrackEvent('some_event'))
-    const track = result.current
+    const [track] = result.current
 
     // act
-    track()
+    act(() => track())
 
     // assert
     expect(mockPushToGTMDataLayer).toHaveBeenCalledTimes(1)
@@ -38,10 +39,10 @@ describe('useTrackEvent', () => {
     // align
     const event = 'some_event'
     const { result } = renderHook(() => useTrackEvent(event))
-    const track = result.current
+    const [track] = result.current
 
     // act
-    track()
+    act(() => track())
 
     // assert
     expect(mockPushToGTMDataLayer).toHaveBeenCalledWith({
@@ -53,11 +54,11 @@ describe('useTrackEvent', () => {
   it('should call pushToGTMDataLayer same amount of times as returned function is executed', () => {
     // align
     const { result } = renderHook(() => useTrackEvent('some_event'))
-    const track = result.current
+    const [track] = result.current
 
     // act
-    track()
-    track()
+    act(() => track())
+    act(() => track())
 
     // assert
     expect(mockPushToGTMDataLayer).toHaveBeenCalledTimes(2)
@@ -68,10 +69,10 @@ describe('useTrackEvent', () => {
     const event = 'some_event'
     const eventData = { some: 'data' }
     const { result } = renderHook(() => useTrackEvent(event, eventData))
-    const track = result.current
+    const [track] = result.current
 
     // act
-    track()
+    act(() => track())
 
     // assert
     expect(mockPushToGTMDataLayer).toHaveBeenCalledWith({ event, eventData })
@@ -83,10 +84,10 @@ describe('useTrackEvent', () => {
     const eventData = { some: 'data' }
     const newData = { some: 'new data', more: 'data' }
     const { result } = renderHook(() => useTrackEvent(event, eventData))
-    const track = result.current
+    const [track] = result.current
 
     // act
-    track(newData)
+    act(() => track(newData))
 
     // assert
     expect(mockPushToGTMDataLayer).toHaveBeenCalledWith({
@@ -101,15 +102,44 @@ describe('useTrackEvent', () => {
     const eventData = { some: 'data' }
     const newData = { more: 'data' }
     const { result } = renderHook(() => useTrackEvent(event, eventData))
-    const track = result.current
+    const [track] = result.current
 
     // act
-    track(newData)
+    act(() => track(newData))
 
     // assert
     expect(mockPushToGTMDataLayer).toHaveBeenCalledWith({
       event,
       eventData: { ...eventData, ...newData },
     })
+  })
+
+  it('should return isTracked=false before track is called', () => {
+    // align
+    const event = 'some_event'
+    const eventData = { some: 'data' }
+    const { result } = renderHook(() => useTrackEvent(event, eventData))
+    const [, { hasTracked }] = result.current
+
+    // act
+
+    // assert
+    expect(hasTracked).toEqual(false)
+  })
+
+  it('should return isTracked=true after track is called', () => {
+    // align
+    const event = 'some_event'
+    const eventData = { some: 'data' }
+    const newData = { more: 'data' }
+    const { result } = renderHook(() => useTrackEvent(event, eventData))
+    const [track] = result.current
+
+    // act
+    act(() => track(newData))
+
+    // assert
+    const [, { hasTracked }] = result.current
+    expect(hasTracked).toEqual(true)
   })
 })

--- a/src/client/utils/tracking/gtm/useTrackEvent.ts
+++ b/src/client/utils/tracking/gtm/useTrackEvent.ts
@@ -1,0 +1,41 @@
+import { useCallback } from 'react'
+import { pushToGTMDataLayer } from './dataLayer'
+
+/**
+ * @param event event name
+ * @param data initial data
+ * @returns A `track` function which can be called when event is triggered. This function supports passing additional data which means that this function can overwrite the initial data.
+ *
+ * @example
+ * // Set default properties and track event
+ * const trackPageView = useTrackEvent('begin_onboarding_page', {
+ *   begin_from: referer,
+ * })
+ * useEffect(() => {
+ *  trackPageView() // will send eventData: `{ begin_from: <referer> }`
+ * }, [trackPageView])
+ *
+ * @example
+ * // Add additional properties when event is tracked
+ * const trackSelectedCard = useTrackEvent('begin_onboarding_insurance_type_selected', {
+ *   begin_from: referer,
+ * })
+ * const handleClick = (type) => {
+ *   trackSelectedCard({ type }) // will send eventData: `{ begin_from: <referer>, type: <type> }`
+ * }
+ */
+export const useTrackEvent = (event: string, data?: Record<string, any>) => {
+  const track = useCallback(
+    (newData?: Record<string, any>) => {
+      const eventData = {
+        ...data,
+        ...newData,
+      }
+
+      pushToGTMDataLayer({ event, eventData })
+    },
+    [event, data],
+  )
+
+  return track
+}

--- a/src/client/utils/tracking/gtm/useTrackEvent.ts
+++ b/src/client/utils/tracking/gtm/useTrackEvent.ts
@@ -1,14 +1,19 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { pushToGTMDataLayer } from './dataLayer'
+
+type useTrackEventReturnType = [
+  (newData?: Record<string, any>) => void,
+  { hasTracked: boolean },
+]
 
 /**
  * @param event event name
  * @param data initial data
- * @returns A `track` function which can be called when event is triggered. This function supports passing additional data which means that this function can overwrite the initial data.
+ * @returns An array with a `track` function which can be called when event is triggered, and a data object. The track function supports passing additional data which means that this function can overwrite the initial data. The data object contains `hasTracked` which can be used to make sure that no additional tracking occurs.
  *
  * @example
  * // Set default properties and track event
- * const trackPageView = useTrackEvent('begin_onboarding_page', {
+ * const [trackPageView] = useTrackEvent('begin_onboarding_page', {
  *   begin_from: referer,
  * })
  * useEffect(() => {
@@ -17,14 +22,19 @@ import { pushToGTMDataLayer } from './dataLayer'
  *
  * @example
  * // Add additional properties when event is tracked
- * const trackSelectedCard = useTrackEvent('begin_onboarding_insurance_type_selected', {
+ * const [trackSelectedCard, { hasTracked }] = useTrackEvent('begin_onboarding_insurance_type_selected', {
  *   begin_from: referer,
  * })
  * const handleClick = (type) => {
- *   trackSelectedCard({ type }) // will send eventData: `{ begin_from: <referer>, type: <type> }`
+ *   if (!hasTracked) trackSelectedCard({ type }) // will send eventData: `{ begin_from: <referer>, type: <type> }`
  * }
  */
-export const useTrackEvent = (event: string, data?: Record<string, any>) => {
+export const useTrackEvent = (
+  event: string,
+  data?: Record<string, any>,
+): useTrackEventReturnType => {
+  const [hasTracked, setHasTracked] = useState(false)
+
   const track = useCallback(
     (newData?: Record<string, any>) => {
       const eventData = {
@@ -33,9 +43,10 @@ export const useTrackEvent = (event: string, data?: Record<string, any>) => {
       }
 
       pushToGTMDataLayer({ event, eventData })
+      setHasTracked(true)
     },
     [event, data],
   )
 
-  return track
+  return [track, { hasTracked }]
 }

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -144,9 +144,9 @@ export const getPage = (
     new ServerCookieStorage(ctx),
   )
 
-  const clientConfigData = {
+  const clientConfigData: ClientConfigServerData = {
     referer: ctx.req.headers.referer ?? null,
-  } as ClientConfigServerData
+  }
 
   const session = createSession<Session>(serverCookieStorage)
 

--- a/src/shared/clientConfig.ts
+++ b/src/shared/clientConfig.ts
@@ -23,7 +23,11 @@ export type FeatureMap = Record<Feature, Array<MarketLabel>>
 
 export type AdyenEnvironment = 'test' | 'live'
 
-export interface ClientConfig {
+export type ClientConfigServerData = {
+  referer: string | null
+}
+
+export type ClientConfig = {
   adyenEnvironment: AdyenEnvironment
   adyenClientKey: string
   contentServiceEndpoint: string
@@ -33,7 +37,7 @@ export interface ClientConfig {
   appEnvironment: AppEnvironment
   features: FeatureMap
   datadog: RumInitConfiguration
-}
+} & ClientConfigServerData
 
 declare global {
   interface Window {


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

This PR ports `useTrackEvent` from https://github.com/HedvigInsurance/racoon/pull/233 and adds tracking to the "SE home" landing page according to GRW-1200.

A question is if it's worth trying to get `referer` from server to the client? 

Also, it seems the pages are rendered at least twice (at least in local testing) so I had to also keep track of whether the hook has called its function or not. Maybe not the prettiest solution?

<!-- What changes are made? If there are many changes, a list might be a good format. -->


## Why?

Add event tracking to different landing pages between racoon and web-onboarding now that the flow has grown in complexity.

<!-- Why are these changes made? -->



**Ticket(s): [GRW-1200]**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->



[GRW-1200]: https://hedvig.atlassian.net/browse/GRW-1200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ