### PR TITLE
styles(Switch): removed undesired line-height from icon

### DIFF
--- a/src/client/components/Switch.tsx
+++ b/src/client/components/Switch.tsx
@@ -4,6 +4,11 @@ import { motion } from 'framer-motion'
 import React from 'react'
 import { Tick } from 'components/icons/Tick'
 
+const Wrapper = styled.div({
+  position: 'relative',
+  lineHeight: 0,
+})
+
 const SwitchContainer = styled(motion.span)`
   display: inline-flex;
   justify-content: center;
@@ -42,7 +47,7 @@ type SwitchProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value'>
 export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
   ({ className, ...checkboxProps }, forwardedRef) => {
     return (
-      <div className={className}>
+      <Wrapper className={className}>
         <InclusiveHiddenCheckbox
           ref={forwardedRef}
           type="checkbox"
@@ -65,7 +70,7 @@ export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
         >
           <Tick />
         </SwitchContainer>
-      </div>
+      </Wrapper>
     )
   },
 )


### PR DESCRIPTION
## What?

Removes undesired line-height from icon since

**Before**
<img width="423" alt="old" src="https://user-images.githubusercontent.com/19200662/184824636-d77b2a8d-6b7f-4dac-8859-fc6a8c7308f5.png">

**After**
<img width="421" alt="new" src="https://user-images.githubusercontent.com/19200662/184824655-18967551-63d8-4eb9-822b-2a96b887508a.png">

## Why?

It adds some vertical spacing take makes difficult align things vertically.
It was added as a side effect of #1113 

