### PR TITLE
Refactor how to populate start date from Insurely

### DIFF
--- a/src/client/components/DateInput/index.tsx
+++ b/src/client/components/DateInput/index.tsx
@@ -54,7 +54,7 @@ interface DateInputProps {
   setOpen: (open: boolean) => void
   date: Date
   setDate: (date: Date | null) => void
-  isCurrentInsurerSwichable: boolean
+  currentInsurerRenewalDate?: Date | null
 }
 
 export const DateInput: React.FC<DateInputProps> = ({
@@ -62,7 +62,7 @@ export const DateInput: React.FC<DateInputProps> = ({
   setOpen,
   date,
   setDate,
-  isCurrentInsurerSwichable,
+  currentInsurerRenewalDate,
 }) => {
   const textKeys = useTextKeys()
   const containerRef = useRef<HTMLDivElement>(null)
@@ -125,11 +125,11 @@ export const DateInput: React.FC<DateInputProps> = ({
           </ButtonWrapper>
         </TopSection>
 
-        {isCurrentInsurerSwichable && (
+        {currentInsurerRenewalDate !== undefined && (
           <AtStartDateContainer>
             <TextButton
               onClick={() => {
-                setDate(null)
+                setDate(currentInsurerRenewalDate)
                 setOpen(false)
               }}
             >


### PR DESCRIPTION
## What?

Refactor how we populate start date from Insurely for Car on offer page.

Re-use the same solution inside `DateInput` but make it possible to set a defined start date or `null`.

## Why?

It was confusing with 2 different solutions/labels.
This solution is not very scalable so if we do additional changes here we should consider a bigger refactoring.
