### PR TITLE
Override 'type' for close button

### DIFF
--- a/src/client/components/DetailsModal/index.tsx
+++ b/src/client/components/DetailsModal/index.tsx
@@ -334,6 +334,7 @@ export const DetailsModal = ({
               <ModalFooter>
                 <ButtonGroup fullWidth>
                   <Button
+                    type="button"
                     background={colorsV3.white}
                     foreground={colorsV3.black}
                     border


### PR DESCRIPTION
## What?

Close button should be a regular button and not "submit" which is the default.

## Why?

Avoid closing the form "on enter".

**Ticket(s): []**
