### PR TITLE
Fix issue forgetting selected insurance after Adyen

### DIFF
--- a/src/client/components/buttons.tsx
+++ b/src/client/components/buttons.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import { Link, LinkProps, useLocation } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import styled from '@emotion/styled'
 import { css } from '@emotion/core'
 import { colorsV3 } from '@hedviginsurance/brand'
@@ -87,15 +86,7 @@ export const Button = styled(UnstyledButton)<ButtonProps>`
     `}
 `
 
-const LinkWithQuery = ({ to, ...others }: LinkProps) => {
-  const { search } = useLocation()
-
-  return <Link to={to + search} {...others} />
-}
-
 export const LinkButton = Button.withComponent(Link)
-
-export const LinkWithQueryButton = Button.withComponent(LinkWithQuery)
 
 export type TextButtonProps = {
   color?: string

--- a/src/client/pages/Checkout/CheckoutDetails/CheckoutDetails.tsx
+++ b/src/client/pages/Checkout/CheckoutDetails/CheckoutDetails.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
-import { useHistory, useLocation } from 'react-router-dom'
+import { useHistory } from 'react-router-dom'
 import { useTrackOfferEvent } from 'utils/tracking/hooks/useTrackOfferEvent'
 import { useTextKeys } from 'utils/textKeys'
 import { useQuoteCartIdFromUrl } from 'utils/hooks/useQuoteCartIdFromUrl'
@@ -48,7 +48,6 @@ export const CheckoutDetails = () => {
   const { quoteCartId } = useQuoteCartIdFromUrl()
 
   const history = useHistory()
-  const { search } = useLocation()
   const startDateProps = useStartDateProps()
   useScrollToTop()
 
@@ -70,7 +69,7 @@ export const CheckoutDetails = () => {
   }
 
   const handleClickBackButton = () => {
-    const offerPageLink = `/${localePath}/new-member/offer/${quoteCartId}${search}`
+    const offerPageLink = `/${localePath}/new-member/offer/${quoteCartId}`
     trackOfferEvent({ eventName: EventName.CheckoutOpenGoBack })
     history.push(offerPageLink)
   }
@@ -86,7 +85,7 @@ export const CheckoutDetails = () => {
   const priceData = data.priceData
   const quoteDetails = data.quoteDetails
   const allQuotes = data.selectedQuoteBundleVariant.bundle.quotes
-  const paymentPageLink = `/${localePath}/new-member/checkout/payment/${quoteCartId}${search}`
+  const paymentPageLink = `/${localePath}/new-member/checkout/payment/${quoteCartId}`
 
   return (
     <CheckoutDetailsWrapper handleClickBackButton={handleClickBackButton}>

--- a/src/client/pages/Checkout/CheckoutPayment/CheckoutPayment.tsx
+++ b/src/client/pages/Checkout/CheckoutPayment/CheckoutPayment.tsx
@@ -495,7 +495,7 @@ export const CheckoutPayment = ({
   }
 
   const handleClickBackButton = () => {
-    const detailsPageLink = `/${locale.path}/new-member/checkout/details/${quoteCartId}${search}`
+    const detailsPageLink = `/${locale.path}/new-member/checkout/details/${quoteCartId}`
     trackOfferEvent({ eventName: EventName.ContactInformationPageGoBack })
     history.push(detailsPageLink)
   }

--- a/src/client/pages/Offer/Introduction/Sidebar/Sidebar.tsx
+++ b/src/client/pages/Offer/Introduction/Sidebar/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   useQuoteCartQuery,
 } from 'data/graphql'
 
-import { Button, TextButton, LinkWithQueryButton } from 'components/buttons'
+import { Button, TextButton, LinkButton } from 'components/buttons'
 import { CampaignBadge } from 'components/CampaignBadge/CampaignBadge'
 import { OfferData } from 'pages/Offer/types'
 import { Price } from 'pages/Offer/Checkout/Price/price'
@@ -315,7 +315,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
               </Body>
               <Footer>
                 {isConnectPaymentAtSignEnabled ? (
-                  <LinkWithQueryButton
+                  <LinkButton
                     size="sm"
                     fullWidth
                     to={`/${localePath}/new-member/checkout/details/${quoteCartId}`}
@@ -327,7 +327,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                     }}
                   >
                     {textKeys.SIDEBAR_PROCEED_BUTTON()}
-                  </LinkWithQueryButton>
+                  </LinkButton>
                 ) : (
                   <Button
                     size="sm"

--- a/src/client/pages/Offer/Introduction/Sidebar/StickyBottomSidebar.tsx
+++ b/src/client/pages/Offer/Introduction/Sidebar/StickyBottomSidebar.tsx
@@ -5,7 +5,7 @@ import { TOP_BAR_Z_INDEX } from 'components/TopBar'
 import { useTextKeys } from 'utils/textKeys'
 import { LARGE_SCREEN_MEDIA_QUERY } from 'utils/mediaQueries'
 import { useFeature, Features } from 'utils/hooks/useFeature'
-import { Button, LinkWithQueryButton } from 'components/buttons'
+import { Button, LinkButton } from 'components/buttons'
 import { useQuoteCartIdFromUrl } from 'utils/hooks/useQuoteCartIdFromUrl'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 
@@ -78,7 +78,7 @@ export const StickyBottomSidebar: React.FC<Hidable & {
     <Wrapper isVisible={reallyIsVisible} displayNone={displayNone}>
       <CtaWrapper>
         {isConnectPaymentAtSignEnabled ? (
-          <LinkWithQueryButton
+          <LinkButton
             size="sm"
             fullWidth
             to={`/${localePath}/new-member/checkout/details/${quoteCartId}`}
@@ -87,7 +87,7 @@ export const StickyBottomSidebar: React.FC<Hidable & {
             disabled={isLoadingQuoteCart}
           >
             {textKeys.SIDEBAR_PROCEED_BUTTON()}
-          </LinkWithQueryButton>
+          </LinkButton>
         ) : (
           <Button
             size="sm"

--- a/src/client/pages/Offer/ProductSelector/Selector.tsx
+++ b/src/client/pages/Offer/ProductSelector/Selector.tsx
@@ -1,12 +1,13 @@
 import React, { useRef } from 'react'
-import { useLocation, useHistory } from 'react-router'
 import styled from '@emotion/styled'
 import { useTextKeys } from 'utils/textKeys'
 import { MEDIA_QUERIES } from 'utils/mediaQueries'
 import { StandaloneProductCard } from 'components/StandaloneProductCard'
 import { AdditionalProductCard } from 'components/AdditionalProductCard'
-
-const SEARCH_PARAM = 'type'
+import {
+  useSelectedInsuranceTypes,
+  validateInsuranceTypes,
+} from 'utils/hooks/useSelectedInsuranceTypes'
 
 export type Product = {
   id: string
@@ -28,37 +29,30 @@ export const Selector = ({
   additionalProducts,
 }: SelectorProps) => {
   const textKeys = useTextKeys()
-
-  const { search: searchParams } = useLocation()
-  const history = useHistory()
-
   const inputRef = useRef<HTMLInputElement | null>(null)
 
-  const selectedProductIds = new Set(
-    new URLSearchParams(searchParams).getAll(SEARCH_PARAM),
+  const [
+    selectedInsuranceTypes,
+    changeInsuranceTypes,
+  ] = useSelectedInsuranceTypes()
+
+  const selectedInsuranceTypesSet = new Set(
+    selectedInsuranceTypes as Array<string>,
   )
+
   const selectedStandaloneProducts = standaloneProducts.filter(({ id }) =>
-    selectedProductIds.has(id),
+    selectedInsuranceTypesSet.has(id),
   )
 
-  const handleClick = (productId: string) => {
-    const searchParams = new URLSearchParams()
-
-    const newSelectedProductIds = new Set(selectedProductIds)
-    const isProductSelected = selectedProductIds.has(productId)
-    if (isProductSelected) {
-      newSelectedProductIds.delete(productId)
+  const handleClick = (insuranceType: string) => {
+    if (selectedInsuranceTypesSet.has(insuranceType)) {
+      selectedInsuranceTypesSet.delete(insuranceType)
     } else {
-      newSelectedProductIds.add(productId)
+      selectedInsuranceTypesSet.add(insuranceType)
     }
 
-    newSelectedProductIds.forEach((productId) =>
-      searchParams.append(SEARCH_PARAM, productId),
-    )
-
-    history.replace({
-      search: searchParams.toString(),
-    })
+    const newTypes = validateInsuranceTypes([...selectedInsuranceTypesSet])
+    changeInsuranceTypes(newTypes)
   }
 
   return (
@@ -83,7 +77,7 @@ export const Selector = ({
                     price={price}
                     description={description}
                     image={image}
-                    checked={selectedProductIds.has(id)}
+                    checked={selectedInsuranceTypesSet.has(id)}
                     onClick={() => {
                       if (isTheOnlySelectedStandaloneProduct) {
                         inputRef.current?.setCustomValidity(
@@ -114,7 +108,7 @@ export const Selector = ({
                   price={price}
                   description={description}
                   image={image}
-                  checked={selectedProductIds.has(id)}
+                  checked={selectedInsuranceTypesSet.has(id)}
                   onClick={() => handleClick(id)}
                 />
               ),

--- a/src/client/utils/tracking/hooks/useSendDatadogAction.ts
+++ b/src/client/utils/tracking/hooks/useSendDatadogAction.ts
@@ -3,18 +3,17 @@ import { useCallback } from 'react'
 import { getSelectedBundleVariant } from 'api/quoteCartQuerySelectors'
 import { QuoteCartDocument, QuoteCartQuery } from 'data/graphql'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
-import { getSelectedInsuranceTypes } from 'utils/hooks/useSelectedInsuranceTypes'
+import { useSelectedInsuranceTypes } from 'utils/hooks/useSelectedInsuranceTypes'
 import { useQuoteCartIdFromUrl } from 'utils/hooks/useQuoteCartIdFromUrl'
 import { apolloClient } from 'apolloClient'
 
 export const useSendDatadogAction = () => {
   const { apiMarket, isoLocale } = useCurrentLocale()
   const { quoteCartId } = useQuoteCartIdFromUrl()
+  const [insuranceTypes] = useSelectedInsuranceTypes()
 
   return useCallback(
     (eventName: string) => {
-      const insuranceTypes = getSelectedInsuranceTypes()
-
       const data = apolloClient?.client.readQuery({
         query: QuoteCartDocument,
         variables: { id: quoteCartId, locale: isoLocale },
@@ -33,6 +32,6 @@ export const useSendDatadogAction = () => {
         market: apiMarket,
       })
     },
-    [quoteCartId, apiMarket, isoLocale],
+    [quoteCartId, apiMarket, isoLocale, insuranceTypes],
   )
 }

--- a/src/client/utils/tracking/hooks/useTrackOfferEvent.ts
+++ b/src/client/utils/tracking/hooks/useTrackOfferEvent.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import { QuoteCartDocument, QuoteCartQuery } from 'data/graphql'
 import { useQuoteCartIdFromUrl } from 'utils/hooks/useQuoteCartIdFromUrl'
-import { getSelectedInsuranceTypes } from 'utils/hooks/useSelectedInsuranceTypes'
+import { useSelectedInsuranceTypes } from 'utils/hooks/useSelectedInsuranceTypes'
 import {
   getSelectedBundleVariant,
   hasMonthlyCostDeduction,
@@ -17,6 +17,7 @@ import {
 export const useTrackOfferEvent = () => {
   const { isoLocale } = useCurrentLocale()
   const { quoteCartId } = useQuoteCartIdFromUrl()
+  const [insuranceTypes] = useSelectedInsuranceTypes()
 
   const trackEventHandler = useCallback(
     ({ eventName, options = {} }: EventParameters) => {
@@ -31,7 +32,7 @@ export const useTrackOfferEvent = () => {
 
         const bundle = getSelectedBundleVariant(
           quoteCartQueryData,
-          getSelectedInsuranceTypes(),
+          insuranceTypes,
         )?.bundle
 
         if (bundle) {
@@ -50,7 +51,7 @@ export const useTrackOfferEvent = () => {
         trackEventCallback(apolloClient)
       }
     },
-    [quoteCartId, isoLocale],
+    [quoteCartId, isoLocale, insuranceTypes],
   )
 
   return trackEventHandler

--- a/src/client/utils/tracking/hooks/useTrackSignedCustomerEvent.ts
+++ b/src/client/utils/tracking/hooks/useTrackSignedCustomerEvent.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import { QuoteCartDocument, QuoteCartQuery } from 'data/graphql'
 import { useQuoteCartIdFromUrl } from 'utils/hooks/useQuoteCartIdFromUrl'
-import { getSelectedInsuranceTypes } from 'utils/hooks/useSelectedInsuranceTypes'
+import { useSelectedInsuranceTypes } from 'utils/hooks/useSelectedInsuranceTypes'
 import {
   getSelectedBundleVariant,
   getCampaign,
@@ -17,8 +17,8 @@ import {
 
 export const useTrackSignedCustomerEvent = () => {
   const { isoLocale, adTractionConfig, marketLabel } = useCurrentLocale()
-
   const { quoteCartId } = useQuoteCartIdFromUrl()
+  const [insuranceTypes] = useSelectedInsuranceTypes()
 
   const trackEventHandler = useCallback(
     ({
@@ -37,7 +37,7 @@ export const useTrackSignedCustomerEvent = () => {
 
         const selectedBundleVariant = getSelectedBundleVariant(
           quoteCartQueryData,
-          getSelectedInsuranceTypes(),
+          insuranceTypes,
         )
 
         if (selectedBundleVariant) {
@@ -60,7 +60,7 @@ export const useTrackSignedCustomerEvent = () => {
         trackEventCallback(apolloClient)
       }
     },
-    [quoteCartId, isoLocale, adTractionConfig, marketLabel],
+    [quoteCartId, isoLocale, adTractionConfig, marketLabel, insuranceTypes],
   )
 
   return trackEventHandler


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

Use SessionStorage instead of URL to store selected insurance types.
Use URL to store initial insurance types (from Embark).
Update previous users of `getSelectedInsuranceTypes`.
Remove handling of search params in new Checkout.

<!-- What changes are made? If there are many changes, a list might be a good format. -->


## Why?

We have a bug in production where we lose this information.

Reference: https://hedviginsurance.slack.com/archives/CPCUHMMJQ/p1663578089945019

This results in users signing other insurances than they intended.

<!-- Why are these changes made? -->



**Ticket(s): []**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

