### PR TITLE
GRW-1730 - feat: enable SE car price matching flow A/B testing

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -47,6 +47,7 @@ enum EmbarkStory {
   SwedenQuoteCartSwitcher = 'Web Onboarding SE - Quote Cart Switcher',
   SwedenQuoteCartSwitcherV2 = 'Web Onboarding SE - Quote Cart Switcher-v2',
   SwedenCarV2 = 'SE-onboarding-car-v2',
+  SwedenCarV3 = 'SE-onboarding-car-v3',
 }
 
 export type CanonicalLinksPerLocale = Record<LocalePath, string>
@@ -398,6 +399,12 @@ export const routes: Route[] = [
                   return {
                     baseUrl,
                     name: EmbarkStory.SwedenCarV2,
+                    quoteCart: true,
+                  }
+                case 'car-v3':
+                  return {
+                    baseUrl,
+                    name: EmbarkStory.SwedenCarV3,
                     quoteCart: true,
                   }
               }


### PR DESCRIPTION
## What?

Enable A/B testing with `SE-onboarding-car-v3` flow

## How to test it

1. Open the [Review app](https://web-onboardi-grw-1730-f-8nybv3.herokuapp.com/se-en/new-member/car) and observe the cookie with the format: `HEDVIG_EXP_[id]-id_g`
  * If you got `0`, it means you've got selected to our current flow which asks you want to compare the price
  *  If you got `1`, it means you've got selected to the new flow that displays the "compare" passage without asking for consent.

You can clear the cookie and star over in case you want to test both situations.

**Ticket(s): [GRW-1730](https://hedvig.atlassian.net/browse/GRW-1730)**

### [Review app](https://web-onboardi-grw-1730-f-8nybv3.herokuapp.com/se-en/new-member/car)

