### PR TITLE
GRW-1421 / feat / Close modal with escape

### DIFF
--- a/src/client/components/ErrorModal.tsx
+++ b/src/client/components/ErrorModal.tsx
@@ -4,7 +4,7 @@ import { colorsV3 } from '@hedviginsurance/brand'
 import { MEDIUM_SMALL_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
 import { WarningTriangleOutlined } from './icons/WarningTriangle'
 import { Modal, ModalProps } from './ModalNew'
-import { Button } from './CloseButton/CloseButton'
+import { Button } from './buttons'
 
 type Props = ModalProps & {
   children: React.ReactNode
@@ -66,16 +66,40 @@ const ErrorModalWrapper = styled(Modal)`
     max-width: min(36rem, 100% - 2rem);
     min-height: auto;
   }
-  ${Button} {
-    width: 1rem;
-    height: 1rem;
+`
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+  gap: 0.875rem;
+`
+
+export const ButtonOutlined = styled(Button)`
+  border: 1px solid ${colorsV3.gray900};
+  background: ${colorsV3.white};
+  color: ${colorsV3.gray900};
+  padding: 0.375rem 0.75rem;
+  font-size: 0.875rem;
+
+  &:hover,
+  &:focus {
+    color: ${colorsV3.gray900};
   }
 
   ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
-    ${Button} {
-      width: 2rem;
-      height: 2rem;
-    }
+    font-size: 1rem;
+    padding: 0.75rem 2rem;
+  }
+`
+
+export const ButtonFilled = styled(Button)`
+  font-size: 0.875rem;
+  padding: 0.375rem 0.75rem;
+  ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
+    font-size: 1rem;
+    padding: 0.75rem 2rem;
   }
 `
 

--- a/src/client/components/ModalNew.tsx
+++ b/src/client/components/ModalNew.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { motion } from 'framer-motion'
-import React, { ReactNode, useRef } from 'react'
+import React, { ReactNode, useRef, useEffect } from 'react'
 import { useScrollLock, VisibilityState } from 'utils/hooks/useScrollLock'
 import { MEDIUM_SCREEN_MEDIA_QUERY } from '../utils/mediaQueries'
 import { CloseButton } from './CloseButton/CloseButton'
@@ -94,6 +94,18 @@ export const Modal = ({
   )
 
   const hasOnCloseFunction = Boolean(onClose)
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !!onClose) {
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [hasOnCloseFunction, onClose])
 
   return (
     <Wrapper

--- a/src/client/pages/Checkout/shared/ErrorModal.tsx
+++ b/src/client/pages/Checkout/shared/ErrorModal.tsx
@@ -1,53 +1,22 @@
 import React from 'react'
 import styled from '@emotion/styled'
-import { colorsV3 } from '@hedviginsurance/brand'
 import { useHistory } from 'react-router'
 import ReactMarkdown from 'react-markdown/with-html'
-import { ErrorModal, ErrorHeading, ErrorText } from 'components/ErrorModal'
-import { Button, TextButton } from 'components/buttons'
-import { MEDIUM_SMALL_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
+import {
+  ErrorModal,
+  ErrorHeading,
+  ErrorText,
+  ButtonContainer,
+  ButtonFilled,
+  ButtonOutlined,
+} from 'components/ErrorModal'
+import { TextButton } from 'components/buttons'
 import { useTextKeys } from 'utils/textKeys'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 import { ModalProps } from 'components/ModalNew'
 import { useQuoteCartIdFromUrl } from 'utils/hooks/useQuoteCartIdFromUrl'
 import { openIntercomChat } from 'utils/intercom.helpers'
 
-const { gray900, white } = colorsV3
-
-const ButtonContainer = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  flex-wrap: wrap;
-  margin-top: 1rem;
-  gap: 0.875rem;
-`
-
-const ButtonOutlined = styled(Button)`
-  border: 1px solid ${gray900};
-  background: ${white};
-  color: ${gray900};
-  padding: 0.375rem 0.75rem;
-  font-size: 0.875rem;
-
-  &:hover,
-  &:focus {
-    color: ${gray900};
-  }
-
-  ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
-    font-size: 1rem;
-    padding: 0.75rem 2rem;
-  }
-`
-
-const ButtonFilled = styled(Button)`
-  font-size: 0.875rem;
-  padding: 0.375rem 0.75rem;
-  ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
-    font-size: 1rem;
-    padding: 0.75rem 2rem;
-  }
-`
 const InlineTextButton = styled(TextButton)`
   display: inline;
   font-size: inherit;

--- a/src/client/pages/Embark/ErrorModal.tsx
+++ b/src/client/pages/Embark/ErrorModal.tsx
@@ -1,51 +1,17 @@
 import React from 'react'
-import styled from '@emotion/styled'
 import { useHistory } from 'react-router'
 import ReactMarkdown from 'react-markdown/with-html'
-import { colorsV3 } from '@hedviginsurance/brand'
 import { ModalProps } from 'components/ModalNew'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
-import { Button } from 'components/buttons'
 import { useTextKeys } from 'utils/textKeys'
-import { ErrorModal, ErrorHeading, ErrorText } from 'components/ErrorModal'
-import { MEDIUM_SMALL_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
-
-const { gray900, white } = colorsV3
-
-const ButtonContainer = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  flex-wrap: wrap;
-  margin-top: 1rem;
-  gap: 0.875rem;
-`
-
-const ButtonOutlined = styled(Button)`
-  border: 1px solid ${gray900};
-  background: ${white};
-  color: ${gray900};
-  padding: 0.375rem 0.75rem;
-  font-size: 0.875rem;
-
-  &:hover,
-  &:focus {
-    color: ${gray900};
-  }
-
-  ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
-    font-size: 1rem;
-    padding: 0.75rem 2rem;
-  }
-`
-
-const ButtonFilled = styled(Button)`
-  font-size: 0.875rem;
-  padding: 0.375rem 0.75rem;
-  ${MEDIUM_SMALL_SCREEN_MEDIA_QUERY} {
-    font-size: 1rem;
-    padding: 0.75rem 2rem;
-  }
-`
+import {
+  ErrorModal,
+  ErrorHeading,
+  ErrorText,
+  ButtonContainer,
+  ButtonFilled,
+  ButtonOutlined,
+} from 'components/ErrorModal'
 
 type SetupFailedModalProps = Omit<ModalProps, 'onClose'> & {
   onRetry: () => void


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

Just some small updates to modal handling in web-onboarding in regards to working with GRW-1421. 

1. Close modals with Escape button press
2. Move button definitions of Error Modal into the actual component

<!-- What changes are made? If there are many changes, a list might be a good format. -->


## Why?

1. It's annoying not to be able to close Modals with Escape and it's a common user interaction pattern 
2. They're duplicated across the code base and I don't want to duplicate them into yet another component (GRW-1421's modal)

<!-- Why are these changes made? -->



**Ticket(s): sort of [GRW-1421]**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->



[GRW-1421]: https://hedvig.atlassian.net/browse/GRW-1421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ