### PR TITLE
Fix error messages when first/last name is null

### DIFF
--- a/src/client/components/DetailsModal/Details/DanishDetails.tsx
+++ b/src/client/components/DetailsModal/Details/DanishDetails.tsx
@@ -17,8 +17,8 @@ import { Content, ContentColumn } from './components/Details.styles'
 
 export const getDanishValidationSchema = (textKeys: TextKeyMap) => {
   return Yup.object().shape({
-    firstName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
-    lastName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
+    firstName: Yup.string().nullable(true),
+    lastName: Yup.string().nullable(true),
     birthDate: Yup.string()
       .matches(
         birthDateFormats.backEndDefault,

--- a/src/client/components/DetailsModal/Details/DanishHomeDetails.tsx
+++ b/src/client/components/DetailsModal/Details/DanishHomeDetails.tsx
@@ -19,8 +19,8 @@ import { Content, ContentColumn } from './components/Details.styles'
 
 export const getDanishHomeContentsValidationSchema = (textKeys: TextKeyMap) => {
   return Yup.object().shape({
-    firstName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
-    lastName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
+    firstName: Yup.string().nullable(true),
+    lastName: Yup.string().nullable(true),
     birthDate: Yup.string()
       .matches(
         birthDateFormats.backEndDefault,

--- a/src/client/components/DetailsModal/Details/DanishHouseDetails.tsx
+++ b/src/client/components/DetailsModal/Details/DanishHouseDetails.tsx
@@ -19,8 +19,8 @@ import { Content, ContentColumn, ContentRow } from './components/Details.styles'
 
 export const getDanishHouseValidationSchema = (textKeys: TextKeyMap) => {
   return Yup.object().shape({
-    firstName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
-    lastName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
+    firstName: Yup.string().nullable(true),
+    lastName: Yup.string().nullable(true),
     birthDate: Yup.string()
       .matches(
         birthDateFormats.backEndDefault,

--- a/src/client/components/DetailsModal/Details/NorwegianDetails.tsx
+++ b/src/client/components/DetailsModal/Details/NorwegianDetails.tsx
@@ -18,8 +18,8 @@ import { Content, ContentColumn } from './components/Details.styles'
 
 export const getNorwegianValidationSchema = (textKeys: TextKeyMap) => {
   return Yup.object().shape({
-    firstName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
-    lastName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
+    firstName: Yup.string().nullable(true),
+    lastName: Yup.string().nullable(true),
     birthDate: Yup.string()
       .matches(
         birthDateFormats.backEndDefault,

--- a/src/client/components/DetailsModal/Details/NorwegianHomeDetails.tsx
+++ b/src/client/components/DetailsModal/Details/NorwegianHomeDetails.tsx
@@ -22,8 +22,8 @@ export const getNorwegianHomeContentsValidationSchema = (
   textKeys: TextKeyMap,
 ) => {
   return Yup.object().shape({
-    firstName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
-    lastName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
+    firstName: Yup.string().nullable(true),
+    lastName: Yup.string().nullable(true),
     birthDate: Yup.string()
       .matches(
         birthDateFormats.backEndDefault,

--- a/src/client/components/DetailsModal/Details/NorwegianHouseDetails.tsx
+++ b/src/client/components/DetailsModal/Details/NorwegianHouseDetails.tsx
@@ -19,8 +19,8 @@ import { Content, ContentColumn, ContentRow } from './components/Details.styles'
 
 export const getNorwegianHouseValidationSchema = (textKeys: TextKeyMap) => {
   return Yup.object().shape({
-    firstName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
-    lastName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
+    firstName: Yup.string().nullable(true),
+    lastName: Yup.string().nullable(true),
     birthDate: Yup.string()
       .matches(
         birthDateFormats.backEndDefault,

--- a/src/client/pages/Offer/Checkout/UserDetailsForm.tsx
+++ b/src/client/pages/Offer/Checkout/UserDetailsForm.tsx
@@ -13,8 +13,12 @@ export const getCheckoutDetailsValidationSchema = (
   textKeys: TextKeyMap,
 ) =>
   Yup.object().shape({
-    firstName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
-    lastName: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
+    firstName: Yup.string()
+      .nullable(true)
+      .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
+    lastName: Yup.string()
+      .nullable(true)
+      .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
     email: Yup.string()
       .email(textKeys.GENERIC_ERROR_INPUT_FORMAT())
       .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),


### PR DESCRIPTION
## What?

Fix edit details form to allow nullable first and last name inputs.

Make first and last name inputs optional in edit details modal (confirmed with Zak).

Fix checkout form to allow nullable first and last name inputs.

![Screenshot 2022-11-29 at 10.54.04.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/OgXegTwxM9IeuXHZyw5h/6f6ce742-a4c4-465f-823a-f13e689b0021/Screenshot%202022-11-29%20at%2010.54.04.png)

## Why?

We show some very strange error messages when first/last name is null (see jira ticket).

We don't need first/last name when calculating price so it should be optional in edit modal.

**Ticket(s): [GRW-1849]**


[GRW-1849]: https://hedvig.atlassian.net/browse/GRW-1849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ