### PR TITLE
 fixed edit button behaviour in checkout payment flow

### DIFF
--- a/src/client/pages/ConnectPayment/components/useAdyenCheckout.tsx
+++ b/src/client/pages/ConnectPayment/components/useAdyenCheckout.tsx
@@ -141,6 +141,7 @@ export const useAdyenCheckout = ({
 
   useEffect(mountAdyenCss, [])
   const resetAdyen = () => {
+    mountAdyenJs(() => setAdyenState('LOADED'))()
     dropinComponent?.setStatus('ready')
   }
   return { resetAdyen }
@@ -257,7 +258,6 @@ const createAdyenCheckout = ({
         buttonType: 'subscribe',
       },
     },
-    enableStoreDetails: true,
     returnUrl,
     onSubmit: async (state: any, dropinComponent: any) => {
       onSubmit?.()


### PR DESCRIPTION

## What?

Re-mounted the adyen component after you click edit since I could not find an event inside adyen that resets the payment details received from the user. 


## Why?

After you complete payment and click to edit your payment options you can still click the continue button because your card details get saved in the adyen state. 



