### PR TITLE
Add fallback when we can't fetch insurance provider display name

### DIFF
--- a/src/client/pages/Offer/Introduction/ExternalInsuranceProvider/Compare.tsx
+++ b/src/client/pages/Offer/Introduction/ExternalInsuranceProvider/Compare.tsx
@@ -108,7 +108,8 @@ export const Compare: React.FC<Props> = (props) => {
       <CompareBox isExternalProvider>
         <CompareBoxTitle>
           <CompareBoxName isExternalProvider>
-            {insuranceDataCollection.insuranceProviderDisplayName}
+            {insuranceDataCollection.insuranceProviderDisplayName ||
+              textKeys.EXTERNAL_INSURANCE_PROVIDER_UNKNOWN_NAME()}
           </CompareBoxName>
           <Price
             monthlyGross={


### PR DESCRIPTION
## What?

See title.



## Why?

For some providers we don't get display name.

I checked the "insurance provider" field but it's not suitable for display purposes.

This translation key already existed.
