### PR TITLE
GRW-1337-refact: MainProductCard --> StandaloneProductCard

### DIFF
--- a/src/client/components/StandaloneProductCard.tsx
+++ b/src/client/components/StandaloneProductCard.tsx
@@ -4,7 +4,7 @@ import { colorsV3 } from '@hedviginsurance/brand'
 import { MEDIA_QUERIES } from 'utils/mediaQueries'
 import { Switch } from 'components/Switch'
 
-type MainProductCardProps = {
+type StandaloneProductCardProps = {
   title: string
   price: string
   description: string
@@ -14,7 +14,7 @@ type MainProductCardProps = {
   onClick?: () => void
 }
 
-export const MainProductCard = ({
+export const StandaloneProductCard = ({
   title,
   price,
   description,
@@ -22,7 +22,7 @@ export const MainProductCard = ({
   checkboxRef,
   checked = false,
   onClick = () => null,
-}: MainProductCardProps) => {
+}: StandaloneProductCardProps) => {
   return (
     <Card checked={checked} onClick={onClick}>
       {image && (
@@ -42,7 +42,7 @@ export const MainProductCard = ({
   )
 }
 
-export const Card = styled.button<Pick<MainProductCardProps, 'checked'>>(
+export const Card = styled.button<Pick<StandaloneProductCardProps, 'checked'>>(
   ({ checked }) => ({
     all: 'unset',
     cursor: 'pointer',

--- a/src/client/pages/Offer/ProductSelector/Selector.tsx
+++ b/src/client/pages/Offer/ProductSelector/Selector.tsx
@@ -3,7 +3,7 @@ import { useLocation, useHistory } from 'react-router'
 import styled from '@emotion/styled'
 import { useTextKeys } from 'utils/textKeys'
 import { MEDIA_QUERIES } from 'utils/mediaQueries'
-import { MainProductCard } from 'components/MainProductCard'
+import { StandaloneProductCard } from 'components/StandaloneProductCard'
 import { AdditionalProductCard } from 'components/AdditionalProductCard'
 import { Product } from 'pages/Offer/types'
 
@@ -92,23 +92,21 @@ export const Selector = ({
         <h2>{textKeys.OFFER_PAGE_SECTION_TITLE_MAIN()}</h2>
         <MainCoverageCardGrid>
           {standaloneProducts.map(({ id, name, price, description, image }) => {
-            const isTheOnlySelectedMainProduct =
+            const isTheOnlyStandaloneProduct =
               selectedStandaloneProducts.length === 1 &&
               selectedStandaloneProducts[0] === id
 
             return (
-              <MainProductCard
+              <StandaloneProductCard
                 key={id}
-                checkboxRef={
-                  isTheOnlySelectedMainProduct ? inputRef : undefined
-                }
+                checkboxRef={isTheOnlyStandaloneProduct ? inputRef : undefined}
                 title={name}
                 price={price}
                 description={description}
                 image={image}
                 checked={selectedProductsByCategory.standaloneProducts[id]}
                 onClick={() => {
-                  if (isTheOnlySelectedMainProduct) {
+                  if (isTheOnlyStandaloneProduct) {
                     inputRef.current?.setCustomValidity(
                       textKeys.OFFER_PAGE_MISSING_MAIN_COVERAGE_ERROR(),
                     )


### PR DESCRIPTION
## What?

- `MainProductCard` --> `StandaloneProductCard`


## Why?

It seems to be the correct name

I've realised now that it would be better have done that up in the stack. I'm sorry for the trouble 😬 

**Ticket(s): [GRW-1337](https://hedvig.atlassian.net/browse/GRW-1337)**
