### PR TITLE
Pass in Insurely client ids for both Home and Car

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,8 @@ APP_ENVIRONMENT=development
 # Options: true | false
 USE_HELMET=false
 
-INSURELY_CLIENT_ID=#<Set in prod-env>
+INSURELY_HOME_CLIENT_ID=<set in Heroku>
+INSURELY_CAR_CLIENT_ID=<set in Heroku>
 
 # Optional: Datadog Real User Monitoring
 DATADOG_APPLICATION_ID=<datadog application id>

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.23",
     "@hedviginsurance/brand": "^5.0.3",
-    "@hedviginsurance/embark": "2.18.1",
+    "@hedviginsurance/embark": "2.20.0",
     "@tippyjs/react": "^4.2.6",
     "@types/dayzed": "^2.2.1",
     "@types/escape-html": "^1.0.0",

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -422,7 +422,7 @@ export const EmbarkRoot = (props: EmbarkRootProps) => {
                   }}
                   config={{
                     insurelyClientIds: {
-                      HEDVIG: window.hedvigClientConfig.insurelyClientId,
+                      HEDVIG: window.hedvigClientConfig.insurelyHomeClientId,
                       HEDVIG_CAR: window.hedvigClientConfig.insurelyCarClientId,
                     },
                     logLevel:

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -425,6 +425,10 @@ export const EmbarkRoot = (props: EmbarkRootProps) => {
                       HEDVIG: window.hedvigClientConfig.insurelyClientId,
                       HEDVIG_CAR: window.hedvigClientConfig.insurelyCarClientId,
                     },
+                    logLevel:
+                      window.hedvigClientConfig.appEnvironment === 'development'
+                        ? 'debug'
+                        : 'warn',
                   }}
                   data={data[1]}
                   resolvers={{

--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -421,8 +421,10 @@ export const EmbarkRoot = (props: EmbarkRootProps) => {
                     },
                   }}
                   config={{
-                    insurelyClientId:
-                      window.hedvigClientConfig.insurelyClientId,
+                    insurelyClientIds: {
+                      HEDVIG: window.hedvigClientConfig.insurelyClientId,
+                      HEDVIG_CAR: window.hedvigClientConfig.insurelyCarClientId,
+                    },
                   }}
                   data={data[1]}
                   resolvers={{

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -33,7 +33,7 @@ export const DATADOG_CLIENT_TOKEN = process.env.DATADOG_CLIENT_TOKEN!
 
 export const APP_ENVIRONMENT = process.env.APP_ENVIRONMENT ?? 'development'
 
-export const INSURELY_CLIENT_ID = process.env.INSURELY_CLIENT_ID!
+export const INSURELY_HOME_CLIENT_ID = process.env.INSURELY_HOME_CLIENT_ID!
 export const INSURELY_CAR_CLIENT_ID = process.env.INSURELY_CAR_CLIENT_ID!
 
 export const EMBARK_STORY_NO = process.env.EMBARK_STORY_NO ?? 'onboarding-NO-v2'

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -34,6 +34,7 @@ export const DATADOG_CLIENT_TOKEN = process.env.DATADOG_CLIENT_TOKEN!
 export const APP_ENVIRONMENT = process.env.APP_ENVIRONMENT ?? 'development'
 
 export const INSURELY_CLIENT_ID = process.env.INSURELY_CLIENT_ID!
+export const INSURELY_CAR_CLIENT_ID = process.env.INSURELY_CAR_CLIENT_ID!
 
 export const EMBARK_STORY_NO = process.env.EMBARK_STORY_NO ?? 'onboarding-NO-v2'
 export const EMBARK_STORY_DK = process.env.EMBARK_STORY_DK ?? 'onboarding-DK'

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -25,8 +25,8 @@ import {
   GIRAFFE_HOST,
   EMBARK_STORY_NO,
   EMBARK_STORY_DK,
-  INSURELY_CLIENT_ID,
   INSURELY_CAR_CLIENT_ID,
+  INSURELY_HOME_CLIENT_ID,
 } from './config'
 import { favicons } from './favicons'
 import { getPageMeta } from './meta'
@@ -50,7 +50,7 @@ const clientConfig: ClientConfig = {
     version: HEROKU_SLUG_COMMIT,
   },
   referer: null,
-  insurelyClientId: INSURELY_CLIENT_ID,
+  insurelyHomeClientId: INSURELY_HOME_CLIENT_ID,
   insurelyCarClientId: INSURELY_CAR_CLIENT_ID,
   embarkStory: {
     NO: EMBARK_STORY_NO,

--- a/src/server/page.ts
+++ b/src/server/page.ts
@@ -26,6 +26,7 @@ import {
   EMBARK_STORY_NO,
   EMBARK_STORY_DK,
   INSURELY_CLIENT_ID,
+  INSURELY_CAR_CLIENT_ID,
 } from './config'
 import { favicons } from './favicons'
 import { getPageMeta } from './meta'
@@ -50,6 +51,7 @@ const clientConfig: ClientConfig = {
   },
   referer: null,
   insurelyClientId: INSURELY_CLIENT_ID,
+  insurelyCarClientId: INSURELY_CAR_CLIENT_ID,
   embarkStory: {
     NO: EMBARK_STORY_NO,
     DK: EMBARK_STORY_DK,

--- a/src/shared/clientConfig.ts
+++ b/src/shared/clientConfig.ts
@@ -39,7 +39,7 @@ export type ClientConfig = {
   appEnvironment: AppEnvironment
   features: FeatureMap
   datadog: RumInitConfiguration
-  insurelyClientId: string
+  insurelyHomeClientId: string
   insurelyCarClientId: string
   embarkStory: { NO: string; DK: string }
 } & ClientConfigServerData

--- a/src/shared/clientConfig.ts
+++ b/src/shared/clientConfig.ts
@@ -40,6 +40,7 @@ export type ClientConfig = {
   features: FeatureMap
   datadog: RumInitConfiguration
   insurelyClientId: string
+  insurelyCarClientId: string
   embarkStory: { NO: string; DK: string }
 } & ClientConfigServerData
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,10 +2234,10 @@
   resolved "https://registry.yarnpkg.com/@hedviginsurance/brand/-/brand-5.0.3.tgz#8ddc4516830da89220cc4d52eeaab0896916dd82"
   integrity sha512-0fvSwnDWR2inKPvwiCDq67QC/p02E0j+nTJAG/0O5Zkrt52NLFZDVpprhoAFF9Tn+ZGm6Qr7E6/uiQ5A/mPwmg==
 
-"@hedviginsurance/embark@2.18.1":
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.18.1.tgz#07cd4e87ea591152f748192249a65cc941d33fbf"
-  integrity sha512-UqQ30QfA148YXw1DCgEfV9oGYUI2YfAL4psIAlk95uw8f3lfv8jta3Ip5mZNYkYFbDzNFn50yqI+inieGrJX9A==
+"@hedviginsurance/embark@2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.20.0.tgz#c94fa5fd0ffce0072c054391f2caee05a0eb1a78"
+  integrity sha512-PA4qLcTGbukKIiMTeB11ooOYsCpyzVnFs2d7ZDURys7W5Nj4aaDICuv5y+edBfigi8Gf8gCLrmCOjwhp26NNkg==
   dependencies:
     "@emotion/react" "^11.4.1"
     "@emotion/styled" "^11.3.0"


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

Because of https://github.com/HedvigInsurance/embark/pull/1044 the configuration signature for Insurely has changed. It's technically a breaking change but the flow and iframe isn't used by any end-users so it's not a problem.

<!-- What changes are made? If there are many changes, a list might be a good format. -->


## Why?



<!-- Why are these changes made? -->

We need to use different Insurely Client IDs depending on which Embark flow we initialize - Insurely wants us to use different Client IDs for different products.

**Ticket(s): [GRW-1579](https://hedvig.atlassian.net/browse/GRW-1579)**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

