### PR TITLE
Prevent signing non-quote cart quotes

### DIFF
--- a/src/client/pages/Offer/Checkout/Checkout.helpers.ts
+++ b/src/client/pages/Offer/Checkout/Checkout.helpers.ts
@@ -1,0 +1,47 @@
+import { ApolloClient } from '@apollo/client'
+import { InsuranceType } from 'utils/hooks/useSelectedInsuranceTypes'
+import { getSelectedBundleVariant } from 'api/quoteCartQuerySelectors'
+import {
+  QuoteCartQuery,
+  QuoteCartDocument,
+  QuoteCartQueryVariables,
+  Locale,
+  TypeOfContract,
+} from 'data/graphql'
+import { getQuoteIdsFromBundleVariant } from '../utils'
+
+type GetQuoteCartParams = {
+  apolloClient: ApolloClient<unknown>
+  quoteCartId: string
+  locale: Locale
+}
+
+export const getQuoteCart = async ({
+  apolloClient,
+  quoteCartId,
+  locale,
+}: GetQuoteCartParams) => {
+  const { data } = await apolloClient.query<
+    QuoteCartQuery,
+    QuoteCartQueryVariables
+  >({
+    query: QuoteCartDocument,
+    variables: { id: quoteCartId, locale },
+    fetchPolicy: 'network-only',
+  })
+  return data
+}
+
+type GetQuoteIdsParams = {
+  quoteCart: QuoteCartQuery
+  insuranceTypes: Array<InsuranceType> | Array<TypeOfContract>
+}
+
+export const getQuoteIds = ({
+  quoteCart,
+  insuranceTypes,
+}: GetQuoteIdsParams) => {
+  const bundleVariant = getSelectedBundleVariant(quoteCart, insuranceTypes)
+  if (bundleVariant === undefined) throw new Error('No bundle variant selected')
+  return getQuoteIdsFromBundleVariant(bundleVariant)
+}


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

Always fetch latest quote cart before trying to sign.

## Why?

We still run into errors where the request to sign quotes fails since the quotes are no longer associated with the cart.

The reason for this is some mismatching react state.

Therefore it should be safest to always fetch the cart fresh before deciding which quote IDs to sign.



**Ticket(s): []**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

