### PR TITLE
Configure public host to correctly redirect from server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,6 @@ EMBARK_STORY_DK=
 
 # AB Testing weights for purchase flows
 AB_REDIRECT_WEIGHT_CAR_PRICE_MATCH_V2=50
+
+# Server-side redirects
+HOST_URL=www.dev.hedvigit.com


### PR DESCRIPTION
## What?

Configure public host name to be able to correctly redirect from the server.

## Why?

We do redirect after performing access token exchange. It was redirecting to the wrong host name.

**Ticket(s): []**
