### PR TITLE
Skip blank fields from Checkout details

### DIFF
--- a/src/client/utils/hooks/useQuoteCartData.ts
+++ b/src/client/utils/hooks/useQuoteCartData.ts
@@ -51,7 +51,8 @@ const getHomeDetails = (mainQuote: BundledQuote) => {
       street === `${street}, ${formattedFloor}${apartmentString}`
     }
   }
-  return [
+
+  const baseDetails: DetailsGroup = [
     {
       label: 'CHECKOUT_DETAILS_ADDRESS',
       value: { value: street },
@@ -62,25 +63,29 @@ const getHomeDetails = (mainQuote: BundledQuote) => {
         value: zipCode && formatPostalNumber(zipCode),
       },
     },
-    {
+  ]
+
+  const area = livingSpace || squareMeters
+  if (area) {
+    baseDetails.push({
       label: 'CHECKOUT_DETAILS_LIVING_SPACE',
       value: {
-        value: livingSpace || squareMeters,
+        value: area,
         suffix: 'CHECKOUT_DETAILS_SQM_SUFFIX',
       },
-    },
-    {
-      label: 'CHECKOUT_DETAILS_RESIDENCE_TYPE',
-      value: {
-        textKey:
-          typeOfResidenceTextKeys[
-            typeOfContract as HomeInsuranceTypeOfContract
-          ],
-      },
-    },
+    })
+  }
 
-    ...getHouseDetails(mainQuote.data),
-  ]
+  const residenceTextKey =
+    typeOfResidenceTextKeys[typeOfContract as HomeInsuranceTypeOfContract]
+  if (residenceTextKey) {
+    baseDetails.push({
+      label: 'CHECKOUT_DETAILS_RESIDENCE_TYPE',
+      value: { textKey: residenceTextKey },
+    })
+  }
+
+  return [...baseDetails, ...getHouseDetails(mainQuote.data)]
 }
 
 const getHouseDetails = (data: GenericQuoteData) => {


### PR DESCRIPTION
## What?

Skip blank fields in checkout summary when no home (content) quote is part of the selected variant.

### Before
![Screenshot 2022-11-28 at 09.56.53.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/04d7aa41-78f6-4b49-9d8a-2837d61e54a9/Screenshot%202022-11-28%20at%2009.56.53.png)

### After
![Screenshot 2022-11-28 at 10.40.13.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/47a4908d-a9a2-45bb-820b-e352bf234d78/Screenshot%202022-11-28%20at%2010.40.13.png)

## Why?

New since the travel/accident standalone feature.

**Ticket(s): [GRW-1841]**


[GRW-1841]: https://hedvig.atlassian.net/browse/GRW-1841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ