### PR TITLE
Update Embark to version 2.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.23",
     "@hedviginsurance/brand": "^5.0.3",
-    "@hedviginsurance/embark": "2.22.0",
+    "@hedviginsurance/embark": "2.22.1",
     "@tippyjs/react": "^4.2.6",
     "@types/dayzed": "^2.2.1",
     "@types/escape-html": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,10 +2234,10 @@
   resolved "https://registry.yarnpkg.com/@hedviginsurance/brand/-/brand-5.0.3.tgz#8ddc4516830da89220cc4d52eeaab0896916dd82"
   integrity sha512-0fvSwnDWR2inKPvwiCDq67QC/p02E0j+nTJAG/0O5Zkrt52NLFZDVpprhoAFF9Tn+ZGm6Qr7E6/uiQ5A/mPwmg==
 
-"@hedviginsurance/embark@2.22.0":
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.22.0.tgz#a508d2e6b521b73602ce7ddc3043afffd2ad59de"
-  integrity sha512-nlAQrTMgQqCFbvMXzp6kafJbrKkT+UN45eIO3JpFSrngPvQCOU0Ko7moZMkoCmVE9tjd09kfOE1xSbE3oat6tg==
+"@hedviginsurance/embark@2.22.1":
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.22.1.tgz#4fe45840d8a16eea4b479326b0a2453307bceec8"
+  integrity sha512-aXWZfO/hHiIRGq4rP6VpxbYPvGTMIVIxSJsYn8gW+uYXk1VmaQhmd1QjSFnkZVxi//V8m4/fvLq8zOIlulVQjA==
   dependencies:
     "@emotion/react" "^11.4.1"
     "@emotion/styled" "^11.3.0"


### PR DESCRIPTION
## What?

Update Embark to latest version.

Correctly configure language of Insure iFrame

![localhost_8040_se-en_new-member_car_registration-number(iPad Air).png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/e0a6a88c-4498-4ed7-a064-df0be0661b08/localhost_8040_se-en_new-member_car_registration-number(iPad%20Air).png)

## Why?

N/A
