### PR TITLE
Pre-select Car insurance tier based on previous insurance

### DIFF
--- a/src/client/api/quoteCartQuerySelectors.ts
+++ b/src/client/api/quoteCartQuerySelectors.ts
@@ -3,7 +3,6 @@ import {
   QuoteBundleVariant,
   BundledQuote,
   TypeOfContract,
-  ExternalInsuranceDataQuery,
 } from 'data/graphql'
 import { InsuranceType } from 'utils/hooks/useSelectedInsuranceTypes'
 import { OfferData } from 'pages/Offer/types'
@@ -12,7 +11,6 @@ import { getBundleVariantFromInsuranceTypesWithFallback } from '../pages/Offer/u
 export function getSelectedBundleVariant(
   quoteCartQuery: QuoteCartQuery | undefined,
   selectedInsuranceTypes: InsuranceType[] | TypeOfContract[],
-  externalInsuranceData?: ExternalInsuranceDataQuery,
 ) {
   const bundleVariants = (quoteCartQuery?.quoteCart?.bundle
     ?.possibleVariations ?? []) as Array<QuoteBundleVariant>
@@ -22,7 +20,6 @@ export function getSelectedBundleVariant(
   return getBundleVariantFromInsuranceTypesWithFallback(
     bundleVariants,
     selectedInsuranceTypes,
-    externalInsuranceData,
   )
 }
 
@@ -104,7 +101,7 @@ export const getAdditionalQuotes = (quoteCartQuery?: QuoteCartQuery) => {
   return quoteCartQuery?.quoteCart.bundle?.additionalQuotes ?? []
 }
 
-export const getCollectionId = (quoteCartQuery?: QuoteCartQuery) => {
+export const getDataCollectionId = (quoteCartQuery?: QuoteCartQuery) => {
   return quoteCartQuery?.quoteCart?.bundle?.possibleVariations[0].bundle
     .quotes[0].dataCollectionId
 }

--- a/src/client/pages/Offer/InsuranceSelector/InsuranceSelector.helpers.ts
+++ b/src/client/pages/Offer/InsuranceSelector/InsuranceSelector.helpers.ts
@@ -1,0 +1,31 @@
+import {
+  QuoteBundleVariant,
+  ExternalInsuranceDataQuery,
+  InsuranceDataCollection,
+} from 'data/graphql'
+
+/**
+ * Only Car is supported
+ */
+export const getInsuranceExposure = (variants: QuoteBundleVariant[]) => {
+  const registrationNumber =
+    variants[0]?.bundle.quotes[0].data['registrationNumber']
+  return registrationNumber as string | undefined
+}
+
+export const getDataCollection = (
+  data: ExternalInsuranceDataQuery,
+  exposure?: string,
+) => {
+  const dataCollections = data.externalInsuranceProvider?.dataCollection
+  return dataCollections?.find(
+    (dataCollection) => dataCollection.exposure === exposure,
+  )
+}
+
+export const matchVariantAndDataCollection = (
+  variant: QuoteBundleVariant,
+  dataCollection: InsuranceDataCollection,
+) => {
+  return variant.bundle.quotes[0].typeOfContract === dataCollection.coverage
+}

--- a/src/client/pages/Offer/utils.ts
+++ b/src/client/pages/Offer/utils.ts
@@ -14,7 +14,6 @@ import {
   SwedishAccidentDetails,
   SwedishApartmentType,
   SwedishCarDetails,
-  ExternalInsuranceDataQuery,
 } from 'data/graphql'
 import { LocaleLabel, locales } from 'l10n/locales'
 import { birthDateFormats } from 'l10n/inputFormats'
@@ -431,7 +430,6 @@ const isBundleVariantMatchingContractTypes = (
 export const getBundleVariantFromInsuranceTypesWithFallback = (
   variants: Array<QuoteBundleVariant>,
   insuranceTypes: Array<InsuranceType> | Array<TypeOfContract>,
-  externalInsuranceData?: ExternalInsuranceDataQuery,
 ) => {
   // For some insurances (like Car), all insurance types are the same between TRAFFIC, HALF, and FULL.
   // In those cases we need to search on TypeOfContract instead.
@@ -454,15 +452,6 @@ export const getBundleVariantFromInsuranceTypesWithFallback = (
   )
 
   if (matchingVariant) return matchingVariant
-
-  const matchingPreviousInsurance = variants.find(
-    (variant) =>
-      variant.bundle.quotes[0].typeOfContract ===
-      externalInsuranceData?.externalInsuranceProvider?.dataCollection?.[0]
-        .coverage,
-  )
-
-  if (matchingPreviousInsurance) return matchingPreviousInsurance
 
   // Fallback to the variant with the fewest quotes
   return [...variants].sort(


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

See title. Use `exposure` from backend to match relevant data collection (registration number).

Update to the relevant tier when API query completes. Only update in case there's no selected variants already. Avoid sending analytics event in these cases.

Centralize everything to-do with matching Insurely and selected variant inside `InsuranceSelector`.

Refactor into selector helper function.

## Why?

We want to do this to accurately pre-select the correct tier.

I moved this logic out of the selector to simplify the logic a bit. We only need to worry about this when the external insurance provider query returns - not everytime we determine the selected variant.

**Ticket(s): []**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

