### PR TITLE
Upgrade Embark v2.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.23",
     "@hedviginsurance/brand": "^5.0.3",
-    "@hedviginsurance/embark": "2.22.3",
+    "@hedviginsurance/embark": "2.23.0",
     "@tippyjs/react": "^4.2.6",
     "@types/dayzed": "^2.2.1",
     "@types/escape-html": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,10 +2234,10 @@
   resolved "https://registry.yarnpkg.com/@hedviginsurance/brand/-/brand-5.0.3.tgz#8ddc4516830da89220cc4d52eeaab0896916dd82"
   integrity sha512-0fvSwnDWR2inKPvwiCDq67QC/p02E0j+nTJAG/0O5Zkrt52NLFZDVpprhoAFF9Tn+ZGm6Qr7E6/uiQ5A/mPwmg==
 
-"@hedviginsurance/embark@2.22.3":
-  version "2.22.3"
-  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.22.3.tgz#6451d380d6af081f32e9902353f6726aa184d84e"
-  integrity sha512-SC8N8mS5tTvCDVXnkAMnDK/ZlfJrOP6c7jO/TtvLRkaIOw5EWsO4K0Vcoi74DpDLscdUqFz5hIBZKZOQCs9tyA==
+"@hedviginsurance/embark@2.23.0":
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/@hedviginsurance/embark/-/embark-2.23.0.tgz#d4414fbdc37b46caafaceaccf3c5107538197b75"
+  integrity sha512-Fe9gv+7Ep8fxgfDXwov7jXc3C7sx0WB38Kz8OWK7kJcwHVnB59sVKv+7pRa0WcRk5rODfcH30CMT50C3PZN5sQ==
   dependencies:
     "@emotion/react" "^11.4.1"
     "@emotion/styled" "^11.3.0"


### PR DESCRIPTION
## What?

Upgrade to latest Embark 2.23.0.
This enables automatic pre-selected company in Insurely iframe.

## Why?

N/A.

**Ticket(s): [GRW-1682]**


[GRW-1682]: https://hedvig.atlassian.net/browse/GRW-1682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ