### PR TITLE
fix(SitckBottonSidebar): preserve query params while redirecting

### DIFF
--- a/src/client/pages/Offer/Introduction/Sidebar/StickyBottomSidebar.tsx
+++ b/src/client/pages/Offer/Introduction/Sidebar/StickyBottomSidebar.tsx
@@ -5,7 +5,7 @@ import { TOP_BAR_Z_INDEX } from 'components/TopBar'
 import { useTextKeys } from 'utils/textKeys'
 import { LARGE_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
 import { useFeature, Features } from 'utils/hooks/useFeature'
-import { Button, LinkButton } from 'components/buttons'
+import { Button, LinkWithQueryButton } from 'components/buttons'
 import { useQuoteCartIdFromUrl } from 'utils/hooks/useQuoteCartIdFromUrl'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 
@@ -78,7 +78,7 @@ export const StickyBottomSidebar: React.FC<Hidable & {
     <Wrapper isVisible={reallyIsVisible} displayNone={displayNone}>
       <CtaWrapper>
         {isConnectPaymentAtSignEnabled ? (
-          <LinkButton
+          <LinkWithQueryButton
             size="sm"
             fullWidth
             to={`/${localePath}/new-member/checkout/details/${quoteCartId}`}
@@ -87,7 +87,7 @@ export const StickyBottomSidebar: React.FC<Hidable & {
             disabled={isLoadingQuoteCart}
           >
             {textKeys.SIDEBAR_PROCEED_BUTTON()}
-          </LinkButton>
+          </LinkWithQueryButton>
         ) : (
           <Button
             size="sm"


### PR DESCRIPTION
## What?

Change `SitckBottomSidebar` so it preserves query parameters while redirecting.

## Why?

Query parameters should be preserve otherwise _Pentagon House Cross Sell_ UI will be inconsistent while redirecting to checking page using that button

<img width="379" alt="Screenshot 2022-09-08 at 16 56 51" src="https://user-images.githubusercontent.com/19200662/189157369-c98eec8f-6ca4-44c3-aa3f-6a6b4376811e.png">

**[Review App](https://web-onboardi-grw-1478-b-hjf82w.herokuapp.com/no-en/new-member/offer/3970252f-3557-4362-b16f-4a0fe607a15d?type=NORWEGIAN_HOME_CONTENT)**
_You need to use mobile screen dimensions to trigger the appearance of that button_

**Ticket(s): [GRW-1478](https://hedvig.atlassian.net/browse/GRW-1478)**


