### PR TITLE
Show specific error for manual review error in new checkout

### DIFF
--- a/src/client/pages/Checkout/CheckoutDetails/CheckoutDetails.tsx
+++ b/src/client/pages/Checkout/CheckoutDetails/CheckoutDetails.tsx
@@ -60,7 +60,11 @@ export const CheckoutDetails = () => {
     return (
       <>
         <LoadingPage loading />
-        <CheckoutErrorModal isVisible={error !== undefined} onRetry={onRetry} />
+        <CheckoutErrorModal
+          isVisible={error !== undefined}
+          onRetry={onRetry}
+          isManualReviewRequired={false}
+        />
       </>
     )
   }
@@ -111,7 +115,11 @@ export const CheckoutDetails = () => {
         <PaymentInfo {...priceData} />
       </Footer>
 
-      <CheckoutErrorModal isVisible={error !== undefined} onRetry={onRetry} />
+      <CheckoutErrorModal
+        isVisible={error !== undefined}
+        onRetry={onRetry}
+        isManualReviewRequired={false}
+      />
     </CheckoutDetailsWrapper>
   )
 }

--- a/src/client/pages/Checkout/CheckoutPayment/index.tsx
+++ b/src/client/pages/Checkout/CheckoutPayment/index.tsx
@@ -19,7 +19,11 @@ export const Checkout = () => {
     return (
       <>
         <LoadingPage loading />
-        <CheckoutErrorModal isVisible={error !== undefined} onRetry={onRetry} />
+        <CheckoutErrorModal
+          isVisible={error !== undefined}
+          onRetry={onRetry}
+          isManualReviewRequired={false}
+        />
       </>
     )
   }
@@ -42,7 +46,11 @@ export const Checkout = () => {
         checkoutStatus={checkoutStatus}
       />
 
-      <CheckoutErrorModal isVisible={error !== undefined} onRetry={onRetry} />
+      <CheckoutErrorModal
+        isVisible={error !== undefined}
+        onRetry={onRetry}
+        isManualReviewRequired={false}
+      />
     </>
   )
 }

--- a/src/client/pages/Checkout/shared/ErrorModal.tsx
+++ b/src/client/pages/Checkout/shared/ErrorModal.tsx
@@ -24,6 +24,7 @@ const InlineTextButton = styled(TextButton)`
 
 type SetupFailedModalProps = Omit<ModalProps, 'onClose'> & {
   onRetry: () => void
+  isManualReviewRequired: boolean
 }
 
 export const onRetry = () => {
@@ -33,6 +34,7 @@ export const onRetry = () => {
 
 export const CheckoutErrorModal = ({
   onRetry,
+  isManualReviewRequired,
   ...props
 }: SetupFailedModalProps) => {
   const textKeys = useTextKeys()
@@ -47,11 +49,17 @@ export const CheckoutErrorModal = ({
     <ErrorModal {...props}>
       <ErrorHeading>{textKeys.GENERIC_ERROR_HEADING()}</ErrorHeading>
       <ErrorText>
-        {textKeys.CHECKOUT_ERROR_TEXT_PART_1()}{' '}
-        <InlineTextButton onClick={openIntercomChat}>
-          {textKeys.CHECKOUT_ERROR_TEXT_PART_2()}
-        </InlineTextButton>{' '}
-        <ReactMarkdown source={textKeys.CHECKOUT_ERROR_TEXT_PART_3()} />
+        {isManualReviewRequired ? (
+          <ReactMarkdown source={textKeys.CHECKOUT_SIGN_FAIL_MANUAL_REVIEW()} />
+        ) : (
+          <>
+            {textKeys.CHECKOUT_ERROR_TEXT_PART_1()}{' '}
+            <InlineTextButton onClick={openIntercomChat}>
+              {textKeys.CHECKOUT_ERROR_TEXT_PART_2()}
+            </InlineTextButton>{' '}
+            <ReactMarkdown source={textKeys.CHECKOUT_ERROR_TEXT_PART_3()} />
+          </>
+        )}
       </ErrorText>
 
       <ButtonContainer>


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

Show specific error for manual review error in new checkout

Add `isManualReviewRequired`-prop to `CheckoutErrorModal`.

Refactor `CheckoutPayment` component to derive error state based on checkout error.

![Screen Shot 2022-09-16 at 13.52.44.png](https://graphite-user-uploaded-assets.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/041583b4-f453-41ba-9c5c-8c571c801b60/Screen%20Shot%202022-09-16%20at%2013.52.44.png)

## Why?

We should show a specific error and email address for people that require manual review / fail on debt check.

This already works in the Swedish checkout but was not implemented in the new checkout.


**Ticket(s): [GRW-1496]**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->



[GRW-1496]: https://hedvig.atlassian.net/browse/GRW-1496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ