### PR TITLE
Use renewal date from Insurely as suggested start date

### DIFF
--- a/src/client/pages/Offer/InsuranceSelector/InsuranceSelector.helpers.ts
+++ b/src/client/pages/Offer/InsuranceSelector/InsuranceSelector.helpers.ts
@@ -1,27 +1,4 @@
-import {
-  QuoteBundleVariant,
-  ExternalInsuranceDataQuery,
-  InsuranceDataCollection,
-} from 'data/graphql'
-
-/**
- * Only Car is supported
- */
-export const getInsuranceExposure = (variants: QuoteBundleVariant[]) => {
-  const registrationNumber =
-    variants[0]?.bundle.quotes[0].data['registrationNumber']
-  return registrationNumber as string | undefined
-}
-
-export const getDataCollection = (
-  data: ExternalInsuranceDataQuery,
-  exposure?: string,
-) => {
-  const dataCollections = data.externalInsuranceProvider?.dataCollection
-  return dataCollections?.find(
-    (dataCollection) => dataCollection.exposure === exposure,
-  )
-}
+import { QuoteBundleVariant, InsuranceDataCollection } from 'data/graphql'
 
 export const matchVariantAndDataCollection = (
   variant: QuoteBundleVariant,

--- a/src/client/pages/Offer/index.tsx
+++ b/src/client/pages/Offer/index.tsx
@@ -25,7 +25,6 @@ import {
   getCampaign,
   getMonthlyCostDeductionIncentive,
   isCarInsuranceType,
-  getDataCollectionId,
 } from 'api/quoteCartQuerySelectors'
 import { useTrackOfferEvent } from 'utils/tracking/hooks/useTrackOfferEvent'
 import { useSendDatadogAction } from 'utils/tracking/hooks/useSendDatadogAction'
@@ -119,8 +118,6 @@ export const OfferPage = ({
   const checkoutMatch = useRouteMatch(
     `${localePathPattern}/new-member/sign/${quoteCartId}`,
   )
-
-  const dataCollectionId = getDataCollectionId(quoteCartQueryData) ?? null
 
   const selectedBundleVariant = getSelectedBundleVariant(
     quoteCartQueryData,
@@ -244,7 +241,6 @@ export const OfferPage = ({
         />
         {isInsuranceSelectorVisible && (
           <InsuranceSelector
-            dataCollectionId={dataCollectionId}
             variants={bundleVariants}
             selectedQuoteBundle={selectedBundleVariant}
             onChange={handleInsuranceSelectorChange}

--- a/src/client/utils/hooks/useExternalDataCollection.ts
+++ b/src/client/utils/hooks/useExternalDataCollection.ts
@@ -1,0 +1,54 @@
+import {
+  QuoteCartQuery,
+  useExternalInsuranceDataQuery,
+  InsuranceDataCollection,
+  ExternalInsuranceDataQuery,
+} from 'data/graphql'
+import { getDataCollectionId } from 'api/quoteCartQuerySelectors'
+
+type Options = {
+  onCompleted?: (data: InsuranceDataCollection) => void
+}
+
+export const useExternalDataCollection = (
+  quoteCartQueryData?: QuoteCartQuery,
+  { onCompleted }: Options = {},
+) => {
+  const variants = quoteCartQueryData?.quoteCart.bundle?.possibleVariations
+  const exposure = variants ? getInsuranceExposure(variants) : undefined
+  const dataCollectionId = getDataCollectionId(quoteCartQueryData) ?? null
+
+  const { data } = useExternalInsuranceDataQuery({
+    skip: !dataCollectionId,
+    variables: dataCollectionId ? { reference: dataCollectionId } : undefined,
+    onCompleted(newData) {
+      const matchingDataCollection = getDataCollection(newData, exposure)
+      if (matchingDataCollection) onCompleted?.(matchingDataCollection)
+    },
+  })
+
+  return data ? getDataCollection(data, exposure) : null
+}
+
+type QuoteCartQuoteBundleVariant = NonNullable<
+  QuoteCartQuery['quoteCart']['bundle']
+>['possibleVariations'][number]
+
+/**
+ * Only Car is supported
+ */
+const getInsuranceExposure = (variants: QuoteCartQuoteBundleVariant[]) => {
+  const registrationNumber =
+    variants[0]?.bundle.quotes[0].data['registrationNumber']
+  return registrationNumber as string | undefined
+}
+
+const getDataCollection = (
+  data: ExternalInsuranceDataQuery,
+  exposure?: string,
+) => {
+  const dataCollections = data.externalInsuranceProvider?.dataCollection
+  return dataCollections?.find(
+    (dataCollection) => dataCollection.exposure === exposure,
+  )
+}


### PR DESCRIPTION
## What?

Use renewal date for the old insurance from Insurely data collection to suggest start date on Offer page.

Add new reusable `useExternalDataCollection` hook. Refactor `InsuranceSelector` to use new hook.

Refactor `StartDate` component and add button to update start date to match renewal date of old insurance.

## Why?

We want to help people switch and BankSignering requires us to send a date for the start of the new insurance.

This only works for Car now but when we can match exposure for other insurance types we can enable this same feature.

There's no way to set a default date in our date picker -- that's why I went with a button the user has to click. This is also to inform the user where the date comes from. I made the button disabled if the start date already matches the renewal date to highlight the same thing.

**Ticket(s): []**
