### PR TITLE
fix(CheckoutDetails): change all quotes while editing info

### DIFF
--- a/src/client/pages/Checkout/CheckoutDetails/CheckoutDetails.tsx
+++ b/src/client/pages/Checkout/CheckoutDetails/CheckoutDetails.tsx
@@ -84,7 +84,8 @@ export const CheckoutDetails = () => {
 
   const priceData = data.priceData
   const quoteDetails = data.quoteDetails
-  const allQuotes = data.selectedQuoteBundleVariant.bundle.quotes
+  const allQuotes = data.allQuotes
+  const selectedQuotes = data.selectedQuoteBundleVariant.bundle.quotes
   const paymentPageLink = `/${localePath}/new-member/checkout/payment/${quoteCartId}`
 
   return (
@@ -96,7 +97,7 @@ export const CheckoutDetails = () => {
           groups={quoteDetails}
           onEditInfoButtonClick={() => setDetailsModalIsOpen(true)}
         />
-        <DocumentLinks allQuotes={allQuotes} />
+        <DocumentLinks allQuotes={selectedQuotes} />
         <CheckoutIntercomVariation />
       </PageSection>
       <DetailsModal

--- a/src/client/utils/hooks/useQuoteCartData.ts
+++ b/src/client/utils/hooks/useQuoteCartData.ts
@@ -12,12 +12,12 @@ import {
   getSelectedBundleVariant,
   getCampaign,
   getPossibleVariations,
+  getAllQuotes,
   getCheckoutStatus,
 } from 'api/quoteCartQuerySelectors'
 import {
   typeOfResidenceTextKeys,
   HomeInsuranceTypeOfContract,
-  getQuoteIdsFromBundleVariant,
 } from 'pages/Offer/utils'
 import { GenericQuoteData } from '../../pages/Offer/types'
 import { formatPostalNumber } from '../postalNumbers'
@@ -202,6 +202,7 @@ export const useQuoteCartData = () => {
     variables: { id: quoteCartId, locale: isoLocale },
   })
 
+  const allQuotes = getAllQuotes(data)
   const bundleVariants = getPossibleVariations(data)
   const [selectedInsuranceTypes] = useSelectedInsuranceTypes()
 
@@ -215,8 +216,6 @@ export const useQuoteCartData = () => {
   const prices = selectedQuoteBundleVariant?.bundle.quotes.map((item) => {
     return { displayName: item.displayName, price: item.price.amount }
   })
-
-  const quoteIds = getQuoteIdsFromBundleVariant(selectedQuoteBundleVariant)
 
   const mainQuote = getMainQuote(selectedQuoteBundleVariant.bundle)
 
@@ -246,7 +245,7 @@ export const useQuoteCartData = () => {
       quoteDetails: quoteDetailsGroups,
       selectedQuoteBundleVariant,
       quoteCartId,
-      quoteIds,
+      allQuotes,
       bundleVariants,
       mainQuote,
       checkoutStatus: getCheckoutStatus(data),


### PR DESCRIPTION
## What?

Make sure to update all quotes when changing information from _CheckoutDetails_ page


## Why?

Otherwise that can be confusing for users that change some info while in the _CheckoutDetails_ page and then go back to _Offer_ page to realise their changes were not applied to all quotes.

E.g: Assume you're in the _Offer_ page and you can select between _Home_ and _Accident_. Your name is defined as "John Doe". You select only _Home_ and move forward to _CheckoutDetails_ page (click on [Continue to Checkout] button). You then update your name to "Arnold Doe". If you go back to _Offer_ page and check Details for accident only you'll se "John Doe" as your name, which is confusing.

**Ticket(s): [GRW-1833](https://hedvig.atlassian.net/browse/GRW-1833)**
