### PR TITLE
GRW-1963 / Feature / Track experiment_impression events for new vs old site

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -2,6 +2,7 @@ import { Provider } from 'constate'
 import React from 'react'
 import { hot } from 'react-hot-loader'
 import { Route, Switch, useHistory } from 'react-router-dom'
+import { useTrackNewSiteExperiment } from 'utils/tracking/hooks/useTrackNewSiteExperiment'
 import { routes } from '../routes'
 import { TextKeyProvider } from './utils/textKeys'
 import { useTrackPageViewEvent } from './utils/tracking/hooks/useTrackPageViewEvent'
@@ -19,9 +20,11 @@ const isProductionEnvironment =
   window.hedvigClientConfig.appEnvironment === 'production'
 
 export const App: React.ComponentType<StorageState> = ({ session }) => {
+  useTrackPageViewEvent()
+  useTrackNewSiteExperiment()
+
   const { isoLocale } = useCurrentLocale()
   const history = useHistory()
-  useTrackPageViewEvent()
 
   return (
     <>

--- a/src/client/utils/tracking/hooks/useTrackAbPurchaseFlowRedirect.ts
+++ b/src/client/utils/tracking/hooks/useTrackAbPurchaseFlowRedirect.ts
@@ -25,11 +25,11 @@ export const useTrackAbPurchaseFlowRedirect = () => {
     if (!redirectConfig) {
       return
     }
-    const cookieVariant = new CookieStorage().getItem(
+    const variantCookie = new CookieStorage().getItem(
       abExperimentCookieName(redirectConfig.optimizeExperimentId),
     )
-    if (typeof cookieVariant === 'string') {
-      const variant = parseInt(cookieVariant, 10) || 0
+    if (typeof variantCookie === 'string') {
+      const variant = parseInt(variantCookie, 10) || 0
       trackExperimentImpression(redirectConfig.optimizeExperimentId, variant)
     }
   }, [abTestPurchaseFlows, params.name])

--- a/src/client/utils/tracking/hooks/useTrackNewSiteExperiment.ts
+++ b/src/client/utils/tracking/hooks/useTrackNewSiteExperiment.ts
@@ -1,0 +1,18 @@
+import { CookieStorage } from 'cookie-storage'
+import { useEffect } from 'react'
+import { trackExperimentImpression } from 'utils/tracking/gtm/trackExperimentImpression'
+import { newSiteAbTest } from 'shared/newSiteAbTest'
+
+export const useTrackNewSiteExperiment = () => {
+  useEffect(() => {
+    const variantCookie = new CookieStorage().getItem(
+      newSiteAbTest.cookies.variant.name,
+    )
+    if (typeof variantCookie === 'string') {
+      const variant = parseInt(variantCookie, 10)
+      if (variant === 0) {
+        trackExperimentImpression(newSiteAbTest.optimizeExperimentId, variant)
+      }
+    }
+  }, [])
+}

--- a/src/shared/newSiteAbTest.ts
+++ b/src/shared/newSiteAbTest.ts
@@ -1,0 +1,19 @@
+type CookieConfig = {
+  name: string
+}
+
+export type AbTestConfig = {
+  optimizeExperimentId: string
+  cookies: {
+    variant: CookieConfig
+  }
+}
+
+export const newSiteAbTest: AbTestConfig = {
+  optimizeExperimentId: 'wmRyD1ofQYSQ5LL5BEH9nw',
+  cookies: {
+    variant: {
+      name: 'HEDVIG_EXP_NEW_SITE',
+    },
+  },
+}


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

<!-- What changes are made? If there are many changes, a list might be a good format. -->

Send Analytics event when we see user selected for old site during AB testing

Simple hardcoded config, no feature flags - sending event is always safe, worst case is that it's ignored


## Why?

Need to track conversion for new vs old site in Google Optimize

<!-- Why are these changes made? -->



**Ticket(s): []**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

