### PR TITLE
Fix edit details for Car

### DIFF
--- a/src/client/components/DetailsModal/index.tsx
+++ b/src/client/components/DetailsModal/index.tsx
@@ -190,6 +190,8 @@ export const DetailsModal = ({
     numberCoInsured,
     squareMeters,
     livingSpace,
+    subType,
+    ...restMainQuoteData
   } = mainQuoteData
   const initialValues = {
     firstName,
@@ -200,11 +202,14 @@ export const DetailsModal = ({
     phoneNumber,
     startDate,
     data: {
-      ...mainQuoteData,
+      type: mainQuoteType,
+      ...restMainQuoteData,
       ...(!quoteSelector.isCar(mainQuote) && {
         isStudent: bundleSelector.isStudent(selectedQuoteBundle.bundle.quotes),
         householdSize: numberCoInsured + 1,
+        numberCoInsured,
         livingSpace: squareMeters ? squareMeters : livingSpace,
+        subType,
       }),
     },
   } as QuoteInput


### PR DESCRIPTION
## What?

Fix issue with edit details modal that changes all `subType` fields for Car to the same value (selected insurance).

## Why?

It breaks the onboarding flow.

**Ticket(s): []**
