### PR TITLE
NO: Allow editing address for travel/accident

### DIFF
--- a/src/client/components/DetailsModal/Details/NorwegianDetails.tsx
+++ b/src/client/components/DetailsModal/Details/NorwegianDetails.tsx
@@ -12,6 +12,7 @@ import {
   TextInput,
   BooleanInput,
   BirthDateInput,
+  ZipcodeInput,
 } from './components/DetailInput'
 import { Content, ContentColumn } from './components/Details.styles'
 
@@ -26,6 +27,11 @@ export const getNorwegianValidationSchema = (textKeys: TextKeyMap) => {
       )
       .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
     data: Yup.object({
+      street: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
+      zipCode: Yup.string().matches(
+        /^[0-9]{4}$/,
+        textKeys.GENERIC_ERROR_INPUT_FORMAT(),
+      ),
       householdSize: Yup.number()
         .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
@@ -64,6 +70,16 @@ export const NorwegianDetails = ({ formikProps }: NorwegianDetailsProps) => {
       </ContentColumn>
       <ContentColumn>
         <InputGroup>
+          <TextInput
+            name="data.street"
+            label="DETAILS_MODULE_TABLE_ADDRESS_CELL_LABEL"
+            formikProps={formikProps}
+          />
+          <ZipcodeInput
+            name="data.zipCode"
+            market="NO"
+            formikProps={formikProps}
+          />
           <DetailInput
             name="data.householdSize"
             field={{


### PR DESCRIPTION
## What?

In Norway, always allow editing street + zip code in edit details modal on offer page.

## Why?

New need when allowing to sign travel/accident standalone.

**Ticket(s): [GRW-1843]**


[GRW-1843]: https://hedvig.atlassian.net/browse/GRW-1843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ