### PR TITLE
GRW-1594 - chore: update default embark stories for NO and DK

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -36,8 +36,8 @@ export const APP_ENVIRONMENT = process.env.APP_ENVIRONMENT ?? 'development'
 export const INSURELY_HOME_CLIENT_ID = process.env.INSURELY_HOME_CLIENT_ID!
 export const INSURELY_CAR_CLIENT_ID = process.env.INSURELY_CAR_CLIENT_ID!
 
-export const EMBARK_STORY_NO = process.env.EMBARK_STORY_NO ?? 'onboarding-NO-v2'
-export const EMBARK_STORY_DK = process.env.EMBARK_STORY_DK ?? 'onboarding-DK'
+export const EMBARK_STORY_NO = process.env.EMBARK_STORY_NO ?? 'onboarding-NO-v3'
+export const EMBARK_STORY_DK = process.env.EMBARK_STORY_DK ?? 'onboarding-DK-v2'
 
 export const FEATURES = (Object.keys(Feature) as Array<Feature>).reduce(
   (featureMap, key) => {


### PR DESCRIPTION
## What?

Update default embark stories for NO and DK


## Why?

With the release of _Pentagon House Cross Sell_ some of the embark stories for NO and DK became obsolete. The obsolete one are the ones used by default here, so that needs to change.


## Relates with

[embark changes](https://github.com/HedvigInsurance/embark/pull/1051)

**Ticket(s): [GRW-1594](https://hedvig.atlassian.net/browse/GRW-1594)**


