### PR TITLE
Wait for response before dismissing edit modal

### DIFF
--- a/src/client/components/DetailsModal/Details/DanishDetails.tsx
+++ b/src/client/components/DetailsModal/Details/DanishDetails.tsx
@@ -27,7 +27,7 @@ export const getDanishValidationSchema = (textKeys: TextKeyMap) => {
       .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
     data: Yup.object({
       householdSize: Yup.number()
-        .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
+        .min(1, textKeys.INVALID_FIELD())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       isStudent: Yup.boolean(),
     }).required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),

--- a/src/client/components/DetailsModal/Details/DanishHomeDetails.tsx
+++ b/src/client/components/DetailsModal/Details/DanishHomeDetails.tsx
@@ -33,7 +33,7 @@ export const getDanishHomeContentsValidationSchema = (textKeys: TextKeyMap) => {
         .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       householdSize: Yup.number()
-        .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
+        .min(1, textKeys.INVALID_FIELD())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       isStudent: Yup.boolean(),
       subType: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),

--- a/src/client/components/DetailsModal/Details/DanishHouseDetails.tsx
+++ b/src/client/components/DetailsModal/Details/DanishHouseDetails.tsx
@@ -38,7 +38,7 @@ export const getDanishHouseValidationSchema = (textKeys: TextKeyMap) => {
         .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       householdSize: Yup.number()
-        .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
+        .min(1, textKeys.INVALID_FIELD())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       extraBuildings: Yup.array().of(
         Yup.object().shape({

--- a/src/client/components/DetailsModal/Details/NorwegianDetails.tsx
+++ b/src/client/components/DetailsModal/Details/NorwegianDetails.tsx
@@ -33,7 +33,7 @@ export const getNorwegianValidationSchema = (textKeys: TextKeyMap) => {
         textKeys.GENERIC_ERROR_INPUT_FORMAT(),
       ),
       householdSize: Yup.number()
-        .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
+        .min(1, textKeys.INVALID_FIELD())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       isStudent: Yup.boolean(),
     }).required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),

--- a/src/client/components/DetailsModal/Details/NorwegianHomeDetails.tsx
+++ b/src/client/components/DetailsModal/Details/NorwegianHomeDetails.tsx
@@ -41,7 +41,7 @@ export const getNorwegianHomeContentsValidationSchema = (
         .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       householdSize: Yup.number()
-        .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
+        .min(1, textKeys.INVALID_FIELD())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       isStudent: Yup.boolean(),
       subType: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),

--- a/src/client/components/DetailsModal/Details/NorwegianHouseDetails.tsx
+++ b/src/client/components/DetailsModal/Details/NorwegianHouseDetails.tsx
@@ -38,7 +38,7 @@ export const getNorwegianHouseValidationSchema = (textKeys: TextKeyMap) => {
         .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       householdSize: Yup.number()
-        .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
+        .min(1, textKeys.INVALID_FIELD())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       extraBuildings: Yup.array().of(
         Yup.object().shape({

--- a/src/client/components/DetailsModal/Details/SwedishApartmentDetails.tsx
+++ b/src/client/components/DetailsModal/Details/SwedishApartmentDetails.tsx
@@ -29,7 +29,7 @@ export const getSwedishApartmentValidationSchema = (textKeys: TextKeyMap) => {
         .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       householdSize: Yup.number()
-        .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
+        .min(1, textKeys.INVALID_FIELD())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       subType: Yup.string().required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       isStudent: Yup.boolean(),

--- a/src/client/components/DetailsModal/Details/SwedishHouseDetails.tsx
+++ b/src/client/components/DetailsModal/Details/SwedishHouseDetails.tsx
@@ -30,7 +30,7 @@ export const getSwedishHouseValidationSchema = (textKeys: TextKeyMap) => {
         .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       householdSize: Yup.number()
-        .min(1, textKeys.GENERIC_ERROR_INPUT_FORMAT())
+        .min(1, textKeys.INVALID_FIELD())
         .required(textKeys.GENERIC_ERROR_INPUT_REQUIRED()),
       ancillaryArea: Yup.number()
         .typeError(textKeys.GENERIC_ERROR_INPUT_REQUIRED())


### PR DESCRIPTION
## What?

Wait before closing edit modal so all mutations respond first.

Update error message when household size field value is invalid.

## Why?

We were reading a value outside the function before. This encloses the variable in the function scope so we are actually reading the value from the previous mutation 🤦🏻 Now we return the response and read it in the same context so they are always in sync.

I changed the error message as well since before it said "wrong format".

Thanks to @fredriklagerblad for reporting the issue!

**Ticket(s): []**
