### PR TITLE
GRW-1454 - fix(Offer): sync url on first load

### DIFF
--- a/src/client/pages/Offer/index.tsx
+++ b/src/client/pages/Offer/index.tsx
@@ -148,11 +148,11 @@ export const OfferPage = ({
   )
 
   useEffect(() => {
-    if (isProductSelectorEnabled) {
-      const selectedQuotes = (selectedBundleVariant?.bundle.quotes ?? []).map(
+    if (isProductSelectorEnabled && selectedBundleVariant) {
+      const insuranceTypes = selectedBundleVariant?.bundle.quotes.map(
         (quote) => quote.insuranceType as InsuranceType,
       )
-      setSelectedInsuranceTypes(selectedQuotes)
+      setSelectedInsuranceTypes(insuranceTypes)
     }
   }, [
     isProductSelectorEnabled,

--- a/src/client/pages/Offer/index.tsx
+++ b/src/client/pages/Offer/index.tsx
@@ -11,7 +11,10 @@ import {
 import { EventName } from 'utils/tracking/gtm/types'
 import { localePathPattern } from 'l10n/localePathPattern'
 import { Features, useFeature } from 'utils/hooks/useFeature'
-import { useSelectedInsuranceTypes } from 'utils/hooks/useSelectedInsuranceTypes'
+import {
+  useSelectedInsuranceTypes,
+  InsuranceType,
+} from 'utils/hooks/useSelectedInsuranceTypes'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 import { LocaleLabel } from 'l10n/locales'
 import {
@@ -143,6 +146,19 @@ export const OfferPage = ({
       }),
     [marketLabel, trackOfferEvent],
   )
+
+  useEffect(() => {
+    if (isProductSelectorEnabled) {
+      const selectedQuotes = (selectedBundleVariant?.bundle.quotes ?? []).map(
+        (quote) => quote.insuranceType as InsuranceType,
+      )
+      setSelectedInsuranceTypes(selectedQuotes)
+    }
+  }, [
+    isProductSelectorEnabled,
+    selectedBundleVariant,
+    setSelectedInsuranceTypes,
+  ])
 
   if (isLoadingQuoteCart) return <LoadingPage loading />
 

--- a/src/client/utils/hooks/useSelectedInsuranceTypes.ts
+++ b/src/client/utils/hooks/useSelectedInsuranceTypes.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useCallback } from 'react'
 import { useLocation, useHistory } from 'react-router'
 import { TypeOfContract } from 'data/graphql'
 
@@ -50,19 +50,20 @@ export const useSelectedInsuranceTypes = () => {
     searchParams,
   ])
 
-  const changeSelectedInsuranceTypes = (
-    newTypes: Array<InsuranceType | TypeOfContract>,
-  ) => {
-    searchParams.delete(SEARCH_PARAM_NAME)
+  const changeSelectedInsuranceTypes = useCallback(
+    (newTypes: Array<InsuranceType | TypeOfContract>) => {
+      searchParams.delete(SEARCH_PARAM_NAME)
 
-    for (const type of newTypes) {
-      searchParams.append(SEARCH_PARAM_NAME, type)
-    }
+      for (const type of newTypes) {
+        searchParams.append(SEARCH_PARAM_NAME, type)
+      }
 
-    history.replace({
-      search: searchParams.toString(),
-    })
-  }
+      history.replace({
+        search: searchParams.toString(),
+      })
+    },
+    [searchParams, history],
+  )
 
   return [insuranceTypes, changeSelectedInsuranceTypes] as const
 }


### PR DESCRIPTION
## What?

Update URL accordingly in case offer page get's loaded without any `type` search parameter


## Why?

To avoid inconsistent UI where offer gets loaded without any Product card selected


**Ticket(s): [GRW-1464](https://hedvig.atlassian.net/browse/GRW-1464)**

## Screenshots / recordings 

https://user-images.githubusercontent.com/19200662/188846848-8913b572-629a-4542-b99c-b11c02f10347.mov

Try to remove `type` parameter and then reload the page
### [Review app](https://web-onboardi-grw-1464-f-obmnps.herokuapp.com/no-en/new-member/offer/3970252f-3557-4362-b16f-4a0fe607a15d)

