### PR TITLE
GRW-1483 - fix(ProductSelector): conditionally displayed based on standalone/addtional coverage presence

### DIFF
--- a/src/client/pages/Offer/ProductSelector/Selector.tsx
+++ b/src/client/pages/Offer/ProductSelector/Selector.tsx
@@ -63,56 +63,65 @@ export const Selector = ({
 
   return (
     <Wrapper className={className}>
-      <section>
-        <h2>{textKeys.OFFER_PAGE_SECTION_TITLE_MAIN()}</h2>
-        <MainCoverageCardGrid>
-          {standaloneProducts.map(({ id, name, price, description, image }) => {
-            const isTheOnlySelectedStandaloneProduct =
-              selectedStandaloneProducts.length === 1 &&
-              selectedStandaloneProducts[0].id === id
+      {standaloneProducts.length > 0 && (
+        <section>
+          <h2>{textKeys.OFFER_PAGE_SECTION_TITLE_MAIN()}</h2>
+          <MainCoverageCardGrid>
+            {standaloneProducts.map(
+              ({ id, name, price, description, image }) => {
+                const isTheOnlySelectedStandaloneProduct =
+                  selectedStandaloneProducts.length === 1 &&
+                  selectedStandaloneProducts[0].id === id
 
-            return (
-              <StandaloneProductCard
-                key={id}
-                checkboxRef={
-                  isTheOnlySelectedStandaloneProduct ? inputRef : undefined
-                }
-                title={name}
-                price={price}
-                description={description}
-                image={image}
-                checked={selectedProductIds.has(id)}
-                onClick={() => {
-                  if (isTheOnlySelectedStandaloneProduct) {
-                    inputRef.current?.setCustomValidity(
-                      textKeys.OFFER_PAGE_MISSING_MAIN_COVERAGE_ERROR(),
-                    )
-                    inputRef.current?.reportValidity()
-                  } else {
-                    handleClick(id)
-                  }
-                }}
-              />
-            )
-          })}
-        </MainCoverageCardGrid>
-      </section>
-      <section>
-        <h2>{textKeys.OFFER_PAGE_SECTION_TITLE_ADDITIONAL()}</h2>
-        <AdditionalCoverageCardGrid>
-          {additionalProducts.map(({ id, name, price, description, image }) => (
-            <AdditionalProductCard
-              key={id}
-              title={name}
-              price={price}
-              description={description}
-              image={image}
-              checked={selectedProductIds.has(id)}
-              onClick={() => handleClick(id)}
-            />
-          ))}
-        </AdditionalCoverageCardGrid>
-      </section>
+                return (
+                  <StandaloneProductCard
+                    key={id}
+                    checkboxRef={
+                      isTheOnlySelectedStandaloneProduct ? inputRef : undefined
+                    }
+                    title={name}
+                    price={price}
+                    description={description}
+                    image={image}
+                    checked={selectedProductIds.has(id)}
+                    onClick={() => {
+                      if (isTheOnlySelectedStandaloneProduct) {
+                        inputRef.current?.setCustomValidity(
+                          textKeys.OFFER_PAGE_MISSING_MAIN_COVERAGE_ERROR(),
+                        )
+                        inputRef.current?.reportValidity()
+                      } else {
+                        handleClick(id)
+                      }
+                    }}
+                  />
+                )
+              },
+            )}
+          </MainCoverageCardGrid>
+        </section>
+      )}
+
+      {additionalProducts.length > 0 && (
+        <section>
+          <h2>{textKeys.OFFER_PAGE_SECTION_TITLE_ADDITIONAL()}</h2>
+          <AdditionalCoverageCardGrid>
+            {additionalProducts.map(
+              ({ id, name, price, description, image }) => (
+                <AdditionalProductCard
+                  key={id}
+                  title={name}
+                  price={price}
+                  description={description}
+                  image={image}
+                  checked={selectedProductIds.has(id)}
+                  onClick={() => handleClick(id)}
+                />
+              ),
+            )}
+          </AdditionalCoverageCardGrid>
+        </section>
+      )}
     </Wrapper>
   )
 }

--- a/src/client/pages/Offer/ProductSelector/index.tsx
+++ b/src/client/pages/Offer/ProductSelector/index.tsx
@@ -79,6 +79,12 @@ export const ProductSelector = ({
     [quoteCartQueryData],
   )
 
+  const areChoicesAvailable =
+    standaloneProducts.length + additionalProducts.length > 1
+  if (!areChoicesAvailable) {
+    return null
+  }
+
   return (
     <ContainerWrapper>
       <Container>


### PR DESCRIPTION
## What?

Displays _Product Selector_ based on the presence of main/additional quotes

## Why?

Otherwise the UI could be inconsistent; E.g: Display "Additional Coverage" subtitle when there's no additional coverage quotes. 

<img width="1220" alt="before" src="https://user-images.githubusercontent.com/19200662/189866535-58fd1b32-b978-45d6-b9d5-6355046bd5e9.png">
<img width="1220" alt="after" src="https://user-images.githubusercontent.com/19200662/189866547-ee92eb7c-c248-45a1-bbb1-b98cf7dbf166.png">

**Ticket(s): [GRW-1484](https://hedvig.atlassian.net/browse/GRW-1484)**

