### PR TITLE
GRW-1512 / Add possibility to pass env variables from to Embark

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ APP_ENVIRONMENT=development
 # Options: true | false
 USE_HELMET=false
 
+INSURELY_CLIENT_ID=#<Set in prod-env>
+
 # Optional: Datadog Real User Monitoring
 DATADOG_APPLICATION_ID=<datadog application id>
 DATADOG_CLIENT_TOKEN=<datadog client token>

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.23",
     "@hedviginsurance/brand": "^5.0.3",
-    "@hedviginsurance/embark": "2.14.0",
+    "@hedviginsurance/embark": "2.15.0",
     "@tippyjs/react": "^4.2.6",
     "@types/dayzed": "^2.2.1",
     "@types/escape-html": "^1.0.0",

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -420,6 +420,10 @@ export const EmbarkRoot = (props: EmbarkRootProps) => {
                       location.href = `/${pathLocale}/${cleanedPath}`
                     },
                   }}
+                  config={{
+                    insurelyClientId:
+                      window.hedvigClientConfig.insurelyClientId,
+                  }}
                   data={data[1]}
                   resolvers={{
                     graphqlQuery: graphQLQuery(storageState, isoLocale),

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -33,6 +33,8 @@ export const DATADOG_CLIENT_TOKEN = process.env.DATADOG_CLIENT_TOKEN!
 
 export const APP_ENVIRONMENT = process.env.APP_ENVIRONMENT ?? 'development'
 
+export const INSURELY_CLIENT_ID = process.env.INSURELY_CLIENT_ID!
+
 export const EMBARK_STORY_NO = process.env.EMBARK_STORY_NO ?? 'onboarding-NO-v2'
 export const EMBARK_STORY_DK = process.env.EMBARK_STORY_DK ?? 'onboarding-DK'
 

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -25,6 +25,7 @@ import {
   GIRAFFE_HOST,
   EMBARK_STORY_NO,
   EMBARK_STORY_DK,
+  INSURELY_CLIENT_ID,
 } from './config'
 import { favicons } from './favicons'
 import { getPageMeta } from './meta'
@@ -48,7 +49,7 @@ const clientConfig: ClientConfig = {
     version: HEROKU_SLUG_COMMIT,
   },
   referer: null,
-
+  insurelyClientId: INSURELY_CLIENT_ID,
   embarkStory: {
     NO: EMBARK_STORY_NO,
     DK: EMBARK_STORY_DK,

--- a/src/shared/clientConfig.ts
+++ b/src/shared/clientConfig.ts
@@ -39,6 +39,7 @@ export type ClientConfig = {
   appEnvironment: AppEnvironment
   features: FeatureMap
   datadog: RumInitConfiguration
+  insurelyClientId: string
   embarkStory: { NO: string; DK: string }
 } & ClientConfigServerData
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,10 +2234,10 @@
   resolved "https://registry.yarnpkg.com/@hedviginsurance/brand/-/brand-5.0.3.tgz#8ddc4516830da89220cc4d52eeaab0896916dd82"
   integrity sha512-0fvSwnDWR2inKPvwiCDq67QC/p02E0j+nTJAG/0O5Zkrt52NLFZDVpprhoAFF9Tn+ZGm6Qr7E6/uiQ5A/mPwmg==
 
-"@hedviginsurance/embark@2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.14.0.tgz#a212784e598f05f0c94151cad0f653cf29b59775"
-  integrity sha512-+kISp4GO0Iyhiqa/oeYUOUilWvpHJhehmAK8p74gNEfjLbdh6GlzOmI8egtyyxt2V9+NIqxlWAxhUwp51TOzcQ==
+"@hedviginsurance/embark@2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.15.0.tgz#0da9f805a613cb295ef18e0bd830cdb6719f6609"
+  integrity sha512-fgBt9NdcViqg/L7865zPNVRJNWl/GuCZ/lv/FBSpwS//Z9AUPm7Pf0qNeY2LLne+fWuJmxeSnlZdAIkP+GDUXg==
   dependencies:
     "@emotion/react" "^11.4.1"
     "@emotion/styled" "^11.3.0"


### PR DESCRIPTION

<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

<!-- What changes are made? If there are many changes, a list might be a good format. -->
Add possibility to pass config variables from web-onboarding to Embark upon init




## Why?

We need to configure which URL Insurely loads from depending on environment and there is no such concept in Embark really. There is obviously no way for the components that are published as an NPM package to be different per environment so instead they need to receive a config from outside.

<!-- Why are these changes made? -->

I tried coming up with a way to do this server-side, either in Embark or Giraffe but in the end it seemed to be simpler just to use the env variables from web-onboarding.

See also https://github.com/HedvigInsurance/embark/pull/1030


**Ticket(s): [GRW-1512]**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->



[GRW-1512]: https://hedvig.atlassian.net/browse/GRW-1512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ