### PR TITLE
Redirect users that fail to connect payment back to store

### DIFF
--- a/src/client/pages/Payment/Payment.tsx
+++ b/src/client/pages/Payment/Payment.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
-import { SessionTokenGuard } from 'containers/SessionTokenGuard'
 import { HedvigLogo } from 'components/icons/HedvigLogo'
 import { useCurrentLocale } from 'l10n/useCurrentLocale'
 import { useTextKeys } from 'utils/textKeys'
@@ -23,7 +22,13 @@ export const PaymentPage = () => {
   const textKeys = useTextKeys()
   const { path: pathLocale } = useCurrentLocale()
   const redirectURL = useStoredRedirectURL()
-  const [, trustlyURL] = useCreateTrustlyURL()
+
+  const [, trustlyURL] = useCreateTrustlyURL({
+    onError: () => {
+      if (!redirectURL) return
+      handleFail(redirectURL)
+    },
+  })
 
   const [showSuccess, setShowSuccess] = useState(false)
   const handleSuccess = (baseRedirectURL: string) => {
@@ -45,55 +50,49 @@ export const PaymentPage = () => {
   }
 
   return (
-    <SessionTokenGuard>
-      <Wrapper y={2.5}>
-        <PageHeader>
-          <HeaderLogo>
-            <HedvigLogo width={78} />
-          </HeaderLogo>
-          <HeaderBreadcrumbs>
-            <Breadcrumbs
-              nextStep={
-                redirectURL?.includes('/switching')
-                  ? 'switching'
-                  : 'confirmation'
-              }
-            />
-          </HeaderBreadcrumbs>
-          <HeaderBack>
-            <HeaderLink
-              href={CUSTOMER_SERVIVE_URL[pathLocale]}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {textKeys.AFTER_SIGN_PAYMENT_HELP_LINK()}
-            </HeaderLink>
-          </HeaderBack>
-        </PageHeader>
+    <Wrapper y={2.5}>
+      <PageHeader>
+        <HeaderLogo>
+          <HedvigLogo width={78} />
+        </HeaderLogo>
+        <HeaderBreadcrumbs>
+          <Breadcrumbs
+            nextStep={
+              redirectURL?.includes('/switching') ? 'switching' : 'confirmation'
+            }
+          />
+        </HeaderBreadcrumbs>
+        <HeaderBack>
+          <HeaderLink
+            href={CUSTOMER_SERVIVE_URL[pathLocale]}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {textKeys.AFTER_SIGN_PAYMENT_HELP_LINK()}
+          </HeaderLink>
+        </HeaderBack>
+      </PageHeader>
 
-        <Content y={2.5}>
-          <LargeParagraph>
-            {textKeys.AFTER_SIGN_PAYMENT_MESSAGE()}
-          </LargeParagraph>
-          {!redirectURL ? (
-            <SmallParagraph>{textKeys.GENERIC_ERROR_HEADING()}</SmallParagraph>
-          ) : showSuccess ? null : (
-            trustlyURL && (
-              <Space y={0.75}>
-                <TrustlyIframe
-                  url={trustlyURL}
-                  onSuccess={() => handleSuccess(redirectURL)}
-                  onFail={() => handleFail(redirectURL)}
-                />
-                <SmallParagraph>
-                  {textKeys.AFTER_SIGN_PAYMENT_FOOTNOTE()}
-                </SmallParagraph>
-              </Space>
-            )
-          )}
-        </Content>
-      </Wrapper>
-    </SessionTokenGuard>
+      <Content y={2.5}>
+        <LargeParagraph>{textKeys.AFTER_SIGN_PAYMENT_MESSAGE()}</LargeParagraph>
+        {!redirectURL ? (
+          <SmallParagraph>{textKeys.GENERIC_ERROR_HEADING()}</SmallParagraph>
+        ) : showSuccess ? null : (
+          trustlyURL && (
+            <Space y={0.75}>
+              <TrustlyIframe
+                url={trustlyURL}
+                onSuccess={() => handleSuccess(redirectURL)}
+                onFail={() => handleFail(redirectURL)}
+              />
+              <SmallParagraph>
+                {textKeys.AFTER_SIGN_PAYMENT_FOOTNOTE()}
+              </SmallParagraph>
+            </Space>
+          )
+        )}
+      </Content>
+    </Wrapper>
   )
 }
 

--- a/src/client/pages/Payment/useCreateTrustlyURL.ts
+++ b/src/client/pages/Payment/useCreateTrustlyURL.ts
@@ -1,9 +1,14 @@
 import { useEffect } from 'react'
 import { useLocation } from 'react-router'
+import { datadogRum } from '@datadog/browser-rum'
 import { useRegisterDirectDebitMutation } from 'data/graphql'
 import { SUCCESS_SUFFIX, FAIL_SUFFIX } from './Payment.constants'
 
-export const useCreateTrustlyURL = () => {
+type Params = {
+  onError: () => void
+}
+
+export const useCreateTrustlyURL = ({ onError }: Params) => {
   const { pathname } = useLocation()
   const baseURL = `${window.location.origin}${pathname}`
   const [registerDirectDebit, { data }] = useRegisterDirectDebitMutation({
@@ -12,6 +17,10 @@ export const useCreateTrustlyURL = () => {
         successUrl: [baseURL, SUCCESS_SUFFIX].join(''),
         failureUrl: [baseURL, FAIL_SUFFIX].join(''),
       },
+    },
+    onError: (error) => {
+      datadogRum.addError(error, { message: 'Failed to create Trustly URL' })
+      onError()
     },
   })
 


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?

Expose `onError` event handler from trustly mutation.

Redirect users that fail to complete the trustly mutation to "hedvig-com".

Skip the `SessionTokenGuard` on the payment page since it doesn't do what we want it to do.

<!-- What changes are made? If there are many changes, a list might be a good format. -->

## Why?

We don't want users to get redirected to "/new-member" when they fail to complete the trustly mutation.

<!-- Why are these changes made? -->



**Ticket(s): []**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->

