### PR TITLE
GRW-1670 / Bug / Avoid iOS Safari going back to previous passage after BankID redirect

### DIFF
--- a/src/client/pages/Embark/index.tsx
+++ b/src/client/pages/Embark/index.tsx
@@ -199,6 +199,11 @@ const Embark = (props: EmbarkProps) => {
         canGoBack={state.history.length > 1}
         historyGoBackListener={(goBack) =>
           history.listen((_: any, action: string) => {
+            // Avoid iOS Safari going back to previous passage for after Insurely BankID redirect
+            if (location.pathname.includes('/price-comparison')) {
+              return
+            }
+
             if (action === 'POP' && state.history.length > 1) {
               goBack()
             }


### PR DESCRIPTION
## What?
BUG: When going through the Car onboarding and using compare your price with Insurely you would get redirected back to the step before `/price-comparison` when having authenticated with BankID. This is due to Safari reading the redirect/reload as a history `POP` event and hence causing the user to end up on the previous passage in Embark.

We manipulate the history in the following way:
```js
historyGoBackListener={(goBack) =>
  history.listen((_: any, action: string) => {
    // This is to enable the browsers back button to navigate to the previous passage in embark
    if (action === 'POP' && state.history.length > 1) {
      goBack()
    }
  })
}
```
I tried to find a way to differentiate between hitting the navigate back button and the redirect from BankID, but couldn't find a straight forward solution. To avoid this cases in the future we might want to rethink how we manipulate the history.

So the solution for now is to do an early return in the `historyGoBackListener` for paths we know would have a BankID redirect.

## Why?
So we can release Car price matching

## Review app
https://web-onboardi-grw-1670-f-uv16in.herokuapp.com/se-en/new-member/car
Test in iOS Safari 

**Ticket(s): [GRW-1670]**




[GRW-1670]: https://hedvig.atlassian.net/browse/GRW-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ