### PR TITLE
GRW-1979 - refact: removes reference to car flow added for A/B testing

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -28,7 +28,6 @@ enum EmbarkStory {
   SwedenQuoteCartNeeder = 'Web Onboarding SE - Quote Cart Needer',
   SwedenQuoteCartSwitcherV2 = 'Web Onboarding SE - Quote Cart Switcher-v2',
   SwedenCarV2 = 'SE-onboarding-car-v2',
-  SwedenCarV3 = 'SE-onboarding-car-v3',
 }
 
 export type CanonicalLinksPerLocale = Record<LocalePath, string>
@@ -311,12 +310,6 @@ export const routes: Route[] = [
                   return {
                     baseUrl,
                     name: EmbarkStory.SwedenCarV2,
-                    quoteCart: true,
-                  }
-                case 'car-v3':
-                  return {
-                    baseUrl,
-                    name: EmbarkStory.SwedenCarV3,
                     quoteCart: true,
                   }
               }


### PR DESCRIPTION
## What?

* Removes reference to `SE-onboarding-car-v3` flow

## Why?

That flow was added as part of an A/B testing experiment. The experiment is now [done](https://hedviginsurance.slack.com/archives/C0381RB3Z5E/p1671445971349189?thread_ts=1669881882.698709&cid=C0381RB3Z5E) and it was decided to keep the other flow, making this one obsolete.

## Relates with

[embark](https://github.com/HedvigInsurance/embark/pull/1100)

**Ticket(s): [GRW-1979](https://hedvig.atlassian.net/browse/GRW-1979)**



[GRW-1979]: https://hedvig.atlassian.net/browse/GRW-1979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRW-1979]: https://hedvig.atlassian.net/browse/GRW-1979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ