### PR TITLE
GRW-1559 - bug: proper update cache so price gets proper updated

### DIFF
--- a/src/client/data/graphql.tsx
+++ b/src/client/data/graphql.tsx
@@ -1751,9 +1751,9 @@ export type Charge = {
 
 export type ChargeEstimation = {
   __typename?: 'ChargeEstimation'
-  charge: MonetaryAmountV2
-  discount: MonetaryAmountV2
   subscription: MonetaryAmountV2
+  discount: MonetaryAmountV2
+  charge: MonetaryAmountV2
 }
 
 export type ChatAction = {
@@ -7850,6 +7850,7 @@ export type PartnerInitWidgetInput = {
   externalMemberId?: Maybe<Scalars['ID']>
   requestId?: Maybe<Scalars['String']>
   market?: Maybe<Market>
+  channel?: Maybe<Scalars['String']>
 }
 
 export type PartnerInitWidgetResult = {
@@ -9851,6 +9852,7 @@ export type SwedishCarInfo = {
   registrationNumber?: Maybe<Scalars['String']>
   personalRegistrationNumber?: Maybe<Scalars['String']>
   currentInsuranceHolderSsn?: Maybe<Scalars['String']>
+  currentInsurer?: Maybe<Scalars['String']>
 }
 
 export enum SwedishCarLineOfBusiness {
@@ -11500,8 +11502,25 @@ export type EditBundledQuoteMutation = { __typename?: 'Mutation' } & {
     | ({ __typename?: 'QuoteCart' } & {
         bundle?: Maybe<
           { __typename?: 'QuoteBundle' } & {
-            quotes: Array<
-              { __typename?: 'BundledQuote' } & QuoteDataFragmentFragment
+            possibleVariations: Array<
+              { __typename?: 'QuoteBundleVariant' } & Pick<
+                QuoteBundleVariant,
+                'id' | 'tag'
+              > & {
+                  bundle: { __typename?: 'QuoteBundle' } & Pick<
+                    QuoteBundle,
+                    'displayName'
+                  > & {
+                      bundleCost: {
+                        __typename?: 'InsuranceCost'
+                      } & BundleCostDataFragmentFragment
+                      quotes: Array<
+                        {
+                          __typename?: 'BundledQuote'
+                        } & QuoteDataFragmentFragment
+                      >
+                    }
+                }
             >
           }
         >
@@ -13185,8 +13204,18 @@ export const EditBundledQuoteDocument = gql`
     ) {
       ... on QuoteCart {
         bundle {
-          quotes {
-            ...QuoteDataFragment
+          possibleVariations {
+            id
+            tag(locale: $locale)
+            bundle {
+              displayName(locale: $locale)
+              bundleCost {
+                ...BundleCostDataFragment
+              }
+              quotes {
+                ...QuoteDataFragment
+              }
+            }
           }
         }
       }
@@ -13199,6 +13228,7 @@ export const EditBundledQuoteDocument = gql`
       }
     }
   }
+  ${BundleCostDataFragmentFragmentDoc}
   ${QuoteDataFragmentFragmentDoc}
 `
 export type EditBundledQuoteMutationFn = ApolloReactCommon.MutationFunction<

--- a/src/client/graphql/EditBundleQuote.graphql
+++ b/src/client/graphql/EditBundleQuote.graphql
@@ -7,8 +7,18 @@ mutation EditBundledQuote(
   quoteCart_editQuote(id: $quoteCartId, quoteId: $quoteId, payload: $payload) {
     ... on QuoteCart {
       bundle {
-        quotes {
-          ...QuoteDataFragment
+        possibleVariations {
+          id
+          tag(locale: $locale)
+          bundle {
+            displayName(locale: $locale)
+            bundleCost {
+              ...BundleCostDataFragment
+            }
+            quotes {
+              ...QuoteDataFragment
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## What?

Also include `possibleVariations` info into edit bundle mutation so we get `QuoteBundleVariant.bundleCost` properly updated after a quote gets executed.

## Why?

The issue was introduced [here](https://github.com/HedvigInsurance/web-onboarding/pull/735) as I thought we could just request information about `BunledQuote`s after executing an edit quote mutation in order to get the cache proper updated. However that was not enough since `bundleCost` is get from the `QuotebundleVariant.bundle`.

**Ticket(s): [GRW-1559](https://hedvig.atlassian.net/browse/GRW-1559)**

## Screenshots / recordings

https://user-images.githubusercontent.com/19200662/192516972-550b69f7-45d6-4f69-ab03-f55744230923.mov

