### PR TITLE
Breadcrumbs: customize next step based on redirectURL

### DIFF
--- a/src/client/pages/Payment/Breadcrumbs.tsx
+++ b/src/client/pages/Payment/Breadcrumbs.tsx
@@ -2,13 +2,21 @@ import React from 'react'
 import styled from '@emotion/styled'
 import { useTextKeys } from 'utils/textKeys'
 
-export const Breadcrumbs = () => {
+type Props = {
+  nextStep: 'switching' | 'confirmation'
+}
+
+export const Breadcrumbs = ({ nextStep }: Props) => {
   const textKeys = useTextKeys()
   return (
     <Root>
       <Step>{textKeys.BREADCRUMB_CHECKOUT()}</Step>
       <Step active>{textKeys.BREADCRUMB_PAYMENT()}</Step>
-      <Step>{textKeys.BREADCRUMB_CONFIRMATION()}</Step>
+      <Step>
+        {nextStep === 'confirmation'
+          ? textKeys.BREADCRUMB_CONFIRMATION()
+          : textKeys.BREADCRUMB_SWITCHING_ASSISTANT()}
+      </Step>
     </Root>
   )
 }

--- a/src/client/pages/Payment/Payment.tsx
+++ b/src/client/pages/Payment/Payment.tsx
@@ -52,7 +52,13 @@ export const PaymentPage = () => {
             <HedvigLogo width={78} />
           </HeaderLogo>
           <HeaderBreadcrumbs>
-            <Breadcrumbs />
+            <Breadcrumbs
+              nextStep={
+                redirectURL?.includes('/switching')
+                  ? 'switching'
+                  : 'confirmation'
+              }
+            />
           </HeaderBreadcrumbs>
           <HeaderBack>
             <HeaderLink


### PR DESCRIPTION
## What?

Customize the "3rd step" of the checkout flow based on the "redirect_url" query parameter.

## Why?

For some carts we include the switching assistant while other people go directly to confirmation page.

**Ticket(s): []**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

